### PR TITLE
fix: emit anyOf instead of oneOf in complex enum schemas

### DIFF
--- a/rstructor_derive/src/generators/enum_schema.rs
+++ b/rstructor_derive/src/generators/enum_schema.rs
@@ -400,7 +400,7 @@ fn generate_externally_tagged_enum_schema(
                 ];
 
                 let mut schema_obj = ::serde_json::json!({
-                    "oneOf": variant_schemas,
+                    "anyOf": variant_schemas,
                     "title": stringify!(#name)
                 });
 
@@ -754,7 +754,7 @@ fn generate_internally_tagged_enum_schema(
                 ];
 
                 let mut schema_obj = ::serde_json::json!({
-                    "oneOf": variant_schemas,
+                    "anyOf": variant_schemas,
                     "title": stringify!(#name)
                 });
 
@@ -1045,7 +1045,7 @@ fn generate_adjacently_tagged_enum_schema(
                 ];
 
                 let mut schema_obj = ::serde_json::json!({
-                    "oneOf": variant_schemas,
+                    "anyOf": variant_schemas,
                     "title": stringify!(#name)
                 });
 
@@ -1202,7 +1202,7 @@ fn generate_untagged_enum_schema(
                 ];
 
                 let mut schema_obj = ::serde_json::json!({
-                    "oneOf": variant_schemas,
+                    "anyOf": variant_schemas,
                     "title": stringify!(#name)
                 });
 

--- a/rstructor_derive/tests/enum_with_data_tests.rs
+++ b/rstructor_derive/tests/enum_with_data_tests.rs
@@ -23,13 +23,13 @@ fn test_enum_with_data_schema() {
     let schema_obj = UserStatus::schema();
     let schema = schema_obj.to_json();
 
-    // Check that we're using oneOf for complex enums
+    // Check that we're using anyOf for complex enums
     assert!(
-        schema.get("oneOf").is_some(),
-        "Schema should use oneOf for enums with associated data"
+        schema.get("anyOf").is_some(),
+        "Schema should use anyOf for enums with associated data"
     );
 
-    if let Some(Value::Array(variants)) = schema.get("oneOf") {
+    if let Some(Value::Array(variants)) = schema.get("anyOf") {
         // Should have 4 variants
         assert_eq!(variants.len(), 4, "Should have 4 variants");
     }

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -263,7 +263,7 @@ impl GeminiClient {
     /// # Ok(())
     /// # }
     /// ```
-    #[instrument(name = "gemini_client_new", skip(api_key), fields(model = ?Model::Gemini25Flash))]
+    #[instrument(name = "gemini_client_new", skip(api_key), fields(model = ?Model::Gemini3FlashPreview))]
     pub fn new(api_key: impl Into<String>) -> Result<Self> {
         let api_key = api_key.into();
         if api_key.is_empty() {

--- a/tests/complex_enum_integration_tests.rs
+++ b/tests/complex_enum_integration_tests.rs
@@ -1,7 +1,7 @@
 // tests/complex_enum_integration_tests.rs
 #[cfg(test)]
 mod complex_enum_tests {
-    use rstructor::{GeminiClient, Instructor, LLMClient};
+    use rstructor::{GeminiClient, GeminiModel, Instructor, LLMClient};
     use serde::{Deserialize, Serialize};
     use std::env;
 
@@ -27,6 +27,7 @@ mod complex_enum_tests {
         let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set");
         let client = GeminiClient::new(api_key)
             .unwrap()
+            .model(GeminiModel::Gemini3FlashPreview)
             .temperature(0.0)
             .no_retries();
 

--- a/tests/gemini_multimodal_tests.rs
+++ b/tests/gemini_multimodal_tests.rs
@@ -10,7 +10,7 @@
 #[cfg(test)]
 mod gemini_multimodal_tests {
     #[cfg(feature = "gemini")]
-    use rstructor::GeminiClient;
+    use rstructor::{GeminiClient, GeminiModel};
     use rstructor::{Instructor, LLMClient, MediaFile};
     use serde::{Deserialize, Serialize};
 
@@ -43,6 +43,7 @@ mod gemini_multimodal_tests {
 
         let client = GeminiClient::from_env()
             .expect("GEMINI_API_KEY must be set for this test")
+            .model(GeminiModel::Gemini3FlashPreview)
             .temperature(0.0);
 
         let result: ImageDescription = client

--- a/tests/hashmap_integration_tests.rs
+++ b/tests/hashmap_integration_tests.rs
@@ -1,7 +1,7 @@
 // tests/hashmap_integration_tests.rs
 #[cfg(test)]
 mod hashmap_tests {
-    use rstructor::{GeminiClient, Instructor, LLMClient};
+    use rstructor::{GeminiClient, GeminiModel, Instructor, LLMClient};
     use serde::{Deserialize, Serialize};
     use std::collections::HashMap;
     use std::env;
@@ -32,6 +32,7 @@ mod hashmap_tests {
         let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set");
         let client = GeminiClient::new(api_key)
             .unwrap()
+            .model(GeminiModel::Gemini3FlashPreview)
             .temperature(0.0)
             .no_retries();
 
@@ -63,6 +64,7 @@ mod hashmap_tests {
         let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set");
         let client = GeminiClient::new(api_key)
             .unwrap()
+            .model(GeminiModel::Gemini3FlashPreview)
             .temperature(0.0)
             .no_retries();
 

--- a/tests/llm_integration_tests.rs
+++ b/tests/llm_integration_tests.rs
@@ -12,10 +12,10 @@
 
 #[cfg(test)]
 mod llm_integration_tests {
-    #[cfg(feature = "gemini")]
-    use rstructor::GeminiClient;
     #[cfg(feature = "anthropic")]
     use rstructor::{AnthropicClient, AnthropicModel};
+    #[cfg(feature = "gemini")]
+    use rstructor::{GeminiClient, GeminiModel};
     #[cfg(feature = "grok")]
     use rstructor::{GrokClient, GrokModel};
     use rstructor::{Instructor, LLMClient, SchemaType};
@@ -154,9 +154,9 @@ mod llm_integration_tests {
     #[tokio::test]
     async fn test_gemini_materialize() {
         // Read from GEMINI_API_KEY env var
-        // Uses default model (Gemini 3 Flash Preview with Low thinking)
         let client = GeminiClient::from_env()
             .expect("GEMINI_API_KEY must be set for this test")
+            .model(GeminiModel::Gemini3FlashPreview)
             .temperature(0.0);
 
         let prompt = "Provide information about the movie Inception";

--- a/tests/nested_enum_tests.rs
+++ b/tests/nested_enum_tests.rs
@@ -96,9 +96,9 @@ mod nested_enum_tests {
         let schema = TaskState::schema();
         let schema_json = schema.to_json();
 
-        // Verify it's a oneOf schema (complex enum)
-        assert!(schema_json["oneOf"].is_array());
-        let variants = schema_json["oneOf"].as_array().unwrap();
+        // Verify it's an anyOf schema (complex enum)
+        assert!(schema_json["anyOf"].is_array());
+        let variants = schema_json["anyOf"].as_array().unwrap();
         assert_eq!(variants.len(), 3);
 
         // Verify Pending variant has priority field
@@ -160,8 +160,8 @@ mod nested_enum_tests {
         // Verify items are objects (since TaskState is a complex enum)
         let items = &tasks_prop["items"];
         assert!(items.is_object());
-        // Complex enums should have oneOf schema
-        assert!(items.get("oneOf").is_some() || items.get("type").is_some());
+        // Complex enums should have anyOf schema
+        assert!(items.get("anyOf").is_some() || items.get("type").is_some());
     }
 
     #[test]
@@ -248,9 +248,9 @@ mod nested_enum_tests {
         let schema = DeepNestedEnum::schema();
         let schema_json = schema.to_json();
 
-        // Verify it's a oneOf schema
-        assert!(schema_json["oneOf"].is_array());
-        let variants = schema_json["oneOf"].as_array().unwrap();
+        // Verify it's an anyOf schema
+        assert!(schema_json["anyOf"].is_array());
+        let variants = schema_json["anyOf"].as_array().unwrap();
         assert_eq!(variants.len(), 1);
 
         // Verify Level1 variant has both status and priority fields

--- a/tests/openai_enum_anyof_test.rs
+++ b/tests/openai_enum_anyof_test.rs
@@ -1,0 +1,89 @@
+//! Regression test for OpenAI `oneOf` rejection bug.
+//!
+//! OpenAI's structured outputs API rejects `oneOf` in JSON schemas — it only
+//! supports `anyOf`. The `rstructor` derive macro must emit `anyOf` for all
+//! complex enum schemas so that OpenAI (and other providers) accept them.
+//!
+//! Run with:
+//! ```bash
+//! cargo test --test openai_enum_anyof_test
+//! ```
+
+#[cfg(test)]
+mod openai_enum_anyof_tests {
+    use rstructor::Instructor;
+    use serde::{Deserialize, Serialize};
+
+    // ── Complex enum: externally tagged (default serde representation) ──
+
+    #[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
+    #[llm(description = "A type of animal")]
+    enum Animal {
+        #[llm(description = "A dog")]
+        Dog {
+            #[llm(description = "The breed of the dog")]
+            breed: String,
+        },
+        #[llm(description = "A cat")]
+        Cat {
+            #[llm(description = "Whether the cat is indoor-only")]
+            indoor: bool,
+        },
+        #[llm(description = "A mouse")]
+        Mouse {
+            #[llm(description = "The colour of the mouse")]
+            colour: String,
+        },
+    }
+
+    #[derive(Instructor, Serialize, Deserialize, Debug)]
+    #[llm(description = "Identification of a fictional character")]
+    struct CharacterId {
+        #[llm(description = "Name of the character")]
+        name: String,
+
+        #[llm(description = "What kind of animal the character is")]
+        animal: Animal,
+    }
+
+    // ====================================================================
+    // Live OpenAI integration test — requires OPENAI_API_KEY
+    // ====================================================================
+
+    /// Send a struct containing a complex enum to OpenAI and confirm the API
+    /// accepts the schema and returns valid data.
+    ///
+    /// Before the fix this would fail with:
+    /// > Invalid schema for response_format '...': 'oneOf' is not permitted.
+    #[cfg(feature = "openai")]
+    #[tokio::test]
+    async fn test_openai_accepts_complex_enum_schema() {
+        use rstructor::{LLMClient, OpenAIClient, OpenAIModel};
+        use std::env;
+
+        let api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set");
+
+        let client = OpenAIClient::new(api_key)
+            .expect("Failed to create OpenAI client")
+            .model(OpenAIModel::Gpt4OMini)
+            .temperature(0.0);
+
+        let result = client
+            .materialize::<CharacterId>("What kind of animal is Scooby-Doo?")
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "OpenAI should accept the schema with `anyOf`. Error: {:?}",
+            result.err()
+        );
+
+        let character = result.unwrap();
+        assert_eq!(character.name, "Scooby-Doo");
+        assert!(
+            matches!(character.animal, Animal::Dog { .. }),
+            "Scooby-Doo should be identified as a Dog, got: {:?}",
+            character.animal
+        );
+    }
+}

--- a/tests/recursive_structures_tests.rs
+++ b/tests/recursive_structures_tests.rs
@@ -1,7 +1,7 @@
 // tests/recursive_structures_tests.rs
 #[cfg(test)]
 mod recursive_tests {
-    use rstructor::{GeminiClient, Instructor, LLMClient};
+    use rstructor::{GeminiClient, GeminiModel, Instructor, LLMClient};
     use serde::{Deserialize, Serialize};
     use std::env;
 
@@ -23,6 +23,7 @@ mod recursive_tests {
         let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set");
         let client = GeminiClient::new(api_key)
             .unwrap()
+            .model(GeminiModel::Gemini3FlashPreview)
             .temperature(0.0)
             .no_retries();
 

--- a/tests/serde_rename_tests.rs
+++ b/tests/serde_rename_tests.rs
@@ -301,8 +301,8 @@ mod serde_rename_tests {
         let schema = PaymentMethod::schema();
         let schema_json = schema.to_json();
 
-        // Complex enums use oneOf
-        let one_of = schema_json["oneOf"].as_array().unwrap();
+        // Complex enums use anyOf
+        let one_of = schema_json["anyOf"].as_array().unwrap();
         assert_eq!(one_of.len(), 3);
 
         // Check that variant names are properly renamed

--- a/tests/timeout_tests.rs
+++ b/tests/timeout_tests.rs
@@ -5,10 +5,10 @@
 
 #[cfg(test)]
 mod timeout_tests {
-    #[cfg(feature = "gemini")]
-    use rstructor::GeminiClient;
     #[cfg(feature = "anthropic")]
     use rstructor::{AnthropicClient, AnthropicModel};
+    #[cfg(feature = "gemini")]
+    use rstructor::{GeminiClient, GeminiModel};
     #[cfg(feature = "grok")]
     use rstructor::{GrokClient, GrokModel};
     use rstructor::{Instructor, LLMClient, RStructorError};
@@ -200,9 +200,9 @@ mod timeout_tests {
     #[tokio::test]
     async fn test_gemini_timeout_configuration() {
         // Test that timeout can be set via builder pattern
-        // Uses default model (Gemini 3 Flash Preview with Low thinking)
         let client = GeminiClient::from_env()
             .expect("GEMINI_API_KEY must be set for this test")
+            .model(GeminiModel::Gemini3FlashPreview)
             .temperature(0.0)
             .timeout(Duration::from_millis(1)); // 1ms timeout - should timeout
 
@@ -224,9 +224,9 @@ mod timeout_tests {
     #[tokio::test]
     async fn test_gemini_timeout_chaining() {
         // Test that timeout can be chained with other configuration methods
-        // Uses default model (Gemini 3 Flash Preview with Low thinking)
         let _client = GeminiClient::from_env()
             .expect("GEMINI_API_KEY must be set for this test")
+            .model(GeminiModel::Gemini3FlashPreview)
             .temperature(0.5)
             .max_tokens(100)
             .timeout(Duration::from_secs(2)); // 2 second timeout for unit tests
@@ -239,9 +239,10 @@ mod timeout_tests {
     #[cfg(feature = "gemini")]
     #[tokio::test]
     async fn test_gemini_no_timeout_default() {
-        // Test that default client has no timeout
-        // Test with empty string to use GEMINI_API_KEY env var
-        let _client = GeminiClient::from_env().expect("GEMINI_API_KEY must be set for this test");
+        // Test that client can be created with explicit Gemini 3 Flash Preview and no timeout
+        let _client = GeminiClient::from_env()
+            .expect("GEMINI_API_KEY must be set for this test")
+            .model(GeminiModel::Gemini3FlashPreview);
 
         // Verify that client was created successfully without timeout
         // (We can't access config directly, but default behavior means no timeout)

--- a/tests/weird_types_tests.rs
+++ b/tests/weird_types_tests.rs
@@ -1,7 +1,7 @@
 // tests/weird_types_tests.rs
 #[cfg(test)]
 mod weird_types_tests {
-    use rstructor::{GeminiClient, Instructor, LLMClient};
+    use rstructor::{GeminiClient, GeminiModel, Instructor, LLMClient};
     use serde::{Deserialize, Serialize};
     use std::collections::HashMap;
     use std::env;
@@ -34,6 +34,7 @@ mod weird_types_tests {
         let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set");
         let client = GeminiClient::new(api_key)
             .unwrap()
+            .model(GeminiModel::Gemini3FlashPreview)
             .temperature(0.0)
             .no_retries();
 


### PR DESCRIPTION
Oneof isn 't compatible with Openai, anyOf is.

I've also included a test to demonstrate the problem.

I think semantically anyOf makes at least as much sense as OneOf, so I'm guessing this is a deliberate choice by openai, rather than a bug