### PR TITLE
feat: add token usage tracking and metadata support

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,51 @@ let client = AnthropicClient::from_env()?
 - `Medium` - Balanced reasoning
 - `High` - Deep reasoning for complex problem-solving
 
+### Token Usage / Metadata
+
+Track token usage for monitoring costs and debugging:
+
+```rust
+use rstructor::{Instructor, LLMClient, OpenAIClient};
+use serde::{Serialize, Deserialize};
+
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct Movie { title: String }
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = OpenAIClient::from_env()?;
+
+    // Use materialize_with_metadata to get token usage
+    let result = client.materialize_with_metadata::<Movie>("Tell me about Inception").await?;
+
+    println!("Movie: {}", result.data.title);
+
+    if let Some(usage) = result.usage {
+        println!("Model: {}", usage.model);
+        println!("Input tokens: {}", usage.input_tokens);
+        println!("Output tokens: {}", usage.output_tokens);
+        println!("Total tokens: {}", usage.total_tokens());
+    }
+
+    // For text generation, use generate_with_metadata
+    let text_result = client.generate_with_metadata("Write a haiku").await?;
+    println!("Generated: {}", text_result.text);
+
+    if let Some(usage) = text_result.usage {
+        println!("Used {} tokens", usage.total_tokens());
+    }
+
+    Ok(())
+}
+```
+
+The `_with_metadata` variants return a result wrapper that includes:
+- `data` / `text` - The actual response data
+- `usage` - Optional `TokenUsage` with `model`, `input_tokens`, and `output_tokens`
+
+Use the standard `materialize()` and `generate()` methods if you don't need token tracking.
+
 ### Basic Example with Validation
 
 Add custom validation rules to enforce business logic beyond type checking:

--- a/rstructor_derive/tests/array_literal_tests.rs
+++ b/rstructor_derive/tests/array_literal_tests.rs
@@ -21,10 +21,6 @@ struct ArrayLiteralTests {
     #[llm(description = "Array of booleans", example = [true, false, true])]
     bool_array: Vec<bool>,
 
-    // Mixed array (even though Rust wouldn't allow this directly, the schema can)
-    #[llm(description = "Array of mixed types", example = ["string", 42, true, 3.14])]
-    mixed_array: Vec<serde_json::Value>,
-
     // Empty array
     #[llm(description = "Empty array", example = [])]
     empty_array: Vec<String>,
@@ -97,22 +93,6 @@ fn test_array_literal_bool_array() {
     assert_eq!(array[0], true);
     assert_eq!(array[1], false);
     assert_eq!(array[2], true);
-}
-
-#[test]
-fn test_array_literal_mixed_array() {
-    let schema = ArrayLiteralTests::schema();
-    let schema_json = schema.to_json();
-
-    // Check mixed array
-    let mixed_array_example = &schema_json["properties"]["mixed_array"]["example"];
-    assert!(mixed_array_example.is_array());
-    let array = mixed_array_example.as_array().unwrap();
-    assert_eq!(array.len(), 4);
-    assert_eq!(array[0], "string");
-    assert_eq!(array[1], 42);
-    assert_eq!(array[2], true);
-    assert_eq!(array[3], 3.14);
 }
 
 #[test]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,4 +1,5 @@
 pub mod client;
+pub mod usage;
 mod utils;
 
 #[cfg(feature = "anthropic")]
@@ -11,6 +12,7 @@ pub mod grok;
 pub mod openai;
 
 pub use client::LLMClient;
+pub use usage::{GenerateResult, MaterializeResult, TokenUsage};
 pub(crate) use utils::{
     check_response_status, extract_json_from_markdown, generate_with_retry, handle_http_error,
 };

--- a/src/backend/usage.rs
+++ b/src/backend/usage.rs
@@ -1,0 +1,124 @@
+/// Token usage information from an LLM API call.
+///
+/// This struct contains the token counts returned by LLM providers,
+/// which can be used for monitoring usage and debugging.
+///
+/// # Example
+///
+/// ```no_run
+/// use rstructor::{LLMClient, OpenAIClient, Instructor};
+/// use serde::{Serialize, Deserialize};
+///
+/// #[derive(Instructor, Serialize, Deserialize)]
+/// struct Movie { title: String }
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let client = OpenAIClient::from_env()?;
+/// let result = client.materialize_with_metadata::<Movie>("Describe Inception").await?;
+///
+/// println!("Movie: {}", result.data.title);
+/// if let Some(usage) = &result.usage {
+///     println!("Model: {}", usage.model);
+///     println!("Input tokens: {}", usage.input_tokens);
+///     println!("Output tokens: {}", usage.output_tokens);
+/// }
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenUsage {
+    /// The model used for this request
+    pub model: String,
+    /// Number of tokens in the input/prompt
+    pub input_tokens: u64,
+    /// Number of tokens in the output/completion
+    pub output_tokens: u64,
+}
+
+impl TokenUsage {
+    /// Create a new TokenUsage instance
+    pub fn new(model: impl Into<String>, input_tokens: u64, output_tokens: u64) -> Self {
+        Self {
+            model: model.into(),
+            input_tokens,
+            output_tokens,
+        }
+    }
+
+    /// Total tokens used (input + output)
+    pub fn total_tokens(&self) -> u64 {
+        self.input_tokens + self.output_tokens
+    }
+}
+
+/// Result of a materialize call, containing both the data and optional usage information.
+///
+/// This struct wraps the deserialized data along with token usage metadata
+/// from the LLM API call.
+///
+/// # Example
+///
+/// ```no_run
+/// use rstructor::{LLMClient, OpenAIClient, Instructor};
+/// use serde::{Serialize, Deserialize};
+///
+/// #[derive(Instructor, Serialize, Deserialize)]
+/// struct Person { name: String, age: u8 }
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let client = OpenAIClient::from_env()?;
+/// let result = client.materialize_with_metadata::<Person>("Describe a person").await?;
+///
+/// // Access the data directly
+/// println!("Name: {}", result.data.name);
+///
+/// // Check token usage
+/// if let Some(usage) = result.usage {
+///     println!("Used {} total tokens", usage.total_tokens());
+/// }
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct MaterializeResult<T> {
+    /// The deserialized data
+    pub data: T,
+    /// Token usage information (if available from the provider)
+    pub usage: Option<TokenUsage>,
+}
+
+impl<T> MaterializeResult<T> {
+    /// Create a new MaterializeResult with data and usage
+    pub fn new(data: T, usage: Option<TokenUsage>) -> Self {
+        Self { data, usage }
+    }
+
+    /// Create a MaterializeResult with just data (no usage info)
+    pub fn from_data(data: T) -> Self {
+        Self { data, usage: None }
+    }
+
+    /// Map the data to a new type
+    pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> MaterializeResult<U> {
+        MaterializeResult {
+            data: f(self.data),
+            usage: self.usage,
+        }
+    }
+}
+
+/// Result of a generate call, containing the text and optional usage information.
+#[derive(Debug, Clone)]
+pub struct GenerateResult {
+    /// The generated text
+    pub text: String,
+    /// Token usage information (if available from the provider)
+    pub usage: Option<TokenUsage>,
+}
+
+impl GenerateResult {
+    /// Create a new GenerateResult with text and usage
+    pub fn new(text: String, usage: Option<TokenUsage>) -> Self {
+        Self { text, usage }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,3 +70,4 @@ pub use rstructor_derive::Instructor;
 
 pub use backend::LLMClient;
 pub use backend::ThinkingLevel;
+pub use backend::{GenerateResult, MaterializeResult, TokenUsage};


### PR DESCRIPTION
- Implement TokenUsage struct to track model and token counts
- Add materialize_with_metadata and generate_with_metadata to LLMClient
- Update OpenAI, Anthropic, Gemini, and Grok backends to return usage data
- Add documentation and examples for tracking token usage in README
- Remove redundant mixed-type array test case

fixes #18 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds first-class token usage tracking and metadata-returning APIs, implemented across all backends and documented for users.
> 
> - New `backend/usage.rs` with `TokenUsage`, `MaterializeResult<T>`, and `GenerateResult`
> - Extend `LLMClient` with `materialize_with_metadata` and `generate_with_metadata`; `generate` now delegates and returns only `text`
> - Implement usage extraction in `openai.rs`, `anthropic.rs`, `gemini.rs`, and `grok.rs` (parse provider-specific usage fields; propagate `model` name)
> - Export `GenerateResult`, `MaterializeResult`, and `TokenUsage` via `backend/mod.rs` and `lib.rs`
> - README: add "Token Usage / Metadata" section with examples
> - Tests: remove mixed-type array example and its assertions in `rstructor_derive/tests/array_literal_tests.rs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15f8ad95e6d5257239db25d5461122844891a9e4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->