### PR TITLE
feat: add rich api error handling and model discovery

### DIFF
--- a/examples/recipe_extractor.rs
+++ b/examples/recipe_extractor.rs
@@ -1,4 +1,6 @@
-use rstructor::{AnthropicClient, Instructor, LLMClient, OpenAIClient, RStructorError};
+use rstructor::{
+    AnthropicClient, ApiErrorKind, Instructor, LLMClient, OpenAIClient, RStructorError,
+};
 use serde::{Deserialize, Serialize};
 use std::{
     env,
@@ -139,9 +141,8 @@ fn validate_recipe(recipe: &Recipe) -> rstructor::Result<()> {
 
 async fn get_recipe_from_openai(recipe_name: &str) -> rstructor::Result<Recipe> {
     // Get API key from environment
-    let api_key = env::var("OPENAI_API_KEY").map_err(|_| {
-        RStructorError::ApiError("OPENAI_API_KEY environment variable not set".into())
-    })?;
+    let api_key = env::var("OPENAI_API_KEY")
+        .map_err(|_| RStructorError::api_error("OpenAI", ApiErrorKind::AuthenticationFailed))?;
 
     // Create OpenAI client
     let client = OpenAIClient::new(api_key)?
@@ -178,9 +179,8 @@ async fn get_recipe_from_openai(recipe_name: &str) -> rstructor::Result<Recipe> 
 
 async fn get_recipe_from_anthropic(recipe_name: &str) -> rstructor::Result<Recipe> {
     // Get API key from environment
-    let api_key = env::var("ANTHROPIC_API_KEY").map_err(|_| {
-        RStructorError::ApiError("ANTHROPIC_API_KEY environment variable not set".into())
-    })?;
+    let api_key = env::var("ANTHROPIC_API_KEY")
+        .map_err(|_| RStructorError::api_error("Anthropic", ApiErrorKind::AuthenticationFailed))?;
 
     // Create Anthropic client
     let client = AnthropicClient::new(api_key)?

--- a/src/backend/client.rs
+++ b/src/backend/client.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 
+use crate::backend::ModelInfo;
 use crate::backend::usage::{GenerateResult, MaterializeResult};
 use crate::error::Result;
 use crate::model::Instructor;
@@ -210,4 +211,27 @@ pub trait LLMClient {
     fn from_env() -> Result<Self>
     where
         Self: Sized;
+
+    /// Fetch available models from the provider's API.
+    ///
+    /// This method queries the provider's models endpoint to return a list of
+    /// models available for use. The results are filtered to include only
+    /// chat/completion models relevant to this library.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use rstructor::{LLMClient, OpenAIClient};
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenAIClient::from_env()?;
+    /// let models = client.list_models().await?;
+    ///
+    /// println!("Available models:");
+    /// for model in models {
+    ///     println!("  - {}", model.id);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn list_models(&self) -> Result<Vec<ModelInfo>>;
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -13,6 +13,35 @@ pub mod openai;
 
 pub use client::LLMClient;
 pub use usage::{GenerateResult, MaterializeResult, TokenUsage};
+
+/// Information about an available model from an LLM provider.
+///
+/// This struct is returned by [`LLMClient::list_models()`] to provide
+/// information about models available through the provider's API.
+///
+/// # Example
+///
+/// ```no_run
+/// # use rstructor::{OpenAIClient, LLMClient};
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let client = OpenAIClient::from_env()?;
+/// let models = client.list_models().await?;
+///
+/// for model in models {
+///     println!("{}: {}", model.id, model.description.unwrap_or_default());
+/// }
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelInfo {
+    /// The model identifier used in API requests
+    pub id: String,
+    /// Human-readable display name (if different from id)
+    pub name: Option<String>,
+    /// Description of the model's capabilities
+    pub description: Option<String>,
+}
 pub(crate) use utils::{
     check_response_status, extract_json_from_markdown, generate_with_retry, handle_http_error,
 };

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,4 +1,258 @@
+use std::time::Duration;
 use thiserror::Error;
+
+/// Classification of API errors for better handling and retry logic.
+///
+/// This enum categorizes HTTP errors from LLM providers into actionable types,
+/// making it easier to determine appropriate responses (retry, fix config, wait, etc.).
+///
+/// # Example
+///
+/// ```
+/// use rstructor::{RStructorError, ApiErrorKind};
+///
+/// fn handle_api_error(err: &RStructorError) {
+///     if let Some(kind) = err.api_error_kind() {
+///         match kind {
+///             ApiErrorKind::RateLimited { retry_after } => {
+///                 println!("Rate limited! Wait {:?} and retry", retry_after);
+///             }
+///             ApiErrorKind::AuthenticationFailed => {
+///                 println!("Check your API key");
+///             }
+///             ApiErrorKind::InvalidModel { model, suggestion } => {
+///                 println!("Model '{}' not found", model);
+///                 if let Some(s) = suggestion {
+///                     println!("Try: {}", s);
+///                 }
+///             }
+///             _ if err.is_retryable() => {
+///                 println!("Transient error, will retry");
+///             }
+///             _ => {
+///                 println!("Unrecoverable error");
+///             }
+///         }
+///     }
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub enum ApiErrorKind {
+    /// Rate limit exceeded (HTTP 429)
+    ///
+    /// The API is rate limiting requests. Wait for the specified duration before retrying.
+    RateLimited {
+        /// How long to wait before retrying (if provided by the API)
+        retry_after: Option<Duration>,
+    },
+
+    /// Invalid or unknown model (HTTP 404 with model context)
+    ///
+    /// The requested model does not exist or is not accessible.
+    InvalidModel {
+        /// The model name that was not found
+        model: String,
+        /// A suggested alternative model, if available
+        suggestion: Option<String>,
+    },
+
+    /// Service temporarily unavailable (HTTP 503)
+    ///
+    /// The API service is temporarily down. This is usually transient.
+    ServiceUnavailable,
+
+    /// Gateway/proxy error (HTTP 520-524, Cloudflare errors)
+    ///
+    /// An error occurred at the gateway level. Usually transient.
+    GatewayError {
+        /// The specific HTTP status code
+        code: u16,
+    },
+
+    /// Authentication failed (HTTP 401)
+    ///
+    /// The API key is invalid, expired, or missing.
+    AuthenticationFailed,
+
+    /// Permission denied (HTTP 403)
+    ///
+    /// The API key doesn't have permission for this operation or model.
+    PermissionDenied,
+
+    /// Request too large (HTTP 413)
+    ///
+    /// The request payload (usually the prompt) is too large.
+    RequestTooLarge,
+
+    /// Invalid request (HTTP 400)
+    ///
+    /// The request was malformed or contained invalid parameters.
+    BadRequest {
+        /// Details about what was invalid
+        details: String,
+    },
+
+    /// Server error (HTTP 500, 502)
+    ///
+    /// An internal server error occurred. May be transient.
+    ServerError {
+        /// The specific HTTP status code
+        code: u16,
+    },
+
+    /// Generic/unclassified API error
+    Other {
+        /// The HTTP status code
+        code: u16,
+        /// The error message from the API
+        message: String,
+    },
+
+    /// Unexpected response format from API
+    ///
+    /// The API returned a successful HTTP status but the response content
+    /// was missing expected fields (e.g., empty choices array, no content).
+    UnexpectedResponse {
+        /// Description of what was expected vs received
+        details: String,
+    },
+}
+
+impl ApiErrorKind {
+    /// Returns whether this error is potentially retryable.
+    ///
+    /// Retryable errors are transient issues that may succeed on a subsequent attempt.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rstructor::ApiErrorKind;
+    /// use std::time::Duration;
+    ///
+    /// let rate_limited = ApiErrorKind::RateLimited { retry_after: Some(Duration::from_secs(5)) };
+    /// assert!(rate_limited.is_retryable());
+    ///
+    /// let auth_failed = ApiErrorKind::AuthenticationFailed;
+    /// assert!(!auth_failed.is_retryable());
+    /// ```
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            ApiErrorKind::RateLimited { .. }
+                | ApiErrorKind::ServiceUnavailable
+                | ApiErrorKind::GatewayError { .. }
+                | ApiErrorKind::ServerError { .. }
+        )
+    }
+
+    /// Returns the suggested wait duration for retryable errors.
+    ///
+    /// For rate-limited errors, returns the `retry_after` duration if available.
+    /// For other retryable errors, returns a sensible default.
+    pub fn retry_delay(&self) -> Option<Duration> {
+        match self {
+            ApiErrorKind::RateLimited { retry_after } => {
+                Some(retry_after.unwrap_or(Duration::from_secs(5)))
+            }
+            ApiErrorKind::ServiceUnavailable => Some(Duration::from_secs(2)),
+            ApiErrorKind::GatewayError { .. } => Some(Duration::from_secs(1)),
+            ApiErrorKind::ServerError { .. } => Some(Duration::from_secs(2)),
+            _ => None,
+        }
+    }
+
+    /// Returns a user-friendly message describing the error and suggested action.
+    pub fn user_message(&self, provider_name: &str) -> String {
+        match self {
+            ApiErrorKind::RateLimited { retry_after } => {
+                if let Some(duration) = retry_after {
+                    format!(
+                        "Rate limit exceeded. Please wait {} seconds and try again.",
+                        duration.as_secs()
+                    )
+                } else {
+                    "Rate limit exceeded. Please wait a moment and try again.".to_string()
+                }
+            }
+            ApiErrorKind::InvalidModel { model, suggestion } => {
+                let mut msg = format!("Model '{}' not found.", model);
+                if let Some(s) = suggestion {
+                    msg.push_str(&format!(" Try using '{}'.", s));
+                }
+                msg
+            }
+            ApiErrorKind::ServiceUnavailable => {
+                format!(
+                    "{} service is temporarily unavailable. Please try again.",
+                    provider_name
+                )
+            }
+            ApiErrorKind::GatewayError { code } => {
+                format!(
+                    "Gateway error ({}). This is usually transient - please retry.",
+                    code
+                )
+            }
+            ApiErrorKind::AuthenticationFailed => {
+                format!(
+                    "Authentication failed. Check your {}_API_KEY environment variable.",
+                    provider_name.to_uppercase()
+                )
+            }
+            ApiErrorKind::PermissionDenied => {
+                "Permission denied. Your API key may not have access to this model or feature."
+                    .to_string()
+            }
+            ApiErrorKind::RequestTooLarge => {
+                "Request too large. Try reducing the prompt length or max_tokens.".to_string()
+            }
+            ApiErrorKind::BadRequest { details } => {
+                format!("Invalid request: {}", details)
+            }
+            ApiErrorKind::ServerError { code } => {
+                format!(
+                    "{} server error ({}). This may be transient - please retry.",
+                    provider_name, code
+                )
+            }
+            ApiErrorKind::Other { code, message } => {
+                format!("{} API error ({}): {}", provider_name, code, message)
+            }
+            ApiErrorKind::UnexpectedResponse { details } => {
+                format!(
+                    "{} returned an unexpected response: {}",
+                    provider_name, details
+                )
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for ApiErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ApiErrorKind::RateLimited { retry_after } => {
+                write!(f, "Rate limited")?;
+                if let Some(d) = retry_after {
+                    write!(f, " (retry after {}s)", d.as_secs())?;
+                }
+                Ok(())
+            }
+            ApiErrorKind::InvalidModel { model, .. } => write!(f, "Invalid model: {}", model),
+            ApiErrorKind::ServiceUnavailable => write!(f, "Service unavailable"),
+            ApiErrorKind::GatewayError { code } => write!(f, "Gateway error ({})", code),
+            ApiErrorKind::AuthenticationFailed => write!(f, "Authentication failed"),
+            ApiErrorKind::PermissionDenied => write!(f, "Permission denied"),
+            ApiErrorKind::RequestTooLarge => write!(f, "Request too large"),
+            ApiErrorKind::BadRequest { details } => write!(f, "Bad request: {}", details),
+            ApiErrorKind::ServerError { code } => write!(f, "Server error ({})", code),
+            ApiErrorKind::Other { code, message } => write!(f, "API error ({}): {}", code, message),
+            ApiErrorKind::UnexpectedResponse { details } => {
+                write!(f, "Unexpected response: {}", details)
+            }
+        }
+    }
+}
 
 /// Error types for the rstructor library.
 ///
@@ -33,9 +287,14 @@ use thiserror::Error;
 /// ```
 #[derive(Error, Debug)]
 pub enum RStructorError {
-    /// Error interacting with the LLM API
-    #[error("API error: {0}")]
-    ApiError(String),
+    /// Error interacting with the LLM API (with rich error classification)
+    #[error("{}", .kind.user_message(.provider))]
+    ApiError {
+        /// The provider that returned the error (e.g., "OpenAI", "Anthropic")
+        provider: String,
+        /// The classified error kind
+        kind: ApiErrorKind,
+    },
 
     /// Error validating data against schema or business rules
     #[error("Validation error: {0}")]
@@ -62,13 +321,97 @@ pub enum RStructorError {
     JsonError(#[from] serde_json::Error),
 }
 
+impl RStructorError {
+    /// Create a new API error with rich classification.
+    ///
+    /// # Arguments
+    ///
+    /// * `provider` - The LLM provider name (e.g., "OpenAI", "Anthropic")
+    /// * `kind` - The classified error kind
+    pub fn api_error(provider: impl Into<String>, kind: ApiErrorKind) -> Self {
+        RStructorError::ApiError {
+            provider: provider.into(),
+            kind,
+        }
+    }
+
+    /// Returns the API error kind if this is an API error.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rstructor::{RStructorError, ApiErrorKind};
+    ///
+    /// let err = RStructorError::api_error("OpenAI", ApiErrorKind::AuthenticationFailed);
+    /// assert!(matches!(err.api_error_kind(), Some(ApiErrorKind::AuthenticationFailed)));
+    /// ```
+    pub fn api_error_kind(&self) -> Option<&ApiErrorKind> {
+        match self {
+            RStructorError::ApiError { kind, .. } => Some(kind),
+            _ => None,
+        }
+    }
+
+    /// Returns whether this error is potentially retryable.
+    ///
+    /// Retryable errors include:
+    /// - Rate limiting (429)
+    /// - Service unavailable (503)
+    /// - Gateway errors (520-524)
+    /// - Server errors (500, 502)
+    /// - Timeout errors
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rstructor::{RStructorError, ApiErrorKind};
+    /// use std::time::Duration;
+    ///
+    /// let rate_limited = RStructorError::api_error(
+    ///     "OpenAI",
+    ///     ApiErrorKind::RateLimited { retry_after: Some(Duration::from_secs(5)) }
+    /// );
+    /// assert!(rate_limited.is_retryable());
+    ///
+    /// let auth_error = RStructorError::api_error("OpenAI", ApiErrorKind::AuthenticationFailed);
+    /// assert!(!auth_error.is_retryable());
+    /// ```
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            RStructorError::ApiError { kind, .. } => kind.is_retryable(),
+            RStructorError::Timeout => true,
+            _ => false,
+        }
+    }
+
+    /// Returns the suggested retry delay for retryable errors.
+    ///
+    /// Returns `None` for non-retryable errors.
+    pub fn retry_delay(&self) -> Option<Duration> {
+        match self {
+            RStructorError::ApiError { kind, .. } => kind.retry_delay(),
+            RStructorError::Timeout => Some(Duration::from_secs(1)),
+            _ => None,
+        }
+    }
+}
+
 // Manual implementation of PartialEq for RStructorError
 // Note: HttpError and JsonError variants are considered unequal
 // because reqwest::Error and serde_json::Error don't implement PartialEq
 impl PartialEq for RStructorError {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::ApiError(a), Self::ApiError(b)) => a == b,
+            (
+                Self::ApiError {
+                    provider: p1,
+                    kind: k1,
+                },
+                Self::ApiError {
+                    provider: p2,
+                    kind: k2,
+                },
+            ) => p1 == p2 && k1 == k2,
             (Self::ValidationError(a), Self::ValidationError(b)) => a == b,
             (Self::SchemaError(a), Self::SchemaError(b)) => a == b,
             (Self::SerializationError(a), Self::SerializationError(b)) => a == b,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub mod model;
 pub mod schema;
 
 // Re-exports for convenience
-pub use error::{RStructorError, Result};
+pub use error::{ApiErrorKind, RStructorError, Result};
 pub use model::Instructor;
 pub use schema::{CustomTypeSchema, Schema, SchemaBuilder, SchemaType};
 
@@ -69,5 +69,6 @@ pub use backend::grok::{GrokClient, Model as GrokModel};
 pub use rstructor_derive::Instructor;
 
 pub use backend::LLMClient;
+pub use backend::ModelInfo;
 pub use backend::ThinkingLevel;
 pub use backend::{GenerateResult, MaterializeResult, TokenUsage};

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -1,13 +1,293 @@
 #[cfg(test)]
 mod error_tests {
-    use rstructor::{RStructorError, Result};
+    use rstructor::{ApiErrorKind, RStructorError, Result};
     use serde_json::json;
+    use std::time::Duration;
 
     #[test]
-    fn test_api_error() {
-        let err = RStructorError::ApiError("API connection failed".to_string());
+    fn test_api_error_unexpected_response() {
+        let err = RStructorError::api_error(
+            "TestProvider",
+            ApiErrorKind::UnexpectedResponse {
+                details: "No content returned".to_string(),
+            },
+        );
         let err_string = format!("{}", err);
-        assert_eq!(err_string, "API error: API connection failed");
+        assert!(err_string.contains("unexpected response"));
+        assert!(err_string.contains("No content returned"));
+        assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn test_api_error_rich() {
+        let err = RStructorError::api_error("OpenAI", ApiErrorKind::AuthenticationFailed);
+        let err_string = format!("{}", err);
+        assert_eq!(
+            err_string,
+            "Authentication failed. Check your OPENAI_API_KEY environment variable."
+        );
+        assert!(!err.is_retryable());
+        assert!(matches!(
+            err.api_error_kind(),
+            Some(ApiErrorKind::AuthenticationFailed)
+        ));
+    }
+
+    #[test]
+    fn test_api_error_rate_limited() {
+        let err = RStructorError::api_error(
+            "Anthropic",
+            ApiErrorKind::RateLimited {
+                retry_after: Some(Duration::from_secs(30)),
+            },
+        );
+        assert!(err.is_retryable());
+        assert_eq!(err.retry_delay(), Some(Duration::from_secs(30)));
+        let err_string = format!("{}", err);
+        assert!(err_string.contains("30 seconds"));
+    }
+
+    #[test]
+    fn test_api_error_kind_is_retryable() {
+        // Retryable errors
+        assert!(ApiErrorKind::RateLimited { retry_after: None }.is_retryable());
+        assert!(
+            ApiErrorKind::RateLimited {
+                retry_after: Some(Duration::from_secs(10))
+            }
+            .is_retryable()
+        );
+        assert!(ApiErrorKind::ServiceUnavailable.is_retryable());
+        assert!(ApiErrorKind::GatewayError { code: 520 }.is_retryable());
+        assert!(ApiErrorKind::GatewayError { code: 521 }.is_retryable());
+        assert!(ApiErrorKind::GatewayError { code: 522 }.is_retryable());
+        assert!(ApiErrorKind::GatewayError { code: 523 }.is_retryable());
+        assert!(ApiErrorKind::GatewayError { code: 524 }.is_retryable());
+        assert!(ApiErrorKind::ServerError { code: 500 }.is_retryable());
+        assert!(ApiErrorKind::ServerError { code: 502 }.is_retryable());
+
+        // Non-retryable errors
+        assert!(!ApiErrorKind::AuthenticationFailed.is_retryable());
+        assert!(!ApiErrorKind::PermissionDenied.is_retryable());
+        assert!(!ApiErrorKind::RequestTooLarge.is_retryable());
+        assert!(
+            !ApiErrorKind::BadRequest {
+                details: "test".into()
+            }
+            .is_retryable()
+        );
+        assert!(
+            !ApiErrorKind::InvalidModel {
+                model: "gpt-5".into(),
+                suggestion: None
+            }
+            .is_retryable()
+        );
+        assert!(
+            !ApiErrorKind::Other {
+                code: 418,
+                message: "teapot".into()
+            }
+            .is_retryable()
+        );
+        assert!(
+            !ApiErrorKind::UnexpectedResponse {
+                details: "test".into()
+            }
+            .is_retryable()
+        );
+    }
+
+    #[test]
+    fn test_all_error_kinds_have_retry_delay() {
+        // Retryable errors have delays
+        assert!(
+            ApiErrorKind::RateLimited { retry_after: None }
+                .retry_delay()
+                .is_some()
+        );
+        assert_eq!(
+            ApiErrorKind::RateLimited {
+                retry_after: Some(Duration::from_secs(42))
+            }
+            .retry_delay(),
+            Some(Duration::from_secs(42))
+        );
+        assert!(ApiErrorKind::ServiceUnavailable.retry_delay().is_some());
+        assert!(
+            ApiErrorKind::GatewayError { code: 520 }
+                .retry_delay()
+                .is_some()
+        );
+        assert!(
+            ApiErrorKind::ServerError { code: 500 }
+                .retry_delay()
+                .is_some()
+        );
+
+        // Non-retryable errors have no delay
+        assert!(ApiErrorKind::AuthenticationFailed.retry_delay().is_none());
+        assert!(ApiErrorKind::PermissionDenied.retry_delay().is_none());
+        assert!(ApiErrorKind::RequestTooLarge.retry_delay().is_none());
+        assert!(
+            ApiErrorKind::BadRequest {
+                details: "test".into()
+            }
+            .retry_delay()
+            .is_none()
+        );
+        assert!(
+            ApiErrorKind::InvalidModel {
+                model: "x".into(),
+                suggestion: None
+            }
+            .retry_delay()
+            .is_none()
+        );
+        assert!(
+            ApiErrorKind::UnexpectedResponse {
+                details: "x".into()
+            }
+            .retry_delay()
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn test_all_error_kinds_have_user_messages() {
+        let test_cases = [
+            (
+                ApiErrorKind::RateLimited { retry_after: None },
+                "Rate limit",
+            ),
+            (
+                ApiErrorKind::RateLimited {
+                    retry_after: Some(Duration::from_secs(5)),
+                },
+                "5 seconds",
+            ),
+            (
+                ApiErrorKind::InvalidModel {
+                    model: "test-model".into(),
+                    suggestion: None,
+                },
+                "test-model",
+            ),
+            (
+                ApiErrorKind::InvalidModel {
+                    model: "old".into(),
+                    suggestion: Some("new".into()),
+                },
+                "new",
+            ),
+            (ApiErrorKind::ServiceUnavailable, "temporarily unavailable"),
+            (ApiErrorKind::GatewayError { code: 520 }, "520"),
+            (ApiErrorKind::AuthenticationFailed, "API_KEY"),
+            (ApiErrorKind::PermissionDenied, "Permission denied"),
+            (ApiErrorKind::RequestTooLarge, "too large"),
+            (
+                ApiErrorKind::BadRequest {
+                    details: "invalid param".into(),
+                },
+                "invalid param",
+            ),
+            (ApiErrorKind::ServerError { code: 500 }, "500"),
+            (
+                ApiErrorKind::Other {
+                    code: 418,
+                    message: "I'm a teapot".into(),
+                },
+                "teapot",
+            ),
+            (
+                ApiErrorKind::UnexpectedResponse {
+                    details: "empty array".into(),
+                },
+                "empty array",
+            ),
+        ];
+
+        for (kind, expected_substr) in test_cases {
+            let msg = kind.user_message("TestProvider");
+            assert!(
+                msg.contains(expected_substr),
+                "Expected '{}' to contain '{}' for {:?}",
+                msg,
+                expected_substr,
+                kind
+            );
+        }
+    }
+
+    #[test]
+    fn test_error_display_implementations() {
+        // All variants should have Display implementations that don't panic
+        let variants = [
+            ApiErrorKind::RateLimited { retry_after: None },
+            ApiErrorKind::RateLimited {
+                retry_after: Some(Duration::from_secs(10)),
+            },
+            ApiErrorKind::InvalidModel {
+                model: "test".into(),
+                suggestion: None,
+            },
+            ApiErrorKind::InvalidModel {
+                model: "test".into(),
+                suggestion: Some("alt".into()),
+            },
+            ApiErrorKind::ServiceUnavailable,
+            ApiErrorKind::GatewayError { code: 520 },
+            ApiErrorKind::AuthenticationFailed,
+            ApiErrorKind::PermissionDenied,
+            ApiErrorKind::RequestTooLarge,
+            ApiErrorKind::BadRequest {
+                details: "test".into(),
+            },
+            ApiErrorKind::ServerError { code: 500 },
+            ApiErrorKind::Other {
+                code: 999,
+                message: "custom".into(),
+            },
+            ApiErrorKind::UnexpectedResponse {
+                details: "test".into(),
+            },
+        ];
+
+        for variant in variants {
+            let display = format!("{}", variant);
+            assert!(
+                !display.is_empty(),
+                "Display for {:?} should not be empty",
+                variant
+            );
+        }
+    }
+
+    #[test]
+    fn test_rstructor_error_is_retryable() {
+        // API errors delegate to kind
+        let retryable =
+            RStructorError::api_error("Test", ApiErrorKind::RateLimited { retry_after: None });
+        assert!(retryable.is_retryable());
+
+        let not_retryable = RStructorError::api_error("Test", ApiErrorKind::AuthenticationFailed);
+        assert!(!not_retryable.is_retryable());
+
+        // Timeout is retryable
+        assert!(RStructorError::Timeout.is_retryable());
+
+        // Other errors are not retryable
+        assert!(!RStructorError::ValidationError("test".into()).is_retryable());
+        assert!(!RStructorError::SchemaError("test".into()).is_retryable());
+        assert!(!RStructorError::SerializationError("test".into()).is_retryable());
+    }
+
+    #[test]
+    fn test_timeout_has_retry_delay() {
+        assert_eq!(
+            RStructorError::Timeout.retry_delay(),
+            Some(Duration::from_secs(1))
+        );
     }
 
     #[test]


### PR DESCRIPTION
- Implement ApiErrorKind for granular error classification (rate limits, auth, etc.)
- Add list_models method to LLMClient trait for all providers
- Enhance retry logic to respect retry-after headers and transient failures
- Update README with comprehensive error handling and model discovery guides
- Refactor provider clients to use structured error creation

fixes #21 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Error handling overhaul**
> 
> - Adds `ApiErrorKind` and restructures `RStructorError::ApiError` with provider-aware messages, retryability, and `retry_delay()`
> - Classifies HTTP errors in `backend/utils::check_response_status` (handles 4xx/5xx, `retry-after`) and updates providers to use `RStructorError::api_error`
> - Improves `generate_with_retry` to retry transient API errors and respect suggested delays
> 
> **Model discovery**
> 
> - Extends `LLMClient` with `async fn list_models()` and introduces `backend::ModelInfo`
> - Implements model listing for OpenAI, Anthropic, Gemini, and Grok (filtered to chat-capable models)
> 
> **Provider/client updates**
> 
> - Refactors OpenAI, Anthropic, Gemini, and Grok clients to emit structured errors (e.g., `UnexpectedResponse`) and adopt new error flow
> - Example `recipe_extractor.rs` updated to use structured auth errors
> 
> **Docs & tests**
> 
> - README adds Error Handling and Model Discovery guides with examples
> - New `tests/error_tests.rs` covering error kinds, retryability, display, and delays
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab1eaedb6f2c4ff80d251c00af78a42db564163c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->