### PR TITLE
Fix for 6 bugs around enums and data/UUID format handling

### DIFF
--- a/rstructor_derive/Cargo.toml
+++ b/rstructor_derive/Cargo.toml
@@ -32,3 +32,5 @@ serde_json = "1.0"
 rstructor = { path = ".." }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1.0", features = ["serde"] }

--- a/rstructor_derive/src/generators/enum_schema.rs
+++ b/rstructor_derive/src/generators/enum_schema.rs
@@ -20,8 +20,9 @@ pub fn generate_enum_schema(
 ) -> TokenStream {
     // Check if it's a simple enum (no data)
     let all_simple = data_enum.variants.iter().all(|v| v.fields.is_empty());
+    let has_tag = container_attrs.serde_tag.is_some();
 
-    if all_simple {
+    if all_simple && !has_tag {
         // Generate implementation for simple enum as before
         generate_simple_enum_schema(name, data_enum, container_attrs)
     } else {
@@ -713,32 +714,83 @@ fn generate_internally_tagged_enum_schema(
                     }
                 });
             }
-            Fields::Unnamed(_) => {
-                // Internal tagging doesn't support tuple variants in serde
-                // Fall back to treating it as a unit variant with the tag only
+            Fields::Unnamed(fields) => {
                 let variant_name_str = variant_name.clone();
                 let description_str = description.clone();
                 let tag_name_str = tag_name.to_string();
-                variant_schemas.push(quote! {
-                    {
-                        let mut schema_obj = ::serde_json::Map::new();
-                        schema_obj.insert("type".to_string(), ::serde_json::Value::String("object".to_string()));
 
-                        let mut properties = ::serde_json::Map::new();
-                        properties.insert(#tag_name_str.to_string(), ::serde_json::json!({
-                            "type": "string",
-                            "enum": [#variant_name_str]
-                        }));
-                        schema_obj.insert("properties".to_string(), ::serde_json::Value::Object(properties));
+                if fields.unnamed.len() == 1 {
+                    // Newtype variant (e.g. Present(InnerStruct)):
+                    // serde flattens the inner struct's fields alongside the tag.
+                    let field = fields.unnamed.first().unwrap();
+                    let inner_ty = &field.ty;
 
-                        let required = vec![::serde_json::Value::String(#tag_name_str.to_string())];
-                        schema_obj.insert("required".to_string(), ::serde_json::Value::Array(required));
-                        schema_obj.insert("description".to_string(), ::serde_json::Value::String(#description_str.to_string()));
-                        schema_obj.insert("additionalProperties".to_string(), ::serde_json::Value::Bool(false));
+                    // Unwrap Box<T> if present — Box<T> doesn't implement SchemaType
+                    let schema_ty = if is_box_type(inner_ty) {
+                        get_box_inner_type(inner_ty).unwrap_or(inner_ty)
+                    } else {
+                        inner_ty
+                    };
 
-                        ::serde_json::Value::Object(schema_obj)
-                    }
-                });
+                    variant_schemas.push(quote! {
+                        {
+                            let inner_schema = <#schema_ty as ::rstructor::schema::SchemaType>::schema().to_json();
+
+                            let mut properties = ::serde_json::Map::new();
+                            properties.insert(#tag_name_str.to_string(), ::serde_json::json!({
+                                "type": "string",
+                                "enum": [#variant_name_str]
+                            }));
+
+                            let mut required = vec![::serde_json::Value::String(#tag_name_str.to_string())];
+
+                            if let Some(inner_obj) = inner_schema.as_object() {
+                                if let Some(::serde_json::Value::Object(inner_props)) = inner_obj.get("properties") {
+                                    for (k, v) in inner_props {
+                                        properties.insert(k.clone(), v.clone());
+                                    }
+                                }
+                                if let Some(::serde_json::Value::Array(inner_req)) = inner_obj.get("required") {
+                                    for r in inner_req {
+                                        required.push(r.clone());
+                                    }
+                                }
+                            }
+
+                            let mut schema_obj = ::serde_json::Map::new();
+                            schema_obj.insert("type".to_string(), ::serde_json::Value::String("object".to_string()));
+                            schema_obj.insert("properties".to_string(), ::serde_json::Value::Object(properties));
+                            schema_obj.insert("required".to_string(), ::serde_json::Value::Array(required));
+                            schema_obj.insert("description".to_string(), ::serde_json::Value::String(#description_str.to_string()));
+                            schema_obj.insert("additionalProperties".to_string(), ::serde_json::Value::Bool(false));
+
+                            ::serde_json::Value::Object(schema_obj)
+                        }
+                    });
+                } else {
+                    // True tuple variants: serde doesn't support these with internal tagging.
+                    // Fall back to treating as a unit variant with the tag only.
+                    variant_schemas.push(quote! {
+                        {
+                            let mut schema_obj = ::serde_json::Map::new();
+                            schema_obj.insert("type".to_string(), ::serde_json::Value::String("object".to_string()));
+
+                            let mut properties = ::serde_json::Map::new();
+                            properties.insert(#tag_name_str.to_string(), ::serde_json::json!({
+                                "type": "string",
+                                "enum": [#variant_name_str]
+                            }));
+                            schema_obj.insert("properties".to_string(), ::serde_json::Value::Object(properties));
+
+                            let required = vec![::serde_json::Value::String(#tag_name_str.to_string())];
+                            schema_obj.insert("required".to_string(), ::serde_json::Value::Array(required));
+                            schema_obj.insert("description".to_string(), ::serde_json::Value::String(#description_str.to_string()));
+                            schema_obj.insert("additionalProperties".to_string(), ::serde_json::Value::Bool(false));
+
+                            ::serde_json::Value::Object(schema_obj)
+                        }
+                    });
+                }
             }
         }
     }

--- a/rstructor_derive/src/generators/enum_schema.rs
+++ b/rstructor_derive/src/generators/enum_schema.rs
@@ -482,6 +482,60 @@ fn generate_field_schema(field_type: &Type, description: &Option<String>) -> Tok
         return generate_field_schema(inner_ty, description);
     }
 
+    // Extract type name for well-known library types
+    let type_name = if let Type::Path(type_path) = actual_type {
+        type_path.path.segments.first().map(|s| s.ident.to_string())
+    } else {
+        None
+    };
+
+    // Handle date/time types
+    let is_datetime_type = matches!(
+        type_name.as_deref(),
+        Some("DateTime") | Some("NaiveDateTime")
+    );
+    let is_date_only_type = matches!(type_name.as_deref(), Some("NaiveDate") | Some("Date"));
+    let is_uuid_type = matches!(type_name.as_deref(), Some("Uuid"));
+
+    if is_datetime_type {
+        let date_desc = description
+            .clone()
+            .unwrap_or_else(|| "ISO-8601 formatted date and time".to_string());
+        return quote! {
+            ::serde_json::json!({
+                "type": "string",
+                "format": "date-time",
+                "description": #date_desc
+            })
+        };
+    }
+
+    if is_date_only_type {
+        let date_desc = description
+            .clone()
+            .unwrap_or_else(|| "ISO-8601 formatted date (YYYY-MM-DD)".to_string());
+        return quote! {
+            ::serde_json::json!({
+                "type": "string",
+                "format": "date",
+                "description": #date_desc
+            })
+        };
+    }
+
+    if is_uuid_type {
+        let uuid_desc = description
+            .clone()
+            .unwrap_or_else(|| "UUID identifier string".to_string());
+        return quote! {
+            ::serde_json::json!({
+                "type": "string",
+                "format": "uuid",
+                "description": #uuid_desc
+            })
+        };
+    }
+
     // Handle tuples
     if is_tuple_type(actual_type)
         && let Some(element_types) = get_tuple_element_types(actual_type)
@@ -522,6 +576,60 @@ fn generate_field_schema(field_type: &Type, description: &Option<String>) -> Tok
     if is_array_type(actual_type) {
         if let Some(inner_type) = get_array_inner_type(actual_type) {
             let inner_schema_type = get_schema_type_from_rust_type(inner_type);
+
+            // Extract inner type name for well-known library types
+            let inner_type_name = if let Type::Path(type_path) = inner_type {
+                type_path.path.segments.first().map(|s| s.ident.to_string())
+            } else {
+                None
+            };
+
+            let is_inner_datetime = matches!(
+                inner_type_name.as_deref(),
+                Some("DateTime") | Some("NaiveDateTime")
+            );
+            let is_inner_date_only =
+                matches!(inner_type_name.as_deref(), Some("NaiveDate") | Some("Date"));
+            let is_inner_uuid = matches!(inner_type_name.as_deref(), Some("Uuid"));
+
+            if is_inner_datetime {
+                return quote! {
+                    ::serde_json::json!({
+                        "type": "array",
+                        #desc_prop
+                        "items": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    })
+                };
+            }
+
+            if is_inner_date_only {
+                return quote! {
+                    ::serde_json::json!({
+                        "type": "array",
+                        #desc_prop
+                        "items": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    })
+                };
+            }
+
+            if is_inner_uuid {
+                return quote! {
+                    ::serde_json::json!({
+                        "type": "array",
+                        #desc_prop
+                        "items": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    })
+                };
+            }
 
             if inner_schema_type == "object" {
                 // For arrays of complex types

--- a/rstructor_derive/src/generators/struct_schema.rs
+++ b/rstructor_derive/src/generators/struct_schema.rs
@@ -61,25 +61,54 @@ pub fn generate_struct_schema(
                     None
                 };
 
+                // Also extract the inner type name when the field is Optional,
+                // so Option<NaiveDate>, Option<DateTime>, Option<Uuid> etc. get proper format metadata
+                let inner_type_name = if is_optional {
+                    if let Type::Path(type_path) = get_option_inner_type(&field.ty) {
+                        type_path.path.segments.first().map(|s| s.ident.to_string())
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+
                 // Check for well-known library types by exact match only (no contains checks)
-                let is_date_type = matches!(
+                let is_datetime_type = matches!(
                     type_name.as_deref(),
-                    Some("DateTime") | Some("NaiveDateTime") | Some("NaiveDate") | Some("Date")
+                    Some("DateTime") | Some("NaiveDateTime")
+                ) || matches!(
+                    inner_type_name.as_deref(),
+                    Some("DateTime") | Some("NaiveDateTime")
                 );
-                let is_uuid_type = matches!(type_name.as_deref(), Some("Uuid"));
+                let is_date_only_type =
+                    matches!(type_name.as_deref(), Some("NaiveDate") | Some("Date"))
+                        || matches!(inner_type_name.as_deref(), Some("NaiveDate") | Some("Date"));
+                let is_uuid_type = matches!(type_name.as_deref(), Some("Uuid"))
+                    || matches!(inner_type_name.as_deref(), Some("Uuid"));
 
                 // Create field property
                 // IMPORTANT: Default to treating unknown types as structs (objects)
                 // Structs are far more common than enums, and this is the safest default
-                let field_prop = if is_date_type {
-                    // For date types
+                let field_prop = if is_datetime_type {
+                    // For date-time types (DateTime, NaiveDateTime)
                     quote! {
-                        // Create property for this date field
+                        // Create property for this date-time field
                         let mut props = ::serde_json::Map::new();
                         props.insert("type".to_string(), ::serde_json::Value::String("string".to_string()));
                         props.insert("format".to_string(), ::serde_json::Value::String("date-time".to_string()));
                         props.insert("description".to_string(),
                                     ::serde_json::Value::String("ISO-8601 formatted date and time".to_string()));
+                    }
+                } else if is_date_only_type {
+                    // For date-only types (NaiveDate, Date)
+                    quote! {
+                        // Create property for this date field
+                        let mut props = ::serde_json::Map::new();
+                        props.insert("type".to_string(), ::serde_json::Value::String("string".to_string()));
+                        props.insert("format".to_string(), ::serde_json::Value::String("date".to_string()));
+                        props.insert("description".to_string(),
+                                    ::serde_json::Value::String("ISO-8601 formatted date (YYYY-MM-DD)".to_string()));
                     }
                 } else if is_uuid_type {
                     // For UUID types
@@ -117,18 +146,33 @@ pub fn generate_struct_schema(
                         };
 
                         // Check for well-known library types by exact match only
-                        let is_date = matches!(
+                        let is_datetime = matches!(
                             inner_type_name.as_deref(),
-                            Some("DateTime")
-                                | Some("NaiveDateTime")
-                                | Some("NaiveDate")
-                                | Some("Date")
+                            Some("DateTime") | Some("NaiveDateTime")
                         );
+                        let is_date_only =
+                            matches!(inner_type_name.as_deref(), Some("NaiveDate") | Some("Date"));
                         let is_uuid = matches!(inner_type_name.as_deref(), Some("Uuid"));
 
                         // Generate items schema
-                        if is_date {
-                            // Handle array of dates
+                        if is_datetime {
+                            // Handle array of date-times
+                            quote! {
+                                // Create property for this array field with date-time items
+                                let mut props = ::serde_json::Map::new();
+                                props.insert("type".to_string(), ::serde_json::Value::String(#schema_type.to_string()));
+
+                                // Add items schema for date-times
+                                let mut items_schema = ::serde_json::Map::new();
+                                items_schema.insert("type".to_string(), ::serde_json::Value::String("string".to_string()));
+                                items_schema.insert("format".to_string(), ::serde_json::Value::String("date-time".to_string()));
+                                items_schema.insert("description".to_string(),
+                                    ::serde_json::Value::String("ISO-8601 formatted date and time".to_string()));
+
+                                props.insert("items".to_string(), ::serde_json::Value::Object(items_schema));
+                            }
+                        } else if is_date_only {
+                            // Handle array of date-only values
                             quote! {
                                 // Create property for this array field with date items
                                 let mut props = ::serde_json::Map::new();
@@ -137,9 +181,9 @@ pub fn generate_struct_schema(
                                 // Add items schema for dates
                                 let mut items_schema = ::serde_json::Map::new();
                                 items_schema.insert("type".to_string(), ::serde_json::Value::String("string".to_string()));
-                                items_schema.insert("format".to_string(), ::serde_json::Value::String("date-time".to_string()));
+                                items_schema.insert("format".to_string(), ::serde_json::Value::String("date".to_string()));
                                 items_schema.insert("description".to_string(),
-                                    ::serde_json::Value::String("ISO-8601 formatted date and time".to_string()));
+                                    ::serde_json::Value::String("ISO-8601 formatted date (YYYY-MM-DD)".to_string()));
 
                                 props.insert("items".to_string(), ::serde_json::Value::Object(items_schema));
                             }

--- a/rstructor_derive/tests/date_format_tests.rs
+++ b/rstructor_derive/tests/date_format_tests.rs
@@ -1,0 +1,191 @@
+// Tests for date/UUID format handling in schema generation
+use chrono::{NaiveDate, NaiveDateTime};
+use rstructor::{Instructor, SchemaType};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// Struct with NaiveDate (should get format "date")
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct WithNaiveDate {
+    date: NaiveDate,
+}
+
+// Struct with NaiveDateTime (should get format "date-time")
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct WithNaiveDateTime {
+    #[llm(description = "A date-time field")]
+    timestamp: NaiveDateTime,
+}
+
+// Struct with Option<NaiveDate> (should still get format "date")
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct WithOptionalNaiveDate {
+    date: Option<NaiveDate>,
+}
+
+// Struct with Option<NaiveDateTime> (should still get format "date-time")
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct WithOptionalNaiveDateTime {
+    #[llm(description = "An optional date-time")]
+    timestamp: Option<NaiveDateTime>,
+}
+
+// Struct with Option<Uuid> (should still get format "uuid")
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct WithOptionalUuid {
+    #[llm(description = "An optional UUID")]
+    id: Option<Uuid>,
+}
+
+// Struct with Vec<NaiveDate> (items should get format "date")
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct WithVecNaiveDate {
+    #[llm(description = "A list of dates")]
+    dates: Vec<NaiveDate>,
+}
+
+// Struct with Vec<NaiveDateTime> (items should get format "date-time")
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct WithVecNaiveDateTime {
+    #[llm(description = "A list of date-times")]
+    timestamps: Vec<NaiveDateTime>,
+}
+
+#[test]
+fn test_naive_date_gets_date_format() {
+    let schema = WithNaiveDate::schema();
+    let json = schema.to_json();
+    let date_prop = &json["properties"]["date"];
+
+    assert_eq!(date_prop["type"], "string");
+    assert_eq!(
+        date_prop["format"], "date",
+        "NaiveDate should have format 'date', not 'date-time'"
+    );
+    assert!(
+        date_prop["description"]
+            .as_str()
+            .unwrap()
+            .contains("YYYY-MM-DD"),
+        "NaiveDate description should mention YYYY-MM-DD"
+    );
+}
+
+#[test]
+fn test_naive_datetime_gets_datetime_format() {
+    let schema = WithNaiveDateTime::schema();
+    let json = schema.to_json();
+    let ts_prop = &json["properties"]["timestamp"];
+
+    assert_eq!(ts_prop["type"], "string");
+    assert_eq!(
+        ts_prop["format"], "date-time",
+        "NaiveDateTime should have format 'date-time'"
+    );
+}
+
+#[test]
+fn test_option_naive_date_gets_date_format() {
+    let schema = WithOptionalNaiveDate::schema();
+    let json = schema.to_json();
+    let date_prop = &json["properties"]["date"];
+
+    assert_eq!(date_prop["type"], "string");
+    assert_eq!(
+        date_prop["format"], "date",
+        "Option<NaiveDate> should have format 'date', not be missing"
+    );
+    assert!(
+        date_prop["description"]
+            .as_str()
+            .unwrap()
+            .contains("YYYY-MM-DD"),
+        "Option<NaiveDate> description should mention YYYY-MM-DD"
+    );
+
+    // Option fields should NOT be in required
+    let required = json["required"].as_array().unwrap();
+    assert!(
+        !required.iter().any(|v| v == "date"),
+        "Option<NaiveDate> should not be required"
+    );
+}
+
+#[test]
+fn test_option_naive_datetime_gets_datetime_format() {
+    let schema = WithOptionalNaiveDateTime::schema();
+    let json = schema.to_json();
+    let ts_prop = &json["properties"]["timestamp"];
+
+    assert_eq!(ts_prop["type"], "string");
+    assert_eq!(
+        ts_prop["format"], "date-time",
+        "Option<NaiveDateTime> should have format 'date-time', not be missing"
+    );
+
+    // Option fields should NOT be in required
+    let required = json["required"].as_array().unwrap();
+    assert!(
+        !required.iter().any(|v| v == "timestamp"),
+        "Option<NaiveDateTime> should not be required"
+    );
+}
+
+#[test]
+fn test_option_uuid_gets_uuid_format() {
+    let schema = WithOptionalUuid::schema();
+    let json = schema.to_json();
+    let id_prop = &json["properties"]["id"];
+
+    assert_eq!(id_prop["type"], "string");
+    assert_eq!(
+        id_prop["format"], "uuid",
+        "Option<Uuid> should have format 'uuid', not be missing"
+    );
+
+    // Option fields should NOT be in required
+    let required = json["required"].as_array().unwrap();
+    assert!(
+        !required.iter().any(|v| v == "id"),
+        "Option<Uuid> should not be required"
+    );
+}
+
+#[test]
+fn test_vec_naive_date_items_get_date_format() {
+    let schema = WithVecNaiveDate::schema();
+    let json = schema.to_json();
+    let dates_prop = &json["properties"]["dates"];
+
+    assert_eq!(dates_prop["type"], "array");
+
+    let items = &dates_prop["items"];
+    assert_eq!(items["type"], "string");
+    assert_eq!(
+        items["format"], "date",
+        "Vec<NaiveDate> items should have format 'date', not 'date-time'"
+    );
+    assert!(
+        items["description"]
+            .as_str()
+            .unwrap()
+            .contains("YYYY-MM-DD"),
+        "Vec<NaiveDate> items description should mention YYYY-MM-DD"
+    );
+}
+
+#[test]
+fn test_vec_naive_datetime_items_get_datetime_format() {
+    let schema = WithVecNaiveDateTime::schema();
+    let json = schema.to_json();
+    let ts_prop = &json["properties"]["timestamps"];
+
+    assert_eq!(ts_prop["type"], "array");
+
+    let items = &ts_prop["items"];
+    assert_eq!(items["type"], "string");
+    assert_eq!(
+        items["format"], "date-time",
+        "Vec<NaiveDateTime> items should have format 'date-time'"
+    );
+}

--- a/rstructor_derive/tests/enum_date_format_tests.rs
+++ b/rstructor_derive/tests/enum_date_format_tests.rs
@@ -1,0 +1,180 @@
+// Tests for date/UUID format handling in enum schema generation
+use chrono::{NaiveDate, NaiveDateTime};
+use rstructor::{Instructor, SchemaType};
+use serde::{Deserialize, Serialize};
+
+// Externally tagged enum (default) with struct variants containing date fields
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+enum EventType {
+    #[llm(description = "A single-day event")]
+    SingleDay { name: String, date: NaiveDate },
+    #[llm(description = "A multi-day event with start and end dates")]
+    MultiDay {
+        name: String,
+        start: NaiveDate,
+        end: NaiveDate,
+    },
+    #[llm(description = "A timestamped event")]
+    Timestamped {
+        name: String,
+        timestamp: NaiveDateTime,
+    },
+}
+
+// Internally tagged enum with struct variant containing a NaiveDate field
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+#[serde(tag = "kind")]
+enum InternallyTaggedEvent {
+    #[llm(description = "A birthday event")]
+    Birthday { person: String, date: NaiveDate },
+    #[llm(description = "A meeting event")]
+    Meeting {
+        title: String,
+        scheduled_at: NaiveDateTime,
+    },
+}
+
+// Externally tagged enum with a Vec<NaiveDate> field
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+enum Schedule {
+    #[llm(description = "A recurring schedule with multiple dates")]
+    Recurring { name: String, dates: Vec<NaiveDate> },
+    #[llm(description = "A one-off event")]
+    OneOff { name: String, date: NaiveDate },
+}
+
+#[test]
+fn test_externally_tagged_enum_naive_date_format() {
+    let schema = EventType::schema();
+    let json = schema.to_json();
+
+    // Externally tagged enums use anyOf
+    let variants = json["anyOf"]
+        .as_array()
+        .expect("Schema should use anyOf for externally tagged enums");
+
+    // Find the SingleDay variant
+    let single_day = variants
+        .iter()
+        .find(|v| {
+            v["properties"]
+                .as_object()
+                .map_or(false, |props| props.contains_key("SingleDay"))
+        })
+        .expect("Should find SingleDay variant");
+
+    let single_day_props = &single_day["properties"]["SingleDay"]["properties"];
+    let date_prop = &single_day_props["date"];
+
+    assert_eq!(
+        date_prop["type"], "string",
+        "NaiveDate should be string type"
+    );
+    assert_eq!(
+        date_prop["format"], "date",
+        "NaiveDate in externally tagged enum should have format 'date'"
+    );
+}
+
+#[test]
+fn test_externally_tagged_enum_naive_datetime_format() {
+    let schema = EventType::schema();
+    let json = schema.to_json();
+
+    let variants = json["anyOf"]
+        .as_array()
+        .expect("Schema should use anyOf for externally tagged enums");
+
+    // Find the Timestamped variant
+    let timestamped = variants
+        .iter()
+        .find(|v| {
+            v["properties"]
+                .as_object()
+                .map_or(false, |props| props.contains_key("Timestamped"))
+        })
+        .expect("Should find Timestamped variant");
+
+    let timestamped_props = &timestamped["properties"]["Timestamped"]["properties"];
+    let ts_prop = &timestamped_props["timestamp"];
+
+    assert_eq!(
+        ts_prop["type"], "string",
+        "NaiveDateTime should be string type"
+    );
+    assert_eq!(
+        ts_prop["format"], "date-time",
+        "NaiveDateTime in externally tagged enum should have format 'date-time'"
+    );
+}
+
+#[test]
+fn test_internally_tagged_enum_naive_date_format() {
+    let schema = InternallyTaggedEvent::schema();
+    let json = schema.to_json();
+    // Internally tagged enums also use anyOf
+    let variants = json["anyOf"]
+        .as_array()
+        .expect("Schema should use anyOf for internally tagged enums");
+
+    // Find the Birthday variant (has "kind" with enum: ["Birthday"] in properties)
+    let birthday = variants
+        .iter()
+        .find(|v| {
+            v["properties"]["kind"]["enum"]
+                .as_array()
+                .and_then(|arr| arr.first())
+                .and_then(|c| c.as_str())
+                == Some("Birthday")
+        })
+        .expect("Should find Birthday variant");
+
+    let date_prop = &birthday["properties"]["date"];
+
+    assert_eq!(
+        date_prop["type"], "string",
+        "NaiveDate in internally tagged enum should be string type"
+    );
+    assert_eq!(
+        date_prop["format"], "date",
+        "NaiveDate in internally tagged enum should have format 'date'"
+    );
+}
+
+#[test]
+fn test_enum_vec_naive_date_items_format() {
+    let schema = Schedule::schema();
+    let json = schema.to_json();
+
+    let variants = json["anyOf"]
+        .as_array()
+        .expect("Schema should use anyOf for externally tagged enums");
+
+    // Find the Recurring variant
+    let recurring = variants
+        .iter()
+        .find(|v| {
+            v["properties"]
+                .as_object()
+                .map_or(false, |props| props.contains_key("Recurring"))
+        })
+        .expect("Should find Recurring variant");
+
+    let recurring_props = &recurring["properties"]["Recurring"]["properties"];
+    let dates_prop = &recurring_props["dates"];
+
+    assert_eq!(
+        dates_prop["type"], "array",
+        "Vec<NaiveDate> should be array type"
+    );
+
+    let items = &dates_prop["items"];
+    assert_eq!(
+        items["type"], "string",
+        "Vec<NaiveDate> items should be string type"
+    );
+    assert_eq!(
+        items["format"], "date",
+        "Vec<NaiveDate> items in enum should have format 'date'"
+    );
+}

--- a/rstructor_derive/tests/internally_tagged_tests.rs
+++ b/rstructor_derive/tests/internally_tagged_tests.rs
@@ -1,0 +1,421 @@
+use rstructor::{Instructor, SchemaType};
+use serde::{Deserialize, Serialize};
+
+// ── Helper structs used as newtype inner types ──────────────────────────
+
+#[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
+struct PersonInfo {
+    #[llm(description = "Person's full name")]
+    name: String,
+    #[llm(description = "Person's age in years")]
+    age: u32,
+}
+
+#[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
+struct CompanyInfo {
+    #[llm(description = "Company name")]
+    company_name: String,
+    #[llm(description = "Number of employees")]
+    employee_count: u32,
+}
+
+#[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
+struct OptionalFieldsData {
+    #[llm(description = "A required field")]
+    required_field: String,
+    #[llm(description = "An optional field")]
+    optional_field: Option<String>,
+}
+
+// ── Test 1: Basic internally tagged enum with newtype variants ──────────
+
+#[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(tag = "kind")]
+enum Contact {
+    #[llm(description = "A person contact")]
+    Person(PersonInfo),
+    #[llm(description = "A company contact")]
+    Company(CompanyInfo),
+}
+
+#[test]
+fn test_newtype_variant_fields_appear_in_schema() {
+    let schema = Contact::schema().to_json();
+    let any_of = schema["anyOf"].as_array().expect("should have anyOf");
+
+    // Find the Person variant
+    let person_variant = any_of
+        .iter()
+        .find(|v| v["properties"]["kind"]["enum"][0] == "Person")
+        .expect("should have Person variant");
+
+    // The inner struct fields must appear alongside the tag
+    assert!(
+        person_variant["properties"].get("name").is_some(),
+        "Person variant should have 'name' property from PersonInfo"
+    );
+    assert!(
+        person_variant["properties"].get("age").is_some(),
+        "Person variant should have 'age' property from PersonInfo"
+    );
+
+    // Find the Company variant
+    let company_variant = any_of
+        .iter()
+        .find(|v| v["properties"]["kind"]["enum"][0] == "Company")
+        .expect("should have Company variant");
+
+    assert!(
+        company_variant["properties"].get("company_name").is_some(),
+        "Company variant should have 'company_name' property from CompanyInfo"
+    );
+    assert!(
+        company_variant["properties"]
+            .get("employee_count")
+            .is_some(),
+        "Company variant should have 'employee_count' property from CompanyInfo"
+    );
+}
+
+// ── Test 2: Tag property has correct enum constraint ────────────────────
+
+#[test]
+fn test_tag_property_enum_constraint() {
+    let schema = Contact::schema().to_json();
+    let any_of = schema["anyOf"].as_array().unwrap();
+
+    for variant in any_of {
+        let tag_prop = &variant["properties"]["kind"];
+        assert_eq!(
+            tag_prop["type"], "string",
+            "tag property should be string type"
+        );
+        let enum_vals = tag_prop["enum"]
+            .as_array()
+            .expect("tag should have enum constraint");
+        assert_eq!(
+            enum_vals.len(),
+            1,
+            "each variant tag should have exactly one allowed value"
+        );
+    }
+
+    let tag_values: Vec<&str> = any_of
+        .iter()
+        .map(|v| v["properties"]["kind"]["enum"][0].as_str().unwrap())
+        .collect();
+    assert!(tag_values.contains(&"Person"));
+    assert!(tag_values.contains(&"Company"));
+}
+
+// ── Test 3: Mixed enum with unit, newtype, and struct variants ──────────
+
+#[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(tag = "type")]
+enum MixedEvent {
+    #[llm(description = "A ping with no data")]
+    Ping,
+
+    #[llm(description = "A message carrying a person")]
+    PersonMessage(PersonInfo),
+
+    #[llm(description = "An inline error")]
+    Error {
+        #[llm(description = "Error code")]
+        code: u32,
+        #[llm(description = "Error message")]
+        message: String,
+    },
+}
+
+#[test]
+fn test_mixed_variant_types() {
+    let schema = MixedEvent::schema().to_json();
+    let any_of = schema["anyOf"].as_array().expect("should have anyOf");
+    assert_eq!(any_of.len(), 3, "should have 3 variants");
+
+    // Unit variant: only tag property
+    let ping = any_of
+        .iter()
+        .find(|v| v["properties"]["type"]["enum"][0] == "Ping")
+        .expect("should have Ping variant");
+    // Ping should have the tag and nothing else
+    let ping_props = ping["properties"].as_object().unwrap();
+    assert_eq!(
+        ping_props.len(),
+        1,
+        "Ping should only have the tag property"
+    );
+
+    // Newtype variant: tag + inner struct fields
+    let person_msg = any_of
+        .iter()
+        .find(|v| v["properties"]["type"]["enum"][0] == "PersonMessage")
+        .expect("should have PersonMessage variant");
+    assert!(person_msg["properties"].get("name").is_some());
+    assert!(person_msg["properties"].get("age").is_some());
+
+    // Struct variant: tag + named fields
+    let error = any_of
+        .iter()
+        .find(|v| v["properties"]["type"]["enum"][0] == "Error")
+        .expect("should have Error variant");
+    assert!(error["properties"].get("code").is_some());
+    assert!(error["properties"].get("message").is_some());
+}
+
+// ── Test 4: Serde roundtrip matches schema shape ────────────────────────
+
+#[test]
+fn test_serde_roundtrip_matches_schema() {
+    // Serialize a Contact::Person and verify the shape matches what the schema describes
+    let contact = Contact::Person(PersonInfo {
+        name: "Alice".to_string(),
+        age: 30,
+    });
+    let json = serde_json::to_value(&contact).unwrap();
+
+    // serde with internal tagging produces {"kind": "Person", "name": "Alice", "age": 30}
+    assert_eq!(json["kind"], "Person");
+    assert_eq!(json["name"], "Alice");
+    assert_eq!(json["age"], 30);
+
+    // The schema should describe exactly these keys
+    let schema = Contact::schema().to_json();
+    let person_variant = schema["anyOf"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|v| v["properties"]["kind"]["enum"][0] == "Person")
+        .unwrap();
+
+    let schema_props: Vec<&str> = person_variant["properties"]
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(|k| k.as_str())
+        .collect();
+
+    for key in json.as_object().unwrap().keys() {
+        assert!(
+            schema_props.contains(&key.as_str()),
+            "serialized key '{}' should appear in schema properties",
+            key
+        );
+    }
+
+    // Roundtrip deserialization
+    let deserialized: Contact = serde_json::from_value(json).unwrap();
+    assert_eq!(
+        deserialized,
+        Contact::Person(PersonInfo {
+            name: "Alice".to_string(),
+            age: 30,
+        })
+    );
+}
+
+// ── Test 5: Newtype variant with optional fields ────────────────────────
+
+#[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(tag = "tag")]
+enum OptionalFieldsEnum {
+    #[llm(description = "Variant with optional fields")]
+    Data(OptionalFieldsData),
+}
+
+#[test]
+fn test_optional_fields_not_required() {
+    let schema = OptionalFieldsEnum::schema().to_json();
+    let variant = &schema["anyOf"].as_array().unwrap()[0];
+
+    let required: Vec<&str> = variant["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+
+    assert!(required.contains(&"tag"), "tag should be required");
+    assert!(
+        required.contains(&"required_field"),
+        "required_field should be required"
+    );
+    assert!(
+        !required.contains(&"optional_field"),
+        "optional_field should NOT be required"
+    );
+
+    // But the optional field should still appear in properties
+    assert!(
+        variant["properties"].get("optional_field").is_some(),
+        "optional_field should still appear in properties"
+    );
+}
+
+// ── Test 6: rename_all support with tagged enums ────────────────────────
+
+#[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum RenamedVariants {
+    #[llm(description = "First variant")]
+    MyFirstVariant,
+    #[llm(description = "Second variant")]
+    MySecondVariant,
+}
+
+#[test]
+fn test_rename_all_with_tagged_enum() {
+    let schema = RenamedVariants::schema().to_json();
+    let any_of = schema["anyOf"].as_array().unwrap();
+
+    let tag_values: Vec<&str> = any_of
+        .iter()
+        .map(|v| v["properties"]["type"]["enum"][0].as_str().unwrap())
+        .collect();
+
+    assert!(
+        tag_values.contains(&"my_first_variant"),
+        "should have snake_case variant name 'my_first_variant', got: {:?}",
+        tag_values
+    );
+    assert!(
+        tag_values.contains(&"my_second_variant"),
+        "should have snake_case variant name 'my_second_variant', got: {:?}",
+        tag_values
+    );
+}
+
+// ── Test 7: All-unit internally tagged enum produces object schemas ─────
+
+#[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(tag = "status")]
+enum Status {
+    #[llm(description = "Currently active")]
+    Active,
+    #[llm(description = "Currently inactive")]
+    Inactive,
+    #[llm(description = "Account is pending")]
+    Pending,
+}
+
+#[test]
+fn test_all_unit_tagged_enum_produces_object_schemas() {
+    let schema = Status::schema().to_json();
+
+    // Should NOT be a simple {"type": "string", "enum": [...]} schema
+    assert!(
+        schema.get("enum").is_none(),
+        "tagged all-unit enum should NOT have top-level 'enum' key"
+    );
+
+    // Should have anyOf with object schemas
+    let any_of = schema["anyOf"]
+        .as_array()
+        .expect("tagged all-unit enum should have 'anyOf' with object variant schemas");
+    assert_eq!(any_of.len(), 3);
+
+    for variant in any_of {
+        assert_eq!(
+            variant["type"], "object",
+            "each variant should be an object"
+        );
+        assert!(
+            variant["properties"].get("status").is_some(),
+            "each variant should have the 'status' tag property"
+        );
+    }
+
+    // Verify serde serialization matches: Status::Active -> {"status": "Active"}
+    let json = serde_json::to_value(Status::Active).unwrap();
+    assert_eq!(json, serde_json::json!({"status": "Active"}));
+}
+
+// ── Test 8: Untagged all-unit enum still produces simple string enum ────
+
+#[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
+enum SimpleColor {
+    #[llm(description = "Red color")]
+    Red,
+    #[llm(description = "Green color")]
+    Green,
+    #[llm(description = "Blue color")]
+    Blue,
+}
+
+#[test]
+fn test_untagged_all_unit_enum_is_string_enum() {
+    let schema = SimpleColor::schema().to_json();
+
+    // Should be a simple {"type": "string", "enum": [...]} schema
+    assert_eq!(
+        schema["type"], "string",
+        "untagged all-unit enum should be string type"
+    );
+    let enum_vals = schema["enum"].as_array().expect("should have enum values");
+    let values: Vec<&str> = enum_vals.iter().map(|v| v.as_str().unwrap()).collect();
+    assert!(values.contains(&"Red"));
+    assert!(values.contains(&"Green"));
+    assert!(values.contains(&"Blue"));
+}
+
+// ── Test 9: Box<T> newtype variant works correctly ──────────────────────
+
+#[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(tag = "kind")]
+enum BoxedContact {
+    #[llm(description = "A boxed person contact")]
+    Person(Box<PersonInfo>),
+    #[llm(description = "A boxed company contact")]
+    Company(Box<CompanyInfo>),
+}
+
+#[test]
+fn test_boxed_newtype_variant_fields_appear() {
+    let schema = BoxedContact::schema().to_json();
+    let any_of = schema["anyOf"].as_array().expect("should have anyOf");
+
+    let person_variant = any_of
+        .iter()
+        .find(|v| v["properties"]["kind"]["enum"][0] == "Person")
+        .expect("should have Person variant");
+
+    assert!(
+        person_variant["properties"].get("name").is_some(),
+        "Boxed Person variant should have 'name' property"
+    );
+    assert!(
+        person_variant["properties"].get("age").is_some(),
+        "Boxed Person variant should have 'age' property"
+    );
+
+    // Required should include tag + inner struct required fields
+    let required: Vec<&str> = person_variant["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(required.contains(&"kind"));
+    assert!(required.contains(&"name"));
+    assert!(required.contains(&"age"));
+
+    // Serde roundtrip
+    let contact = BoxedContact::Person(Box::new(PersonInfo {
+        name: "Bob".to_string(),
+        age: 42,
+    }));
+    let json = serde_json::to_value(&contact).unwrap();
+    assert_eq!(json["kind"], "Person");
+    assert_eq!(json["name"], "Bob");
+    assert_eq!(json["age"], 42);
+
+    let deserialized: BoxedContact = serde_json::from_value(json).unwrap();
+    assert_eq!(
+        deserialized,
+        BoxedContact::Person(Box::new(PersonInfo {
+            name: "Bob".to_string(),
+            age: 42,
+        }))
+    );
+}

--- a/tests/schema_validation_tests.rs
+++ b/tests/schema_validation_tests.rs
@@ -53,31 +53,11 @@ mod schema_validation_tests {
                     // Check type
                     let schema_type = field_schema["type"].as_str().unwrap_or("object");
                     match schema_type {
-                        "string" => {
-                            if !field_value.is_string() {
-                                return false;
-                            }
-                        }
-                        "integer" | "number" => {
-                            if !field_value.is_number() {
-                                return false;
-                            }
-                        }
-                        "boolean" => {
-                            if !field_value.is_boolean() {
-                                return false;
-                            }
-                        }
-                        "array" => {
-                            if !field_value.is_array() {
-                                return false;
-                            }
-                        }
-                        "object" => {
-                            if !field_value.is_object() {
-                                return false;
-                            }
-                        }
+                        "string" if !field_value.is_string() => return false,
+                        "integer" | "number" if !field_value.is_number() => return false,
+                        "boolean" if !field_value.is_boolean() => return false,
+                        "array" if !field_value.is_array() => return false,
+                        "object" if !field_value.is_object() => return false,
                         _ => {}
                     }
                 }


### PR DESCRIPTION
Two main bugs fixed, relating to:
- newtype variants in internally tagged enums, specifically where there's a single anonymous field
- a bit of confusion around date-time versus date

Plus 4 other fixes implied by these.

I initially did these fixes separately and I've redone them to be nicer for the PR and add in more general tests (rather than testing on my own data)

Here's an LLM summary of the changes in more detail

LLM summary
============

Fixes six related bugs in `rstructor_derive`'s schema generation, all causing generated JSON schemas to diverge from what serde actually produces.

## Bug fixes

### Internally tagged enum schema generation

1. **Newtype variants dropped inner struct fields** — `#[serde(tag = "type")] enum E { Variant(InnerStruct) }` generated a schema with only the tag property, discarding all of `InnerStruct`'s fields. Serde flattens the inner struct alongside the tag, so the schema now merges the inner type's properties and required fields with the tag.

2. **All-unit tagged enums got the wrong schema shape** — `#[serde(tag = "status")] enum Status { Active, Inactive }` generated `{"type": "string", "enum": ["Active", "Inactive"]}`, but serde serializes these as `{"status": "Active"}` (objects). Tagged unit enums now route through the complex enum path.

3. **`Box<T>` in newtype variants caused compile errors** — `Variant(Box<Inner>)` is common to avoid infinite size, but `Box<T>` doesn't implement `SchemaType`. The newtype fix now unwraps `Box<T>` before generating the schema call.

### Date and UUID format metadata

4. **`NaiveDate`/`Date` got format `"date-time"` instead of `"date"`** in struct schemas — split detection so `NaiveDate`/`Date` produce `"format": "date"` (YYYY-MM-DD) while `DateTime`/`NaiveDateTime` keep `"format": "date-time"`, per the JSON Schema spec.

5. **`Option<NaiveDate>`, `Option<DateTime>`, `Option<Uuid>` lost format metadata** in struct schemas — type detection only looked at the outermost type (`Option`), so the format was silently dropped. Now unwraps `Option<T>` before checking, matching the pattern already used for `Vec<T>`, `Box<T>`, etc.

6. **Enum struct-variant fields lost date/UUID format entirely** — `generate_field_schema` in `enum_schema.rs` had no special handling for these types, producing bare `{"type": "string"}` across all four tagging modes. Added detection for `DateTime`/`NaiveDateTime` → `"date-time"`, `NaiveDate`/`Date` → `"date"`, and `Uuid` → `"uuid"`, for both direct fields and `Vec<T>` items.

## Tests

20 new tests across 3 test files:

- `internally_tagged_tests.rs` (9 tests) — newtype variants, `Box<T>`, mixed variant types, all-unit tagged enums, serde roundtrips, `rename_all`, regression guard for untagged enums
- `date_format_tests.rs` (7 tests) — `NaiveDate` vs `NaiveDateTime` format, `Option<NaiveDate>`, `Option<Uuid>`, `Vec<NaiveDate>` items
- `enum_date_format_tests.rs` (4 tests) — date fields in externally and internally tagged enum variants, `Vec<NaiveDate>` in enum variants
