### PR TITLE
feat: add flexible model selection and custom endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = env::var("OPENAI_API_KEY")?;
 
     // Create an OpenAI client
+    // You can use enum variants or strings for model names
     let client = OpenAIClient::new(api_key)?
-        .model(OpenAIModel::Gpt4OMini)
+        .model("gpt-4o-mini")  // String model names work!
         .temperature(0.0)
         .timeout(Duration::from_secs(30));  // Optional: set 30 second timeout
 
@@ -465,6 +466,57 @@ impl CustomTypeSchema for EmailAddress {
 ```
 
 The macro automatically detects these custom types and generates appropriate JSON Schema with format specifications that guide LLMs to produce correctly formatted values. The library includes built-in recognition of common date and UUID types, but you can implement the trait for any custom type.
+
+### Flexible Model Selection and Custom Endpoints
+
+rstructor supports both enum variants and string-based model selection, making it easy to:
+- Use new models without waiting for library updates
+- Work with local LLMs or OpenAI-compatible endpoints
+- Configure models from environment variables or config files
+
+#### Using String Model Names
+
+You can specify models as strings, which is especially useful for:
+- New models that haven't been added to the enum yet
+- Local LLMs running on your infrastructure
+- Custom or fine-tuned models
+
+```rust
+use rstructor::OpenAIClient;
+
+// Use a string directly - works with any model name
+let client = OpenAIClient::new("api-key")?
+    .model("gpt-4-custom");  // Custom model name
+
+// Works with environment variables
+let model_name = std::env::var("MODEL_NAME").unwrap();
+let client = OpenAIClient::new("api-key")?
+    .model(model_name);  // Dynamic model selection
+
+// Enum variants still work for convenience
+let client = OpenAIClient::new("api-key")?
+    .model(OpenAIModel::Gpt4O);  // Type-safe enum variant
+```
+
+#### Custom Endpoints for Local LLMs
+
+Use rstructor with local LLMs or proxy endpoints by setting a custom base URL:
+
+```rust
+use rstructor::OpenAIClient;
+
+// Connect to a local LLM server (e.g., Ollama, vLLM, etc.)
+let client = OpenAIClient::new("dummy-key")?  // API key may not be required for local
+    .base_url("http://localhost:1234/v1")  // Custom endpoint
+    .model("llama-3.1-70b");  // Local model name
+
+// Or use with OpenAI-compatible proxy services
+let client = OpenAIClient::new("api-key")?
+    .base_url("https://api.example.com/v1")  // Proxy endpoint
+    .model("gpt-4");
+```
+
+**Note**: All providers (OpenAI, Anthropic, Grok, Gemini) support both string model selection and custom endpoints via the `.base_url()` method.
 
 ### Configuring Different LLM Providers
 

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -177,9 +177,15 @@ macro_rules! impl_client_builder_methods {
         provider_name: $provider:expr
     ) => {
         impl $client {
-            /// Set the model to use
-            #[tracing::instrument(skip(self))]
-            pub fn model(mut self, model: $model) -> Self {
+            /// Set the model to use. Accepts either a Model enum variant or a string.
+            ///
+            /// When a string is provided, it will be converted to a Model enum. If the string
+            /// matches a known model variant, that variant is used; otherwise, it becomes `Custom(name)`.
+            /// This allows using any model name, including new models or local LLMs, without needing
+            /// to update the enum.
+            #[tracing::instrument(skip(self, model))]
+            pub fn model<M: Into<$model>>(mut self, model: M) -> Self {
+                let model = model.into();
                 tracing::debug!(
                     previous_model = ?self.config.model,
                     new_model = ?model,

--- a/tests/model_string_test.rs
+++ b/tests/model_string_test.rs
@@ -1,0 +1,75 @@
+#[cfg(test)]
+mod tests {
+    use rstructor::{AnthropicModel, GeminiModel, GrokModel, OpenAIModel};
+    use std::str::FromStr;
+
+    #[test]
+    fn test_openai_model_from_string() {
+        // Test known model
+        let model = OpenAIModel::from_string("gpt-4o");
+        assert_eq!(model, OpenAIModel::Gpt4O);
+
+        // Test custom model
+        let model = OpenAIModel::from_string("gpt-4-custom");
+        match model {
+            OpenAIModel::Custom(name) => assert_eq!(name, "gpt-4-custom"),
+            _ => panic!("Expected Custom variant"),
+        }
+
+        // Test FromStr
+        let model = OpenAIModel::from_str("gpt-4o-mini").unwrap();
+        assert_eq!(model, OpenAIModel::Gpt4OMini);
+
+        // Test From<&str>
+        let model: OpenAIModel = "gpt-3.5-turbo".into();
+        assert_eq!(model, OpenAIModel::Gpt35Turbo);
+    }
+
+    #[test]
+    fn test_anthropic_model_from_string() {
+        // Test known model
+        let model = AnthropicModel::from_string("claude-sonnet-4-20250514");
+        assert_eq!(model, AnthropicModel::ClaudeSonnet4);
+
+        // Test custom model
+        let model = AnthropicModel::from_string("claude-custom");
+        match model {
+            AnthropicModel::Custom(name) => assert_eq!(name, "claude-custom"),
+            _ => panic!("Expected Custom variant"),
+        }
+    }
+
+    #[test]
+    fn test_grok_model_from_string() {
+        // Test known model
+        let model = GrokModel::from_string("grok-4-0709");
+        assert_eq!(model, GrokModel::Grok4);
+
+        // Test custom model
+        let model = GrokModel::from_string("grok-custom");
+        match model {
+            GrokModel::Custom(name) => assert_eq!(name, "grok-custom"),
+            _ => panic!("Expected Custom variant"),
+        }
+    }
+
+    #[test]
+    fn test_gemini_model_from_string() {
+        // Test known model
+        let model = GeminiModel::from_string("gemini-2.5-flash");
+        assert_eq!(model, GeminiModel::Gemini25Flash);
+
+        // Test custom model
+        let model = GeminiModel::from_string("gemini-custom");
+        match model {
+            GeminiModel::Custom(name) => assert_eq!(name, "gemini-custom"),
+            _ => panic!("Expected Custom variant"),
+        }
+    }
+
+    #[test]
+    fn test_model_as_str_with_custom() {
+        let model = OpenAIModel::Custom("my-custom-model".to_string());
+        assert_eq!(model.as_str(), "my-custom-model");
+    }
+}


### PR DESCRIPTION
- Add support for string-based model names across all providers
- Implement custom endpoint configuration via base_url method
- Document usage with local LLMs and OpenAI-compatible APIs
- Add FromStr implementation for model enums for config-driven setup