### PR TITLE
feat: add from_env() method to LLM clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = OpenAIClient::new(api_key)?
         .model(OpenAIModel::Gpt4OMini)
         .temperature(0.0)
-        .with_timeout(Duration::from_secs(30))  // Optional: set 30 second timeout
+        .timeout(Duration::from_secs(30))  // Optional: set 30 second timeout
         .build();
 
     // Generate structured information with a simple prompt
@@ -466,7 +466,7 @@ let openai_client = OpenAIClient::new(openai_api_key)?
     .model(OpenAIModel::Gpt5)
     .temperature(0.2)
     .max_tokens(1500)
-    .with_timeout(Duration::from_secs(60))  // Optional: set 60 second timeout
+    .timeout(Duration::from_secs(60))  // Optional: set 60 second timeout
     .build();
 
 // Using Anthropic
@@ -474,7 +474,7 @@ let anthropic_client = AnthropicClient::new(anthropic_api_key)?
     .model(AnthropicModel::ClaudeSonnet4)
     .temperature(0.0)
     .max_tokens(2000)
-    .with_timeout(Duration::from_secs(60))  // Optional: set 60 second timeout
+    .timeout(Duration::from_secs(60))  // Optional: set 60 second timeout
     .build();
 
 // Using Grok (xAI) - reads from XAI_API_KEY environment variable
@@ -482,7 +482,7 @@ let grok_client = GrokClient::from_env()?  // Reads from XAI_API_KEY env var
     .model(GrokModel::Grok4)
     .temperature(0.0)
     .max_tokens(1500)
-    .with_timeout(Duration::from_secs(60))  // Optional: set 60 second timeout
+    .timeout(Duration::from_secs(60))  // Optional: set 60 second timeout
     .build();
 
 // Using Gemini (Google) - reads from GEMINI_API_KEY environment variable
@@ -490,7 +490,7 @@ let gemini_client = GeminiClient::from_env()?  // Reads from GEMINI_API_KEY env 
     .model(GeminiModel::Gemini25Flash)
     .temperature(0.0)
     .max_tokens(1500)
-    .with_timeout(Duration::from_secs(60))  // Optional: set 60 second timeout
+    .timeout(Duration::from_secs(60))  // Optional: set 60 second timeout
     .build();
 ```
 
@@ -504,7 +504,7 @@ use std::time::Duration;
 let client = OpenAIClient::new(api_key)?
     .model(OpenAIModel::Gpt4O)
     .temperature(0.0)
-    .with_timeout(Duration::from_secs(30))  // Set 30 second timeout
+    .timeout(Duration::from_secs(30))  // Set 30 second timeout
     .build();
 ```
 

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -259,13 +259,13 @@ impl AnthropicClient {
     /// # use std::time::Duration;
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = AnthropicClient::new("api-key")?
-    ///     .with_timeout(Duration::from_secs(30))  // 30 second timeout
+    ///     .timeout(Duration::from_secs(30))  // 30 second timeout
     ///     .build();
     /// # Ok(())
     /// # }
     /// ```
     #[instrument(skip(self))]
-    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+    pub fn timeout(mut self, timeout: Duration) -> Self {
         debug!(
             previous_timeout = ?self.config.timeout,
             new_timeout = ?timeout,

--- a/src/backend/client.rs
+++ b/src/backend/client.rs
@@ -26,7 +26,7 @@ use crate::model::Instructor;
 ///   - Anthropic: `ANTHROPIC_API_KEY`
 ///   - Grok: `XAI_API_KEY`
 ///   - Gemini: `GEMINI_API_KEY`
-/// - Builder methods: `model()`, `temperature()`, `max_tokens()`, `with_timeout()`, `build()`
+/// - Builder methods: `model()`, `temperature()`, `max_tokens()`, `timeout()`, `build()`
 /// - All clients validate `max_tokens >= 1` to avoid API errors
 ///
 /// # Examples
@@ -51,7 +51,7 @@ use crate::model::Instructor;
 /// let client = OpenAIClient::new("your-openai-api-key")?
 ///     .model(OpenAIModel::Gpt4OMini)
 ///     .temperature(0.0)
-///     .with_timeout(Duration::from_secs(30))  // Optional: set 30 second timeout
+///     .timeout(Duration::from_secs(30))  // Optional: set 30 second timeout
 ///     .build();
 ///
 /// // Generate a structured response
@@ -85,7 +85,7 @@ use crate::model::Instructor;
 /// let client = AnthropicClient::new("your-anthropic-api-key")?
 ///     .model(AnthropicModel::ClaudeSonnet4)
 ///     .temperature(0.0)
-///     .with_timeout(Duration::from_secs(30))  // Optional: set 30 second timeout
+///     .timeout(Duration::from_secs(30))  // Optional: set 30 second timeout
 ///     .build();
 ///
 /// // Generate a structured response

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -254,13 +254,13 @@ impl GeminiClient {
     /// let client = GeminiClient::new("your-api-key")?
     ///     .model(GeminiModel::Gemini25Flash)
     ///     .temperature(0.0)
-    ///     .with_timeout(Duration::from_secs(30))  // 30 second timeout
+    ///     .timeout(Duration::from_secs(30))  // 30 second timeout
     ///     .build();
     /// # Ok(())
     /// # }
     /// ```
     #[instrument(skip(self))]
-    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+    pub fn timeout(mut self, timeout: Duration) -> Self {
         debug!(
             previous_timeout = ?self.config.timeout,
             new_timeout = ?timeout,

--- a/src/backend/grok.rs
+++ b/src/backend/grok.rs
@@ -266,13 +266,13 @@ impl GrokClient {
     /// # use std::time::Duration;
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = GrokClient::from_env()?  // Reads from XAI_API_KEY env var
-    ///     .with_timeout(Duration::from_secs(30))  // 30 second timeout
+    ///     .timeout(Duration::from_secs(30))  // 30 second timeout
     ///     .build();
     /// # Ok(())
     /// # }
     /// ```
     #[instrument(skip(self))]
-    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+    pub fn timeout(mut self, timeout: Duration) -> Self {
         debug!(
             previous_timeout = ?self.config.timeout,
             new_timeout = ?timeout,

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -255,13 +255,13 @@ impl OpenAIClient {
     /// # use std::time::Duration;
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = OpenAIClient::new("api-key")?
-    ///     .with_timeout(Duration::from_secs(30))  // 30 second timeout
+    ///     .timeout(Duration::from_secs(30))  // 30 second timeout
     ///     .build();
     /// # Ok(())
     /// # }
     /// ```
     #[instrument(skip(self))]
-    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+    pub fn timeout(mut self, timeout: Duration) -> Self {
         debug!(
             previous_timeout = ?self.config.timeout,
             new_timeout = ?timeout,

--- a/tests/timeout_tests.rs
+++ b/tests/timeout_tests.rs
@@ -43,7 +43,7 @@ mod timeout_tests {
             .expect("Failed to create OpenAI client")
             .model(OpenAIModel::Gpt4O)
             .temperature(0.0)
-            .with_timeout(Duration::from_millis(1)) // 1ms timeout - should timeout
+            .timeout(Duration::from_millis(1)) // 1ms timeout - should timeout
             .build();
 
         // Try to make a request - it should timeout
@@ -77,7 +77,7 @@ mod timeout_tests {
             .model(OpenAIModel::Gpt4O)
             .temperature(0.5)
             .max_tokens(100)
-            .with_timeout(Duration::from_secs(2)) // 2 second timeout for unit tests
+            .timeout(Duration::from_secs(2)) // 2 second timeout for unit tests
             .build();
 
         // Verify that client was created successfully with timeout
@@ -102,7 +102,7 @@ mod timeout_tests {
             .expect("Failed to create Anthropic client")
             .model(AnthropicModel::ClaudeSonnet45)
             .temperature(0.0)
-            .with_timeout(Duration::from_millis(1)) // 1ms timeout - should timeout
+            .timeout(Duration::from_millis(1)) // 1ms timeout - should timeout
             .build();
 
         // Try to make a request - it should timeout
@@ -136,7 +136,7 @@ mod timeout_tests {
             .model(AnthropicModel::ClaudeSonnet45)
             .temperature(0.5)
             .max_tokens(100)
-            .with_timeout(Duration::from_secs(2)) // 2 second timeout for unit tests
+            .timeout(Duration::from_secs(2)) // 2 second timeout for unit tests
             .build();
 
         // Verify that client was created successfully with timeout
@@ -193,7 +193,7 @@ mod timeout_tests {
             Ok(client) => client
                 .model(GrokModel::Grok4)
                 .temperature(0.0)
-                .with_timeout(Duration::from_millis(1)) // 1ms timeout - should timeout
+                .timeout(Duration::from_millis(1)) // 1ms timeout - should timeout
                 .build(),
             Err(e) => {
                 println!(
@@ -228,7 +228,7 @@ mod timeout_tests {
                 .model(GrokModel::Grok4)
                 .temperature(0.5)
                 .max_tokens(100)
-                .with_timeout(Duration::from_secs(2)) // 2 second timeout for unit tests
+                .timeout(Duration::from_secs(2)) // 2 second timeout for unit tests
                 .build(),
             Err(e) => {
                 println!(
@@ -284,7 +284,7 @@ mod timeout_tests {
         let client = client
             .model(GeminiModel::Gemini25Flash)
             .temperature(0.0)
-            .with_timeout(Duration::from_millis(1)) // 1ms timeout - should timeout
+            .timeout(Duration::from_millis(1)) // 1ms timeout - should timeout
             .build();
 
         // Try to make a request - it should timeout
@@ -321,7 +321,7 @@ mod timeout_tests {
             .model(GeminiModel::Gemini25Flash)
             .temperature(0.5)
             .max_tokens(100)
-            .with_timeout(Duration::from_secs(2)) // 2 second timeout for unit tests
+            .timeout(Duration::from_secs(2)) // 2 second timeout for unit tests
             .build();
 
         // Verify that client was created successfully with timeout


### PR DESCRIPTION
- Add from_env() method to LLMClient trait for environment variable loading
- Implement from_env() in all client implementations (OpenAI, Anthropic, etc.)
- Validate API keys to reject empty strings
- Ensure max_tokens is at least 1 to avoid API errors
- Improve documentation with examples and consistent interface