### PR TITLE
feat: add configurable timeout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Here's a simple example of extracting structured information about a movie from 
 use rstructor::{Instructor, LLMClient, OpenAIClient, OpenAIModel};
 use serde::{Serialize, Deserialize};
 use std::env;
+use std::time::Duration;
 
 // Define your data model
 #[derive(Instructor, Serialize, Deserialize, Debug)]
@@ -69,7 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = OpenAIClient::new(api_key)?
         .model(OpenAIModel::Gpt35Turbo)
         .temperature(0.0)
-        .with_timeout(30.0)  // Optional: set 30 second timeout
+        .with_timeout(Duration::from_secs(30))  // Optional: set 30 second timeout
         .build();
 
     // Generate structured information with a simple prompt
@@ -94,6 +95,7 @@ For production use, prefer `generate_struct_with_retry` which automatically retr
 
 ```rust
 use rstructor::{Instructor, LLMClient, OpenAIClient, OpenAIModel};
+use std::time::Duration;
 use serde::{Serialize, Deserialize};
 
 #[derive(Instructor, Serialize, Deserialize, Debug)]
@@ -178,6 +180,7 @@ RStructor supports complex nested data structures:
 
 ```rust
 use rstructor::{Instructor, LLMClient, OpenAIClient, OpenAIModel};
+use std::time::Duration;
 use serde::{Serialize, Deserialize};
 
 // Define a nested data model for a recipe
@@ -463,7 +466,7 @@ let openai_client = OpenAIClient::new(openai_api_key)?
     .model(OpenAIModel::Gpt4)
     .temperature(0.2)
     .max_tokens(1500)
-    .with_timeout(60.0)  // Optional: set 60 second timeout
+    .with_timeout(Duration::from_secs(60))  // Optional: set 60 second timeout
     .build();
 
 // Using Anthropic
@@ -471,7 +474,7 @@ let anthropic_client = AnthropicClient::new(anthropic_api_key)?
     .model(AnthropicModel::Claude3Sonnet)
     .temperature(0.0)
     .max_tokens(2000)
-    .with_timeout(60.0)  // Optional: set 60 second timeout
+    .with_timeout(Duration::from_secs(60))  // Optional: set 60 second timeout
     .build();
 ```
 
@@ -480,10 +483,12 @@ let anthropic_client = AnthropicClient::new(anthropic_api_key)?
 Both `OpenAIClient` and `AnthropicClient` support configurable timeouts for HTTP requests using the builder pattern:
 
 ```rust
+use std::time::Duration;
+
 let client = OpenAIClient::new(api_key)?
     .model(OpenAIModel::Gpt4O)
     .temperature(0.0)
-    .with_timeout(30.0)  // Set 30 second timeout (in seconds)
+    .with_timeout(Duration::from_secs(30))  // Set 30 second timeout
     .build();
 ```
 
@@ -491,12 +496,13 @@ let client = OpenAIClient::new(api_key)?
 - The timeout applies to each HTTP request made by the client
 - If a request exceeds the timeout, it will return `RStructorError::Timeout`
 - If no timeout is specified, the client uses reqwest's default timeout behavior
-- Timeout values are specified in seconds as `f64` (e.g., `2.5` for 2.5 seconds)
+- Timeout values are specified as `std::time::Duration` (e.g., `Duration::from_secs(30)` or `Duration::from_millis(2500)`)
 
 **Example with timeout error handling:**
 
 ```rust
 use rstructor::{OpenAIClient, OpenAIModel, RStructorError};
+use std::time::Duration;
 
 match client.generate_struct::<Movie>("prompt").await {
     Ok(movie) => println!("Success: {:?}", movie),

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -145,7 +145,7 @@ impl AnthropicClient {
     ///
     /// # Arguments
     ///
-    /// * `timeout_secs` - Timeout in seconds (e.g., 2.5 for 2.5 seconds)
+    /// * `timeout` - Timeout duration (e.g., `Duration::from_secs(30)` for 30 seconds)
     ///
     /// # Examples
     ///
@@ -154,14 +154,13 @@ impl AnthropicClient {
     /// # use std::time::Duration;
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = AnthropicClient::new("api-key")?
-    ///     .with_timeout(30.0)  // 30 second timeout
+    ///     .with_timeout(Duration::from_secs(30))  // 30 second timeout
     ///     .build();
     /// # Ok(())
     /// # }
     /// ```
     #[instrument(skip(self))]
-    pub fn with_timeout(mut self, timeout_secs: f64) -> Self {
-        let timeout = Duration::from_secs_f64(timeout_secs);
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
         debug!(
             previous_timeout = ?self.config.timeout,
             new_timeout = ?timeout,

--- a/src/backend/client.rs
+++ b/src/backend/client.rs
@@ -25,6 +25,7 @@ use crate::model::Instructor;
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// use rstructor::{LLMClient, Instructor, OpenAIClient, OpenAIModel};
 /// use serde::{Serialize, Deserialize};
+/// use std::time::Duration;
 ///
 /// // Define your data model
 /// #[derive(Instructor, Serialize, Deserialize, Debug)]
@@ -38,7 +39,7 @@ use crate::model::Instructor;
 /// let client = OpenAIClient::new("your-openai-api-key")?
 ///     .model(OpenAIModel::Gpt35Turbo)
 ///     .temperature(0.0)
-///     .with_timeout(30.0)  // Optional: set 30 second timeout
+///     .with_timeout(Duration::from_secs(30))  // Optional: set 30 second timeout
 ///     .build();
 ///
 /// // Generate a structured response
@@ -58,6 +59,7 @@ use crate::model::Instructor;
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// use rstructor::{LLMClient, Instructor, AnthropicClient, AnthropicModel};
 /// use serde::{Serialize, Deserialize};
+/// use std::time::Duration;
 ///
 /// // Define your data model
 /// #[derive(Instructor, Serialize, Deserialize, Debug)]
@@ -71,7 +73,7 @@ use crate::model::Instructor;
 /// let client = AnthropicClient::new("your-anthropic-api-key")?
 ///     .model(AnthropicModel::Claude3Haiku)
 ///     .temperature(0.0)
-///     .with_timeout(30.0)  // Optional: set 30 second timeout
+///     .with_timeout(Duration::from_secs(30))  // Optional: set 30 second timeout
 ///     .build();
 ///
 /// // Generate a structured response

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -154,7 +154,7 @@ impl OpenAIClient {
     ///
     /// # Arguments
     ///
-    /// * `timeout_secs` - Timeout in seconds (e.g., 2.5 for 2.5 seconds)
+    /// * `timeout` - Timeout duration (e.g., `Duration::from_secs(30)` for 30 seconds)
     ///
     /// # Examples
     ///
@@ -163,14 +163,13 @@ impl OpenAIClient {
     /// # use std::time::Duration;
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = OpenAIClient::new("api-key")?
-    ///     .with_timeout(30.0)  // 30 second timeout
+    ///     .with_timeout(Duration::from_secs(30))  // 30 second timeout
     ///     .build();
     /// # Ok(())
     /// # }
     /// ```
     #[instrument(skip(self))]
-    pub fn with_timeout(mut self, timeout_secs: f64) -> Self {
-        let timeout = Duration::from_secs_f64(timeout_secs);
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
         debug!(
             previous_timeout = ?self.config.timeout,
             new_timeout = ?timeout,

--- a/tests/timeout_tests.rs
+++ b/tests/timeout_tests.rs
@@ -11,6 +11,7 @@ mod timeout_tests {
     };
     use serde::{Deserialize, Serialize};
     use std::env;
+    use std::time::Duration;
 
     // Simple model for testing
     #[derive(Instructor, Serialize, Deserialize, Debug)]
@@ -36,7 +37,7 @@ mod timeout_tests {
             .expect("Failed to create OpenAI client")
             .model(OpenAIModel::Gpt4O)
             .temperature(0.0)
-            .with_timeout(0.001) // 1ms timeout - should timeout
+            .with_timeout(Duration::from_millis(1)) // 1ms timeout - should timeout
             .build();
 
         // Try to make a request - it should timeout
@@ -69,7 +70,7 @@ mod timeout_tests {
             .model(OpenAIModel::Gpt4O)
             .temperature(0.5)
             .max_tokens(100)
-            .with_timeout(2.0) // 2 second timeout for unit tests
+            .with_timeout(Duration::from_secs(2)) // 2 second timeout for unit tests
             .build();
 
         // Verify that client was created successfully with timeout
@@ -93,7 +94,7 @@ mod timeout_tests {
             .expect("Failed to create Anthropic client")
             .model(AnthropicModel::Claude35Sonnet)
             .temperature(0.0)
-            .with_timeout(0.001) // 1ms timeout - should timeout
+            .with_timeout(Duration::from_millis(1)) // 1ms timeout - should timeout
             .build();
 
         // Try to make a request - it should timeout
@@ -126,7 +127,7 @@ mod timeout_tests {
             .model(AnthropicModel::Claude35Sonnet)
             .temperature(0.5)
             .max_tokens(100)
-            .with_timeout(2.0) // 2 second timeout for unit tests
+            .with_timeout(Duration::from_secs(2)) // 2 second timeout for unit tests
             .build();
 
         // Verify that client was created successfully with timeout


### PR DESCRIPTION
- Add timeout configuration for OpenAI and Anthropic clients
- Implement proper timeout error handling in both backends
- Update documentation with timeout usage examples
- Add detailed timeout behavior explanation in README

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds builder-configurable HTTP request timeouts to OpenAI and Anthropic clients, maps reqwest timeouts to `RStructorError::Timeout`, and updates docs/tests.
> 
> - **Backend**:
>   - **Timeout configuration**:
>     - Add `timeout: Option<Duration>` to `OpenAIConfig` and `AnthropicConfig`.
>     - Introduce `.with_timeout(Duration)` on `OpenAIClient` and `AnthropicClient`.
>     - Update `.build()` to configure `reqwest::Client` with the timeout (changed to `mut self`).
>   - **Error handling**:
>     - Map `reqwest` timeout errors to `RStructorError::Timeout` in both backends.
> - **Docs**:
>   - Update `README.md` examples to include `.with_timeout(...)` and `use std::time::Duration`.
>   - Add a "Configuring Request Timeouts" section detailing behavior and handling.
>   - Update code docs in `src/backend/client.rs` examples to show timeout usage.
> - **Tests**:
>   - Add `tests/timeout_tests.rs` to verify timeout configuration, chaining, default (no-timeout) behavior, and timeout error mapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7527aa07bba657887a29d7ebe617c98d4c1d0a42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->