### PR TITLE
[codex] add multimodal support across providers and unify media retries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ tracing-subscriber = { version = "0.3", features = [
 tracing-futures = { version = "0.2", optional = true }
 rstructor_derive = { version = "0.2.8", path = "./rstructor_derive", optional = true }
 chrono = "0.4" # For date/time validation in examples
-base64 = { version = "0.22", optional = true }
+base64 = "0.22"
 
 # Feature flags
 [features]
@@ -68,7 +68,7 @@ default = ["openai", "anthropic", "grok", "gemini", "derive", "logging"]
 openai = ["reqwest", "tokio"]
 anthropic = ["reqwest", "tokio"]
 grok = ["reqwest", "tokio"]
-gemini = ["reqwest", "tokio", "base64"]
+gemini = ["reqwest", "tokio"]
 derive = ["rstructor_derive"]
 logging = ["tracing-subscriber", "tracing-futures"]
 

--- a/README.md
+++ b/README.md
@@ -201,29 +201,28 @@ struct Event {
 
 ## Multimodal (Image Input)
 
-Analyze images with structured extraction using Gemini's inline data support:
+Analyze images with structured extraction across all major providers using `materialize_with_media`:
 
 ```rust
-use rstructor::{Instructor, LLMClient, GeminiClient, MediaFile};
+use rstructor::{Instructor, LLMClient, OpenAIClient, MediaFile};
 
 #[derive(Instructor, Serialize, Deserialize, Debug)]
 struct ImageAnalysis {
     subject: String,
-    colors: Vec<String>,
-    is_logo: bool,
-    description: String,
+    summary: String,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Download or load image bytes
+    // Download or load image bytes (real-world fixture)
     let image_bytes = reqwest::get("https://example.com/image.png")
         .await?.bytes().await?;
 
-    // Create inline media from bytes (base64-encoded automatically)
+    // Inline media is base64-encoded automatically
     let media = MediaFile::from_bytes(&image_bytes, "image/png");
 
-    let client = GeminiClient::from_env()?;
+    // Works with OpenAI, Anthropic, Grok, and Gemini clients
+    let client = OpenAIClient::from_env()?;
     let analysis: ImageAnalysis = client
         .materialize_with_media("Describe this image", &[media])
         .await?;
@@ -232,7 +231,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-`MediaFile::new(uri, mime_type)` is also available for Gemini Files API / GCS URIs.
+`MediaFile::new(uri, mime_type)` is also available for URL/URI-based media input.
+
+Provider examples:
+- `cargo run --example openai_multimodal_example --features openai`
+- `cargo run --example anthropic_multimodal_example --features anthropic`
+- `cargo run --example grok_multimodal_example --features grok`
+- `cargo run --example gemini_multimodal_example --features gemini`
 
 ## Extended Thinking
 

--- a/examples/anthropic_multimodal_example.rs
+++ b/examples/anthropic_multimodal_example.rs
@@ -1,0 +1,38 @@
+//! Anthropic Multimodal Structured Extraction Example
+//!
+//! Run with:
+//! ```bash
+//! export ANTHROPIC_API_KEY=your_key_here
+//! cargo run --example anthropic_multimodal_example --features anthropic
+//! ```
+
+use rstructor::{AnthropicClient, AnthropicModel, Instructor, LLMClient, MediaFile};
+use serde::{Deserialize, Serialize};
+use std::env;
+
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct ImageAnalysis {
+    subject: String,
+    summary: String,
+    colors: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env::var("ANTHROPIC_API_KEY").expect("Please set ANTHROPIC_API_KEY environment variable");
+
+    let image_url = "https://www.rust-lang.org/logos/rust-logo-512x512.png";
+    let image_bytes = reqwest::get(image_url).await?.bytes().await?;
+    let media = MediaFile::from_bytes(&image_bytes, "image/png");
+
+    let client = AnthropicClient::from_env()?
+        .model(AnthropicModel::ClaudeOpus46)
+        .temperature(0.0);
+
+    let analysis: ImageAnalysis = client
+        .materialize_with_media("Describe this image and list dominant colors.", &[media])
+        .await?;
+
+    println!("{:#?}", analysis);
+    Ok(())
+}

--- a/examples/grok_multimodal_example.rs
+++ b/examples/grok_multimodal_example.rs
@@ -1,0 +1,38 @@
+//! Grok Multimodal Structured Extraction Example
+//!
+//! Run with:
+//! ```bash
+//! export XAI_API_KEY=your_key_here
+//! cargo run --example grok_multimodal_example --features grok
+//! ```
+
+use rstructor::{GrokClient, GrokModel, Instructor, LLMClient, MediaFile};
+use serde::{Deserialize, Serialize};
+use std::env;
+
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct ImageAnalysis {
+    subject: String,
+    summary: String,
+    colors: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env::var("XAI_API_KEY").expect("Please set XAI_API_KEY environment variable");
+
+    let image_url = "https://www.rust-lang.org/logos/rust-logo-512x512.png";
+    let image_bytes = reqwest::get(image_url).await?.bytes().await?;
+    let media = MediaFile::from_bytes(&image_bytes, "image/png");
+
+    let client = GrokClient::from_env()?
+        .model(GrokModel::Grok41FastNonReasoning)
+        .temperature(0.0);
+
+    let analysis: ImageAnalysis = client
+        .materialize_with_media("Describe this image and list dominant colors.", &[media])
+        .await?;
+
+    println!("{:#?}", analysis);
+    Ok(())
+}

--- a/examples/openai_multimodal_example.rs
+++ b/examples/openai_multimodal_example.rs
@@ -1,0 +1,38 @@
+//! OpenAI Multimodal Structured Extraction Example
+//!
+//! Run with:
+//! ```bash
+//! export OPENAI_API_KEY=your_key_here
+//! cargo run --example openai_multimodal_example --features openai
+//! ```
+
+use rstructor::{Instructor, LLMClient, MediaFile, OpenAIClient, OpenAIModel};
+use serde::{Deserialize, Serialize};
+use std::env;
+
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct ImageAnalysis {
+    subject: String,
+    summary: String,
+    colors: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env::var("OPENAI_API_KEY").expect("Please set OPENAI_API_KEY environment variable");
+
+    let image_url = "https://www.rust-lang.org/logos/rust-logo-512x512.png";
+    let image_bytes = reqwest::get(image_url).await?.bytes().await?;
+    let media = MediaFile::from_bytes(&image_bytes, "image/png");
+
+    let client = OpenAIClient::from_env()?
+        .model(OpenAIModel::Gpt52)
+        .temperature(0.0);
+
+    let analysis: ImageAnalysis = client
+        .materialize_with_media("Describe this image and list dominant colors.", &[media])
+        .await?;
+
+    println!("{:#?}", analysis);
+    Ok(())
+}

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -7,10 +7,11 @@ use std::time::Duration;
 use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::backend::{
-    ChatMessage, GenerateResult, LLMClient, MaterializeInternalOutput, MaterializeResult,
-    ModelInfo, ThinkingLevel, TokenUsage, ValidationFailureContext, check_response_status,
-    generate_with_retry_with_history, generate_with_retry_with_initial_messages, handle_http_error,
-    parse_validate_and_create_output, prepare_strict_schema,
+    AnthropicMessageContent, ChatMessage, GenerateResult, LLMClient, MaterializeInternalOutput,
+    MaterializeResult, ModelInfo, ThinkingLevel, TokenUsage, ValidationFailureContext,
+    build_anthropic_message_content, check_response_status, generate_with_retry_with_history,
+    generate_with_retry_with_initial_messages, handle_http_error, parse_validate_and_create_output,
+    prepare_strict_schema,
 };
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
@@ -106,37 +107,6 @@ impl AnthropicModel {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::backend::MediaFile;
-
-    #[test]
-    fn test_anthropic_message_content_text_only_serializes_as_string() {
-        let msg = ChatMessage::user("hello");
-        let content = AnthropicClient::build_message_content(&msg).expect("content should build");
-        let json = serde_json::to_value(&content).expect("content should serialize");
-        assert_eq!(json, serde_json::json!("hello"));
-    }
-
-    #[test]
-    fn test_anthropic_message_content_with_inline_media_serializes_blocks() {
-        let msg = ChatMessage::user_with_media(
-            "describe image",
-            vec![MediaFile::from_bytes(b"abc", "image/png")],
-        );
-        let content = AnthropicClient::build_message_content(&msg).expect("content should build");
-        let json = serde_json::to_value(&content).expect("content should serialize");
-
-        assert_eq!(json[0]["type"], "text");
-        assert_eq!(json[0]["text"], "describe image");
-        assert_eq!(json[1]["type"], "image");
-        assert_eq!(json[1]["source"]["type"], "base64");
-        assert_eq!(json[1]["source"]["media_type"], "image/png");
-        assert_eq!(json[1]["source"]["data"], "YWJj");
-    }
-}
-
 impl FromStr for AnthropicModel {
     type Err = std::convert::Infallible;
 
@@ -185,27 +155,6 @@ pub struct AnthropicClient {
 struct AnthropicMessage {
     role: String,
     content: AnthropicMessageContent,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(untagged)]
-enum AnthropicMessageContent {
-    Text(String),
-    Blocks(Vec<AnthropicContentBlock>),
-}
-
-#[derive(Debug, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-enum AnthropicContentBlock {
-    Text { text: String },
-    Image { source: AnthropicImageSource },
-}
-
-#[derive(Debug, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-enum AnthropicImageSource {
-    Base64 { media_type: String, data: String },
-    Url { url: String },
 }
 
 /// Output format for structured outputs (native Anthropic structured outputs)
@@ -348,53 +297,6 @@ impl AnthropicClient {
 }
 
 impl AnthropicClient {
-    fn build_message_content(msg: &ChatMessage) -> Result<AnthropicMessageContent> {
-        if msg.media.is_empty() {
-            return Ok(AnthropicMessageContent::Text(msg.content.clone()));
-        }
-
-        let mut blocks = Vec::new();
-        if !msg.content.is_empty() {
-            blocks.push(AnthropicContentBlock::Text {
-                text: msg.content.clone(),
-            });
-        }
-
-        for media in &msg.media {
-            if let Some(data) = media.data.as_ref() {
-                if media.mime_type.is_empty() {
-                    return Err(RStructorError::api_error(
-                        "Anthropic",
-                        ApiErrorKind::BadRequest {
-                            details: "MediaFile mime_type cannot be empty".to_string(),
-                        },
-                    ));
-                }
-                blocks.push(AnthropicContentBlock::Image {
-                    source: AnthropicImageSource::Base64 {
-                        media_type: media.mime_type.clone(),
-                        data: data.clone(),
-                    },
-                });
-            } else if !media.uri.is_empty() {
-                blocks.push(AnthropicContentBlock::Image {
-                    source: AnthropicImageSource::Url {
-                        url: media.uri.clone(),
-                    },
-                });
-            } else {
-                return Err(RStructorError::api_error(
-                    "Anthropic",
-                    ApiErrorKind::BadRequest {
-                        details: "MediaFile must include either inline data or uri".to_string(),
-                    },
-                ));
-            }
-        }
-
-        Ok(AnthropicMessageContent::Blocks(blocks))
-    }
-
     /// Internal implementation of materialize (without retry logic)
     /// Accepts conversation history for multi-turn interactions.
     /// Returns the data, raw response, and optional usage info.
@@ -430,7 +332,7 @@ impl AnthropicClient {
             .map(|msg| {
                 Ok(AnthropicMessage {
                     role: msg.role.as_str().to_string(),
-                    content: Self::build_message_content(msg)?,
+                    content: build_anthropic_message_content(msg)?,
                 })
             })
             .collect::<Result<Vec<_>>>()

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -10,7 +10,7 @@ use crate::backend::{
     AnthropicMessageContent, ChatMessage, GenerateResult, LLMClient, MaterializeInternalOutput,
     MaterializeResult, ModelInfo, ThinkingLevel, TokenUsage, ValidationFailureContext,
     build_anthropic_message_content, check_response_status, generate_with_retry_with_history,
-    generate_with_retry_with_initial_messages, handle_http_error, parse_validate_and_create_output,
+    handle_http_error, materialize_with_media_with_retry, parse_validate_and_create_output,
     prepare_strict_schema,
 };
 use crate::error::{ApiErrorKind, RStructorError, Result};
@@ -567,17 +567,16 @@ impl LLMClient for AnthropicClient {
     where
         T: Instructor + DeserializeOwned + Send + 'static,
     {
-        let initial_messages = vec![ChatMessage::user_with_media(prompt, media.to_vec())];
-        let output = generate_with_retry_with_initial_messages(
+        materialize_with_media_with_retry(
             |messages: Vec<ChatMessage>| {
                 let this = self;
                 async move { this.materialize_internal::<T>(&messages).await }
             },
-            initial_messages,
+            prompt,
+            media,
             self.config.max_retries,
         )
-        .await?;
-        Ok(output.data)
+        .await
     }
 
     #[instrument(

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -9,7 +9,8 @@ use tracing::{debug, error, info, instrument, trace, warn};
 use crate::backend::{
     ChatMessage, GenerateResult, LLMClient, MaterializeInternalOutput, MaterializeResult,
     ModelInfo, ThinkingLevel, TokenUsage, ValidationFailureContext, check_response_status,
-    generate_with_retry_with_history, handle_http_error, parse_validate_and_create_output,
+    generate_with_retry_with_history, generate_with_retry_with_initial_messages, handle_http_error,
+    parse_validate_and_create_output,
 };
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
@@ -50,12 +51,16 @@ pub enum Model {
     Gemini25Flash,
     /// Gemini 2.5 Flash Lite (smaller, faster variant)
     Gemini25FlashLite,
+    /// Gemini 2.5 Flash Image (image generation/analysis tuned variant)
+    Gemini25FlashImage,
     /// Gemini 2.0 Flash (stable 2.0 Flash model)
     Gemini20Flash,
     /// Gemini 2.0 Flash 001 (specific version of 2.0 Flash)
     Gemini20Flash001,
     /// Gemini 2.0 Flash Lite (smaller 2.0 Flash variant)
     Gemini20FlashLite,
+    /// Gemini 2.0 Flash Lite 001 (specific version of 2.0 Flash Lite)
+    Gemini20FlashLite001,
     /// Gemini Pro Latest (alias for latest Pro model)
     GeminiProLatest,
     /// Gemini Flash Latest (alias for latest Flash model)
@@ -74,9 +79,11 @@ impl Model {
             Model::Gemini25Pro => "gemini-2.5-pro",
             Model::Gemini25Flash => "gemini-2.5-flash",
             Model::Gemini25FlashLite => "gemini-2.5-flash-lite",
+            Model::Gemini25FlashImage => "gemini-2.5-flash-image",
             Model::Gemini20Flash => "gemini-2.0-flash",
             Model::Gemini20Flash001 => "gemini-2.0-flash-001",
             Model::Gemini20FlashLite => "gemini-2.0-flash-lite",
+            Model::Gemini20FlashLite001 => "gemini-2.0-flash-lite-001",
             Model::GeminiProLatest => "gemini-pro-latest",
             Model::GeminiFlashLatest => "gemini-flash-latest",
             Model::GeminiFlashLiteLatest => "gemini-flash-lite-latest",
@@ -96,9 +103,11 @@ impl Model {
             "gemini-2.5-pro" => Model::Gemini25Pro,
             "gemini-2.5-flash" => Model::Gemini25Flash,
             "gemini-2.5-flash-lite" => Model::Gemini25FlashLite,
+            "gemini-2.5-flash-image" => Model::Gemini25FlashImage,
             "gemini-2.0-flash" => Model::Gemini20Flash,
             "gemini-2.0-flash-001" => Model::Gemini20Flash001,
             "gemini-2.0-flash-lite" => Model::Gemini20FlashLite,
+            "gemini-2.0-flash-lite-001" => Model::Gemini20FlashLite001,
             "gemini-pro-latest" => Model::GeminiProLatest,
             "gemini-flash-latest" => Model::GeminiFlashLatest,
             "gemini-flash-lite-latest" => Model::GeminiFlashLiteLatest,
@@ -652,13 +661,18 @@ impl LLMClient for GeminiClient {
     where
         T: Instructor + DeserializeOwned + Send + 'static,
     {
-        // For media support, we need to create a ChatMessage with media and pass it directly
-        // We can't use generate_with_retry_with_history since it only takes a string prompt
-        let initial_message = ChatMessage::user_with_media(prompt, media.to_vec());
-        let output = self
-            .materialize_internal::<T>(&[initial_message])
-            .await
-            .map_err(|(err, _)| err)?;
+        // Use the same retry/history path as text-only materialize, but seed it with
+        // an initial user message containing media so retries preserve context.
+        let initial_messages = vec![ChatMessage::user_with_media(prompt, media.to_vec())];
+        let output = generate_with_retry_with_initial_messages(
+            |messages: Vec<ChatMessage>| {
+                let this = self;
+                async move { this.materialize_internal::<T>(&messages).await }
+            },
+            initial_messages,
+            self.config.max_retries,
+        )
+        .await?;
         Ok(output.data)
     }
 

--- a/src/backend/grok.rs
+++ b/src/backend/grok.rs
@@ -9,7 +9,7 @@ use crate::backend::{
     ChatMessage, GenerateResult, LLMClient, MaterializeInternalOutput, MaterializeResult,
     ModelInfo, OpenAICompatibleMessageContent, ResponseFormat, TokenUsage,
     ValidationFailureContext, build_openai_compatible_message_content, check_response_status,
-    generate_with_retry_with_history, generate_with_retry_with_initial_messages, handle_http_error,
+    generate_with_retry_with_history, handle_http_error, materialize_with_media_with_retry,
     parse_validate_and_create_output, prepare_strict_schema,
 };
 use crate::error::{ApiErrorKind, RStructorError, Result};
@@ -488,17 +488,16 @@ impl LLMClient for GrokClient {
     where
         T: Instructor + DeserializeOwned + Send + 'static,
     {
-        let initial_messages = vec![ChatMessage::user_with_media(prompt, media.to_vec())];
-        let output = generate_with_retry_with_initial_messages(
+        materialize_with_media_with_retry(
             |messages: Vec<ChatMessage>| {
                 let this = self;
                 async move { this.materialize_internal::<T>(&messages).await }
             },
-            initial_messages,
+            prompt,
+            media,
             self.config.max_retries,
         )
-        .await?;
-        Ok(output.data)
+        .await
     }
 
     #[instrument(

--- a/src/backend/media.rs
+++ b/src/backend/media.rs
@@ -1,0 +1,214 @@
+use serde::Serialize;
+
+use crate::backend::ChatMessage;
+use crate::error::{ApiErrorKind, RStructorError, Result};
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub(crate) enum OpenAICompatibleMessageContent {
+    Text(String),
+    Parts(Vec<OpenAICompatibleMessagePart>),
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum OpenAICompatibleMessagePart {
+    Text { text: String },
+    ImageUrl { image_url: OpenAICompatibleImageUrl },
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct OpenAICompatibleImageUrl {
+    pub(crate) url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) detail: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub(crate) enum AnthropicMessageContent {
+    Text(String),
+    Blocks(Vec<AnthropicContentBlock>),
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum AnthropicContentBlock {
+    Text { text: String },
+    Image { source: AnthropicImageSource },
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum AnthropicImageSource {
+    Base64 { media_type: String, data: String },
+    Url { url: String },
+}
+
+pub(crate) fn build_openai_compatible_message_content(
+    msg: &ChatMessage,
+    provider_name: &str,
+) -> Result<OpenAICompatibleMessageContent> {
+    if msg.media.is_empty() {
+        return Ok(OpenAICompatibleMessageContent::Text(msg.content.clone()));
+    }
+
+    let mut parts = Vec::new();
+    if !msg.content.is_empty() {
+        parts.push(OpenAICompatibleMessagePart::Text {
+            text: msg.content.clone(),
+        });
+    }
+
+    for media in &msg.media {
+        let url = media_to_url(media, provider_name)?;
+        parts.push(OpenAICompatibleMessagePart::ImageUrl {
+            image_url: OpenAICompatibleImageUrl {
+                url,
+                detail: Some("auto".to_string()),
+            },
+        });
+    }
+
+    Ok(OpenAICompatibleMessageContent::Parts(parts))
+}
+
+pub(crate) fn build_anthropic_message_content(
+    msg: &ChatMessage,
+) -> Result<AnthropicMessageContent> {
+    if msg.media.is_empty() {
+        return Ok(AnthropicMessageContent::Text(msg.content.clone()));
+    }
+
+    let mut blocks = Vec::new();
+    if !msg.content.is_empty() {
+        blocks.push(AnthropicContentBlock::Text {
+            text: msg.content.clone(),
+        });
+    }
+
+    for media in &msg.media {
+        if let Some(data) = media.data.as_ref() {
+            if data.is_empty() {
+                return Err(RStructorError::api_error(
+                    "Anthropic",
+                    ApiErrorKind::BadRequest {
+                        details: "MediaFile inline data cannot be empty".to_string(),
+                    },
+                ));
+            }
+            if media.mime_type.is_empty() {
+                return Err(RStructorError::api_error(
+                    "Anthropic",
+                    ApiErrorKind::BadRequest {
+                        details: "MediaFile mime_type cannot be empty".to_string(),
+                    },
+                ));
+            }
+            blocks.push(AnthropicContentBlock::Image {
+                source: AnthropicImageSource::Base64 {
+                    media_type: media.mime_type.clone(),
+                    data: data.clone(),
+                },
+            });
+        } else if !media.uri.is_empty() {
+            blocks.push(AnthropicContentBlock::Image {
+                source: AnthropicImageSource::Url {
+                    url: media.uri.clone(),
+                },
+            });
+        } else {
+            return Err(RStructorError::api_error(
+                "Anthropic",
+                ApiErrorKind::BadRequest {
+                    details: "MediaFile must include either inline data or uri".to_string(),
+                },
+            ));
+        }
+    }
+
+    Ok(AnthropicMessageContent::Blocks(blocks))
+}
+
+fn media_to_url(media: &crate::backend::client::MediaFile, provider_name: &str) -> Result<String> {
+    if let Some(data) = media.data.as_ref() {
+        if data.is_empty() {
+            return Err(RStructorError::api_error(
+                provider_name,
+                ApiErrorKind::BadRequest {
+                    details: "MediaFile inline data cannot be empty".to_string(),
+                },
+            ));
+        }
+        if media.mime_type.is_empty() {
+            return Err(RStructorError::api_error(
+                provider_name,
+                ApiErrorKind::BadRequest {
+                    details: "MediaFile mime_type cannot be empty".to_string(),
+                },
+            ));
+        }
+        Ok(format!("data:{};base64,{}", media.mime_type, data))
+    } else if !media.uri.is_empty() {
+        Ok(media.uri.clone())
+    } else {
+        Err(RStructorError::api_error(
+            provider_name,
+            ApiErrorKind::BadRequest {
+                details: "MediaFile must include either inline data or uri".to_string(),
+            },
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::MediaFile;
+
+    #[test]
+    fn test_openai_compatible_content_text_only() {
+        let msg = ChatMessage::user("hello");
+        let content =
+            build_openai_compatible_message_content(&msg, "OpenAI").expect("content should build");
+        let json = serde_json::to_value(&content).expect("content should serialize");
+        assert_eq!(json, serde_json::json!("hello"));
+    }
+
+    #[test]
+    fn test_openai_compatible_content_with_media() {
+        let msg = ChatMessage::user_with_media(
+            "describe image",
+            vec![MediaFile::from_bytes(b"abc", "image/png")],
+        );
+        let content =
+            build_openai_compatible_message_content(&msg, "OpenAI").expect("content should build");
+        let json = serde_json::to_value(&content).expect("content should serialize");
+        assert_eq!(json[0]["type"], "text");
+        assert_eq!(json[1]["type"], "image_url");
+        assert_eq!(json[1]["image_url"]["url"], "data:image/png;base64,YWJj");
+    }
+
+    #[test]
+    fn test_anthropic_content_text_only() {
+        let msg = ChatMessage::user("hello");
+        let content = build_anthropic_message_content(&msg).expect("content should build");
+        let json = serde_json::to_value(&content).expect("content should serialize");
+        assert_eq!(json, serde_json::json!("hello"));
+    }
+
+    #[test]
+    fn test_anthropic_content_with_inline_media() {
+        let msg = ChatMessage::user_with_media(
+            "describe image",
+            vec![MediaFile::from_bytes(b"abc", "image/png")],
+        );
+        let content = build_anthropic_message_content(&msg).expect("content should build");
+        let json = serde_json::to_value(&content).expect("content should serialize");
+        assert_eq!(json[0]["type"], "text");
+        assert_eq!(json[1]["type"], "image");
+        assert_eq!(json[1]["source"]["type"], "base64");
+        assert_eq!(json[1]["source"]["media_type"], "image/png");
+        assert_eq!(json[1]["source"]["data"], "YWJj");
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,6 +1,7 @@
 pub mod client;
 mod media;
 mod messages;
+mod openai_compatible;
 pub mod usage;
 mod utils;
 
@@ -48,6 +49,10 @@ pub struct ModelInfo {
 pub(crate) use media::{
     AnthropicMessageContent, OpenAICompatibleMessageContent, build_anthropic_message_content,
     build_openai_compatible_message_content,
+};
+pub(crate) use openai_compatible::{
+    OpenAICompatibleChatCompletionRequest, OpenAICompatibleChatCompletionResponse,
+    OpenAICompatibleChatMessage, convert_openai_compatible_chat_messages,
 };
 pub(crate) use utils::{
     ResponseFormat, check_response_status, generate_with_retry_with_history, handle_http_error,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -50,9 +50,8 @@ pub(crate) use media::{
     build_openai_compatible_message_content,
 };
 pub(crate) use utils::{
-    ResponseFormat, check_response_status, generate_with_retry_with_history,
-    generate_with_retry_with_initial_messages, handle_http_error, parse_validate_and_create_output,
-    prepare_strict_schema,
+    ResponseFormat, check_response_status, generate_with_retry_with_history, handle_http_error,
+    materialize_with_media_with_retry, parse_validate_and_create_output, prepare_strict_schema,
 };
 
 /// Thinking level configuration for models that support extended reasoning.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -45,7 +45,8 @@ pub struct ModelInfo {
     pub description: Option<String>,
 }
 pub(crate) use utils::{
-    ResponseFormat, check_response_status, generate_with_retry_with_history, handle_http_error,
+    ResponseFormat, check_response_status, generate_with_retry_with_history,
+    generate_with_retry_with_initial_messages, handle_http_error, media_to_url,
     parse_validate_and_create_output, prepare_strict_schema,
 };
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,4 +1,5 @@
 pub mod client;
+mod media;
 mod messages;
 pub mod usage;
 mod utils;
@@ -44,10 +45,14 @@ pub struct ModelInfo {
     /// Description of the model's capabilities
     pub description: Option<String>,
 }
+pub(crate) use media::{
+    AnthropicMessageContent, OpenAICompatibleMessageContent, build_anthropic_message_content,
+    build_openai_compatible_message_content,
+};
 pub(crate) use utils::{
     ResponseFormat, check_response_status, generate_with_retry_with_history,
-    generate_with_retry_with_initial_messages, handle_http_error, media_to_url,
-    parse_validate_and_create_output, prepare_strict_schema,
+    generate_with_retry_with_initial_messages, handle_http_error, parse_validate_and_create_output,
+    prepare_strict_schema,
 };
 
 /// Thinking level configuration for models that support extended reasoning.

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -1,16 +1,16 @@
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::time::Duration;
 use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::backend::{
     ChatMessage, GenerateResult, LLMClient, MaterializeInternalOutput, MaterializeResult,
-    ModelInfo, OpenAICompatibleMessageContent, ResponseFormat, ThinkingLevel, TokenUsage,
-    ValidationFailureContext, build_openai_compatible_message_content, check_response_status,
-    generate_with_retry_with_history, handle_http_error, materialize_with_media_with_retry,
-    parse_validate_and_create_output, prepare_strict_schema,
+    ModelInfo, OpenAICompatibleChatCompletionRequest, OpenAICompatibleChatCompletionResponse,
+    OpenAICompatibleChatMessage, OpenAICompatibleMessageContent, ResponseFormat, ThinkingLevel,
+    TokenUsage, ValidationFailureContext, check_response_status,
+    convert_openai_compatible_chat_messages, generate_with_retry_with_history, handle_http_error,
+    materialize_with_media_with_retry, parse_validate_and_create_output, prepare_strict_schema,
 };
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
@@ -201,59 +201,8 @@ pub struct OpenAIClient {
     client: reqwest::Client,
 }
 
-// OpenAI API request and response structures
-#[derive(Debug, Serialize)]
-struct OpenAIChatMessage {
-    role: String,
-    content: OpenAICompatibleMessageContent,
-}
-
-// ResponseFormat and JsonSchemaFormat are now imported from utils
-
-#[derive(Debug, Serialize)]
-struct ChatCompletionRequest {
-    model: String,
-    messages: Vec<OpenAIChatMessage>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    response_format: Option<ResponseFormat>,
-    temperature: f32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    max_tokens: Option<u32>,
-    /// Reasoning effort for GPT-5.x models
-    #[serde(skip_serializing_if = "Option::is_none")]
-    reasoning_effort: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)]
-struct ResponseMessage {
-    role: String,
-    content: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)]
-struct ChatCompletionChoice {
-    message: ResponseMessage,
-    finish_reason: String,
-}
-
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)]
-struct UsageInfo {
-    prompt_tokens: u64,
-    completion_tokens: u64,
-    #[serde(default)]
-    total_tokens: u64,
-}
-
-#[derive(Debug, Deserialize)]
-struct ChatCompletionResponse {
-    choices: Vec<ChatCompletionChoice>,
-    #[serde(default)]
-    usage: Option<UsageInfo>,
-    model: Option<String>,
-}
+// ResponseFormat and JsonSchemaFormat are imported from utils and shared
+// OpenAI-compatible chat completion request/response types are in openai_compatible.rs.
 
 impl OpenAIClient {
     /// Create a new OpenAI client with the provided API key.
@@ -477,23 +426,15 @@ impl OpenAIClient {
         };
 
         // Convert ChatMessage to OpenAI's format
-        let api_messages: Vec<OpenAIChatMessage> = messages
-            .iter()
-            .map(|msg| {
-                Ok(OpenAIChatMessage {
-                    role: msg.role.as_str().to_string(),
-                    content: build_openai_compatible_message_content(msg, "OpenAI")?,
-                })
-            })
-            .collect::<Result<Vec<_>>>()
-            .map_err(|e| (e, None))?;
+        let api_messages =
+            convert_openai_compatible_chat_messages(messages, "OpenAI").map_err(|e| (e, None))?;
 
         // Build the request with native structured outputs
         debug!(
             "Building OpenAI API request with structured outputs (history_len={})",
             api_messages.len()
         );
-        let request = ChatCompletionRequest {
+        let request = OpenAICompatibleChatCompletionRequest {
             model: self.config.model.as_str().to_string(),
             messages: api_messages,
             response_format: Some(response_format),
@@ -526,10 +467,11 @@ impl OpenAIClient {
             .map_err(|e| (e, None))?;
 
         debug!("Successfully received response from OpenAI");
-        let completion: ChatCompletionResponse = response.json().await.map_err(|e| {
-            error!(error = %e, "Failed to parse JSON response from OpenAI");
-            (RStructorError::from(e), None)
-        })?;
+        let completion: OpenAICompatibleChatCompletionResponse =
+            response.json().await.map_err(|e| {
+                error!(error = %e, "Failed to parse JSON response from OpenAI");
+                (RStructorError::from(e), None)
+            })?;
 
         if completion.choices.is_empty() {
             error!("OpenAI returned empty choices array");
@@ -707,9 +649,9 @@ impl LLMClient for OpenAIClient {
 
         // Build the request for text generation (no structured output)
         debug!("Building OpenAI API request for text generation");
-        let request = ChatCompletionRequest {
+        let request = OpenAICompatibleChatCompletionRequest {
             model: self.config.model.as_str().to_string(),
-            messages: vec![OpenAIChatMessage {
+            messages: vec![OpenAICompatibleChatMessage {
                 role: "user".to_string(),
                 content: OpenAICompatibleMessageContent::Text(prompt.to_string()),
             }],
@@ -741,10 +683,11 @@ impl LLMClient for OpenAIClient {
         let response = check_response_status(response, "OpenAI").await?;
 
         debug!("Successfully received response from OpenAI");
-        let completion: ChatCompletionResponse = response.json().await.map_err(|e| {
-            error!(error = %e, "Failed to parse JSON response from OpenAI");
-            e
-        })?;
+        let completion: OpenAICompatibleChatCompletionResponse =
+            response.json().await.map_err(|e| {
+                error!(error = %e, "Failed to parse JSON response from OpenAI");
+                e
+            })?;
 
         if completion.choices.is_empty() {
             error!("OpenAI returned empty choices array");

--- a/src/backend/openai_compatible.rs
+++ b/src/backend/openai_compatible.rs
@@ -1,0 +1,107 @@
+use serde::{Deserialize, Serialize};
+
+use crate::backend::{
+    ChatMessage, OpenAICompatibleMessageContent, ResponseFormat,
+    build_openai_compatible_message_content,
+};
+use crate::error::Result;
+
+#[derive(Debug, Serialize)]
+pub(crate) struct OpenAICompatibleChatMessage {
+    pub role: String,
+    pub content: OpenAICompatibleMessageContent,
+}
+
+pub(crate) fn convert_openai_compatible_chat_messages(
+    messages: &[ChatMessage],
+    provider_name: &str,
+) -> Result<Vec<OpenAICompatibleChatMessage>> {
+    messages
+        .iter()
+        .map(|msg| {
+            Ok(OpenAICompatibleChatMessage {
+                role: msg.role.as_str().to_string(),
+                content: build_openai_compatible_message_content(msg, provider_name)?,
+            })
+        })
+        .collect()
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct OpenAICompatibleChatCompletionRequest {
+    pub model: String,
+    pub messages: Vec<OpenAICompatibleChatMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<ResponseFormat>,
+    pub temperature: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    /// Reasoning effort for GPT-5.x models (OpenAI only).
+    /// Omitted for providers that don't support it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct OpenAICompatibleResponseMessage {
+    pub role: String,
+    pub content: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct OpenAICompatibleChatCompletionChoice {
+    pub message: OpenAICompatibleResponseMessage,
+    pub finish_reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct OpenAICompatibleUsageInfo {
+    pub prompt_tokens: u64,
+    pub completion_tokens: u64,
+    #[serde(default)]
+    pub total_tokens: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAICompatibleChatCompletionResponse {
+    pub choices: Vec<OpenAICompatibleChatCompletionChoice>,
+    #[serde(default)]
+    pub usage: Option<OpenAICompatibleUsageInfo>,
+    pub model: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::MediaFile;
+
+    #[test]
+    fn test_convert_openai_compatible_chat_messages_text_only() {
+        let messages = vec![ChatMessage::user("hello")];
+        let converted = convert_openai_compatible_chat_messages(&messages, "OpenAI")
+            .expect("conversion should succeed");
+
+        assert_eq!(converted.len(), 1);
+        assert_eq!(converted[0].role, "user");
+        let json = serde_json::to_value(&converted[0]).expect("serialization should succeed");
+        assert_eq!(json["content"], serde_json::json!("hello"));
+    }
+
+    #[test]
+    fn test_convert_openai_compatible_chat_messages_with_media() {
+        let messages = vec![ChatMessage::user_with_media(
+            "describe image",
+            vec![MediaFile::from_bytes(b"abc", "image/png")],
+        )];
+        let converted = convert_openai_compatible_chat_messages(&messages, "OpenAI")
+            .expect("conversion should succeed");
+
+        assert_eq!(converted.len(), 1);
+        let json = serde_json::to_value(&converted[0]).expect("serialization should succeed");
+        assert_eq!(json["content"][0]["type"], "text");
+        assert_eq!(json["content"][1]["type"], "image_url");
+    }
+}

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -11,47 +11,6 @@ use std::time::Duration;
 use tokio::time::sleep;
 use tracing::{debug, error, info, trace, warn};
 
-/// Convert a `MediaFile` into a provider-ready URL string.
-///
-/// - If inline base64 data is present, this returns a RFC 2397 data URL:
-///   `data:{mime_type};base64,{data}`.
-/// - Otherwise, it returns the media URI.
-///
-/// Returns a `BadRequest` error if both data and URI are missing.
-pub(crate) fn media_to_url(
-    media: &crate::backend::client::MediaFile,
-    provider_name: &str,
-) -> Result<String> {
-    if let Some(data) = media.data.as_ref() {
-        if data.is_empty() {
-            return Err(RStructorError::api_error(
-                provider_name,
-                ApiErrorKind::BadRequest {
-                    details: "MediaFile inline data cannot be empty".to_string(),
-                },
-            ));
-        }
-        if media.mime_type.is_empty() {
-            return Err(RStructorError::api_error(
-                provider_name,
-                ApiErrorKind::BadRequest {
-                    details: "MediaFile mime_type cannot be empty".to_string(),
-                },
-            ));
-        }
-        Ok(format!("data:{};base64,{}", media.mime_type, data))
-    } else if !media.uri.is_empty() {
-        Ok(media.uri.clone())
-    } else {
-        Err(RStructorError::api_error(
-            provider_name,
-            ApiErrorKind::BadRequest {
-                details: "MediaFile must include either inline data or uri".to_string(),
-            },
-        ))
-    }
-}
-
 /// Prepare a JSON schema for strict mode by recursively adding required fields
 /// to all object types in the schema.
 ///
@@ -2041,24 +2000,6 @@ mod tests {
             schema["properties"]["name"].get("x-enum-keys").is_none(),
             "x-enum-keys should be stripped from non-map schemas"
         );
-    }
-
-    #[test]
-    fn test_media_to_url_inline_data() {
-        let media = crate::backend::client::MediaFile::from_bytes(b"abc", "image/png");
-        let url = media_to_url(&media, "TestProvider").expect("media_to_url should succeed");
-        assert_eq!(url, "data:image/png;base64,YWJj");
-    }
-
-    #[test]
-    fn test_media_to_url_requires_data_or_uri() {
-        let media = crate::backend::client::MediaFile::new("", "image/png");
-        let err = media_to_url(&media, "TestProvider")
-            .expect_err("media_to_url should fail for empty uri and no data");
-        assert!(matches!(
-            err.api_error_kind(),
-            Some(ApiErrorKind::BadRequest { .. })
-        ));
     }
 
     #[tokio::test]

--- a/tests/anthropic_multimodal_tests.rs
+++ b/tests/anthropic_multimodal_tests.rs
@@ -1,0 +1,98 @@
+//! Integration tests for Anthropic multimodal structured extraction.
+//!
+//! Requires:
+//! - `ANTHROPIC_API_KEY`
+//! - `--features anthropic`
+
+#[path = "common/mod.rs"]
+mod common;
+
+#[cfg(test)]
+mod anthropic_multimodal_tests {
+    #[cfg(feature = "anthropic")]
+    use rstructor::AnthropicClient;
+    use rstructor::{AnthropicModel, Instructor, LLMClient};
+    use serde::{Deserialize, Serialize};
+
+    use crate::common::{RUST_LOGO_MIME, RUST_LOGO_URL, download_media, media_url};
+
+    #[derive(Instructor, Serialize, Deserialize, Debug)]
+    struct ImageSummary {
+        subject: String,
+        summary: String,
+    }
+
+    #[derive(Instructor, Serialize, Deserialize, Debug)]
+    struct MultiImageSummary {
+        image_count: u8,
+        summary: String,
+    }
+
+    #[cfg(feature = "anthropic")]
+    #[tokio::test]
+    async fn test_anthropic_multimodal_inline_image() {
+        let media = download_media(RUST_LOGO_URL, RUST_LOGO_MIME).await;
+        let client = AnthropicClient::from_env()
+            .expect("ANTHROPIC_API_KEY must be set for this test")
+            .model(AnthropicModel::ClaudeOpus46)
+            .temperature(0.0);
+
+        let result: ImageSummary = client
+            .materialize_with_media(
+                "Identify the main subject in this image and summarize it briefly.",
+                &[media],
+            )
+            .await
+            .expect("Anthropic multimodal inline request failed");
+
+        assert!(!result.subject.is_empty(), "subject should not be empty");
+        assert!(!result.summary.is_empty(), "summary should not be empty");
+    }
+
+    #[cfg(feature = "anthropic")]
+    #[tokio::test]
+    async fn test_anthropic_multimodal_url_image() {
+        let media = media_url(RUST_LOGO_URL, RUST_LOGO_MIME);
+        let client = AnthropicClient::from_env()
+            .expect("ANTHROPIC_API_KEY must be set for this test")
+            .model(AnthropicModel::ClaudeOpus46)
+            .temperature(0.0);
+
+        let result: ImageSummary = client
+            .materialize_with_media(
+                "Describe this image in one concise sentence, focusing on scene type.",
+                &[media],
+            )
+            .await
+            .expect("Anthropic multimodal URL request failed");
+
+        assert!(!result.subject.is_empty(), "subject should not be empty");
+        assert!(!result.summary.is_empty(), "summary should not be empty");
+    }
+
+    #[cfg(feature = "anthropic")]
+    #[tokio::test]
+    async fn test_anthropic_multimodal_multiple_images() {
+        let rust_media = download_media(RUST_LOGO_URL, RUST_LOGO_MIME).await;
+        let lake_media = media_url(RUST_LOGO_URL, RUST_LOGO_MIME);
+        let client = AnthropicClient::from_env()
+            .expect("ANTHROPIC_API_KEY must be set for this test")
+            .model(AnthropicModel::ClaudeOpus46)
+            .temperature(0.0);
+
+        let result: MultiImageSummary = client
+            .materialize_with_media(
+                "You are given two images. Return the exact count in image_count and summarize both images.",
+                &[rust_media, lake_media],
+            )
+            .await
+            .expect("Anthropic multimodal multi-image request failed");
+
+        assert!(
+            result.image_count >= 2,
+            "expected at least 2 images, got {}",
+            result.image_count
+        );
+        assert!(!result.summary.is_empty(), "summary should not be empty");
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,24 @@
+use rstructor::MediaFile;
+
+pub const RUST_LOGO_URL: &str = "https://www.rust-lang.org/logos/rust-logo-512x512.png";
+pub const RUST_LOGO_MIME: &str = "image/png";
+
+#[allow(dead_code)]
+pub const RUST_SOCIAL_URL: &str = "https://www.rust-lang.org/static/images/rust-social-wide.jpg";
+#[allow(dead_code)]
+pub const RUST_SOCIAL_MIME: &str = "image/jpeg";
+
+pub async fn download_media(url: &str, mime: &str) -> MediaFile {
+    let bytes = reqwest::get(url)
+        .await
+        .expect("Failed to download media fixture")
+        .bytes()
+        .await
+        .expect("Failed to read media fixture bytes");
+    MediaFile::from_bytes(&bytes, mime)
+}
+
+#[allow(dead_code)]
+pub fn media_url(url: &str, mime: &str) -> MediaFile {
+    MediaFile::new(url, mime)
+}

--- a/tests/grok_multimodal_tests.rs
+++ b/tests/grok_multimodal_tests.rs
@@ -1,0 +1,98 @@
+//! Integration tests for Grok multimodal structured extraction.
+//!
+//! Requires:
+//! - `XAI_API_KEY`
+//! - `--features grok`
+
+#[path = "common/mod.rs"]
+mod common;
+
+#[cfg(test)]
+mod grok_multimodal_tests {
+    #[cfg(feature = "grok")]
+    use rstructor::GrokClient;
+    use rstructor::{GrokModel, Instructor, LLMClient};
+    use serde::{Deserialize, Serialize};
+
+    use crate::common::{RUST_LOGO_MIME, RUST_LOGO_URL, download_media, media_url};
+
+    #[derive(Instructor, Serialize, Deserialize, Debug)]
+    struct ImageSummary {
+        subject: String,
+        summary: String,
+    }
+
+    #[derive(Instructor, Serialize, Deserialize, Debug)]
+    struct MultiImageSummary {
+        image_count: u8,
+        summary: String,
+    }
+
+    #[cfg(feature = "grok")]
+    #[tokio::test]
+    async fn test_grok_multimodal_inline_image() {
+        let media = download_media(RUST_LOGO_URL, RUST_LOGO_MIME).await;
+        let client = GrokClient::from_env()
+            .expect("XAI_API_KEY must be set for this test")
+            .model(GrokModel::Grok41FastNonReasoning)
+            .temperature(0.0);
+
+        let result: ImageSummary = client
+            .materialize_with_media(
+                "Identify the main subject in this image and summarize it briefly.",
+                &[media],
+            )
+            .await
+            .expect("Grok multimodal inline request failed");
+
+        assert!(!result.subject.is_empty(), "subject should not be empty");
+        assert!(!result.summary.is_empty(), "summary should not be empty");
+    }
+
+    #[cfg(feature = "grok")]
+    #[tokio::test]
+    async fn test_grok_multimodal_url_image() {
+        let media = media_url(RUST_LOGO_URL, RUST_LOGO_MIME);
+        let client = GrokClient::from_env()
+            .expect("XAI_API_KEY must be set for this test")
+            .model(GrokModel::Grok41FastNonReasoning)
+            .temperature(0.0);
+
+        let result: ImageSummary = client
+            .materialize_with_media(
+                "Describe this image in one concise sentence, focusing on scene type.",
+                &[media],
+            )
+            .await
+            .expect("Grok multimodal URL request failed");
+
+        assert!(!result.subject.is_empty(), "subject should not be empty");
+        assert!(!result.summary.is_empty(), "summary should not be empty");
+    }
+
+    #[cfg(feature = "grok")]
+    #[tokio::test]
+    async fn test_grok_multimodal_multiple_images() {
+        let rust_media = download_media(RUST_LOGO_URL, RUST_LOGO_MIME).await;
+        let lake_media = media_url(RUST_LOGO_URL, RUST_LOGO_MIME);
+        let client = GrokClient::from_env()
+            .expect("XAI_API_KEY must be set for this test")
+            .model(GrokModel::Grok41FastNonReasoning)
+            .temperature(0.0);
+
+        let result: MultiImageSummary = client
+            .materialize_with_media(
+                "You are given two images. Return the exact count in image_count and summarize both images.",
+                &[rust_media, lake_media],
+            )
+            .await
+            .expect("Grok multimodal multi-image request failed");
+
+        assert!(
+            result.image_count >= 2,
+            "expected at least 2 images, got {}",
+            result.image_count
+        );
+        assert!(!result.summary.is_empty(), "summary should not be empty");
+    }
+}

--- a/tests/model_string_test.rs
+++ b/tests/model_string_test.rs
@@ -20,6 +20,12 @@ mod tests {
         let model = OpenAIModel::from_str("gpt-4o-mini").unwrap();
         assert_eq!(model, OpenAIModel::Gpt4OMini);
 
+        let model = OpenAIModel::from_str("gpt-5.2-chat-latest").unwrap();
+        assert_eq!(model, OpenAIModel::Gpt52ChatLatest);
+
+        let model = OpenAIModel::from_str("gpt-5.2-codex").unwrap();
+        assert_eq!(model, OpenAIModel::Gpt52Codex);
+
         // Test From<&str>
         let model: OpenAIModel = "gpt-3.5-turbo".into();
         assert_eq!(model, OpenAIModel::Gpt35Turbo);
@@ -94,6 +100,9 @@ mod tests {
         // Test known model
         let model = GeminiModel::from_string("gemini-2.5-flash");
         assert_eq!(model, GeminiModel::Gemini25Flash);
+
+        let model = GeminiModel::from_string("gemini-2.5-flash-image");
+        assert_eq!(model, GeminiModel::Gemini25FlashImage);
 
         // Test custom model
         let model = GeminiModel::from_string("gemini-custom");

--- a/tests/openai_multimodal_tests.rs
+++ b/tests/openai_multimodal_tests.rs
@@ -1,0 +1,98 @@
+//! Integration tests for OpenAI multimodal structured extraction.
+//!
+//! Requires:
+//! - `OPENAI_API_KEY`
+//! - `--features openai`
+
+#[path = "common/mod.rs"]
+mod common;
+
+#[cfg(test)]
+mod openai_multimodal_tests {
+    #[cfg(feature = "openai")]
+    use rstructor::OpenAIClient;
+    use rstructor::{Instructor, LLMClient, OpenAIModel};
+    use serde::{Deserialize, Serialize};
+
+    use crate::common::{RUST_LOGO_MIME, RUST_LOGO_URL, download_media, media_url};
+
+    #[derive(Instructor, Serialize, Deserialize, Debug)]
+    struct ImageSummary {
+        subject: String,
+        summary: String,
+    }
+
+    #[derive(Instructor, Serialize, Deserialize, Debug)]
+    struct MultiImageSummary {
+        image_count: u8,
+        summary: String,
+    }
+
+    #[cfg(feature = "openai")]
+    #[tokio::test]
+    async fn test_openai_multimodal_inline_image() {
+        let media = download_media(RUST_LOGO_URL, RUST_LOGO_MIME).await;
+        let client = OpenAIClient::from_env()
+            .expect("OPENAI_API_KEY must be set for this test")
+            .model(OpenAIModel::Gpt52)
+            .temperature(0.0);
+
+        let result: ImageSummary = client
+            .materialize_with_media(
+                "Identify the main subject in this image and summarize it briefly.",
+                &[media],
+            )
+            .await
+            .expect("OpenAI multimodal inline request failed");
+
+        assert!(!result.subject.is_empty(), "subject should not be empty");
+        assert!(!result.summary.is_empty(), "summary should not be empty");
+    }
+
+    #[cfg(feature = "openai")]
+    #[tokio::test]
+    async fn test_openai_multimodal_url_image() {
+        let media = media_url(RUST_LOGO_URL, RUST_LOGO_MIME);
+        let client = OpenAIClient::from_env()
+            .expect("OPENAI_API_KEY must be set for this test")
+            .model(OpenAIModel::Gpt52)
+            .temperature(0.0);
+
+        let result: ImageSummary = client
+            .materialize_with_media(
+                "Describe this image in one concise sentence, focusing on scene type.",
+                &[media],
+            )
+            .await
+            .expect("OpenAI multimodal URL request failed");
+
+        assert!(!result.subject.is_empty(), "subject should not be empty");
+        assert!(!result.summary.is_empty(), "summary should not be empty");
+    }
+
+    #[cfg(feature = "openai")]
+    #[tokio::test]
+    async fn test_openai_multimodal_multiple_images() {
+        let rust_media = download_media(RUST_LOGO_URL, RUST_LOGO_MIME).await;
+        let lake_media = media_url(RUST_LOGO_URL, RUST_LOGO_MIME);
+        let client = OpenAIClient::from_env()
+            .expect("OPENAI_API_KEY must be set for this test")
+            .model(OpenAIModel::Gpt52)
+            .temperature(0.0);
+
+        let result: MultiImageSummary = client
+            .materialize_with_media(
+                "You are given two images. Return the exact count in image_count and summarize both images.",
+                &[rust_media, lake_media],
+            )
+            .await
+            .expect("OpenAI multimodal multi-image request failed");
+
+        assert!(
+            result.image_count >= 2,
+            "expected at least 2 images, got {}",
+            result.image_count
+        );
+        assert!(!result.summary.is_empty(), "summary should not be empty");
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds first-class multimodal structured extraction support for all major providers in `rstructor` (OpenAI, Anthropic, Grok), and fixes Gemini media-path retry parity.

## Problem
Before this change, `materialize_with_media` only worked in the Gemini backend. For OpenAI, Anthropic, and Grok, media inputs were accepted by the public API but effectively ignored because provider request serialization only emitted text content.

Additionally, Gemini's media path bypassed the existing retry-with-conversation-history flow used by text materialization, which reduced recovery reliability after validation failures.

## User Impact
- Users can now call `materialize_with_media(...)` consistently across OpenAI, Anthropic, Grok, and Gemini.
- Structured multimodal extraction now works with inline bytes and URI/URL media forms (provider-specific mappings).
- Retry behavior is now consistent for Gemini media calls as well, improving robustness for schema-constrained outputs.

## Root Cause
- Provider request models for OpenAI/Grok/Anthropic were implemented as `content: String` only.
- Shared retry utility only accepted prompt text and always built initial messages as `ChatMessage::user(prompt)`.

## Fix
1. Added a new shared retry utility entry point that accepts initial message history:
   - `generate_with_retry_with_initial_messages(...)`
   - Existing `generate_with_retry_with_history(...)` now delegates to it.
2. Implemented provider-native multimodal content serialization:
   - OpenAI/Grok: mixed `content` parts with `type: text` and `type: image_url`.
   - Anthropic: `content` blocks with `type: text` and `type: image` + `source` (`base64` or `url`).
3. Updated each provider backend to override `materialize_with_media(...)` and invoke retry with initial media-bearing messages.
4. Updated Gemini `materialize_with_media(...)` to use retry/history path (parity fix).
5. Added shared `media_to_url(...)` helper for normalized data-URL/URI handling in compatible providers.
6. Updated model enums to include latest discovered IDs used in current docs/API lists:
   - OpenAI: `gpt-5.2-chat-latest`, `gpt-5.2-codex`
   - Gemini: `gemini-2.5-flash-image`, `gemini-2.0-flash-lite-001`
7. Expanded docs/examples for multimodal usage across providers.

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --no-run`
- `cargo test --all-features --test openai_multimodal_tests -- --nocapture`
- `cargo test --all-features --test anthropic_multimodal_tests -- --nocapture`
- `cargo test --all-features --test grok_multimodal_tests -- --nocapture`
- `cargo test --all-features --test gemini_multimodal_tests -- --nocapture`
- `cargo test --all-features --test model_string_test`
- `cargo test --all-features test_generate_with_retry_with_initial_messages -- --nocapture`

All checks passed locally.
