### PR TITLE
Update model references to latest across all providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ let client = AnthropicClient::from_env()?.model("claude-sonnet-4-6");
 let client = GrokClient::from_env()?.model("grok-4.3");
 
 // Gemini (reads GEMINI_API_KEY)
-let client = GeminiClient::from_env()?.model("gemini-3.1-pro-preview");
+let client = GeminiClient::from_env()?.model("gemini-3.5-flash");
 
 // Custom endpoint (local LLMs, proxies)
 let client = OpenAIClient::new("key")?

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -40,7 +40,9 @@ use crate::model::Instructor;
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AnthropicModel {
-    /// Claude Opus 4.7 (latest most capable generally available model)
+    /// Claude Opus 4.8 (latest most capable generally available model)
+    ClaudeOpus48,
+    /// Claude Opus 4.7 (previous most capable model)
     ClaudeOpus47,
     /// Claude Sonnet 4.6 (latest balanced model)
     ClaudeSonnet46,
@@ -58,14 +60,6 @@ pub enum AnthropicModel {
     ClaudeOpus4,
     /// Claude Sonnet 4 (balanced performance model)
     ClaudeSonnet4,
-    /// Claude Sonnet 3.7 (enhanced reasoning)
-    Claude37Sonnet,
-    /// Claude Haiku 3.5 (fast, cost-effective model)
-    Claude35Haiku,
-    /// Claude Haiku 3 (fast, cost-effective model)
-    Claude3Haiku,
-    /// Claude Opus 3 (most capable model for complex tasks)
-    Claude3Opus,
     /// Custom model name (for new models or Anthropic-compatible endpoints)
     Custom(String),
 }
@@ -73,6 +67,7 @@ pub enum AnthropicModel {
 impl AnthropicModel {
     pub fn as_str(&self) -> &str {
         match self {
+            AnthropicModel::ClaudeOpus48 => "claude-opus-4-8",
             AnthropicModel::ClaudeOpus47 => "claude-opus-4-7",
             AnthropicModel::ClaudeSonnet46 => "claude-sonnet-4-6",
             AnthropicModel::ClaudeOpus46 => "claude-opus-4-6",
@@ -82,10 +77,6 @@ impl AnthropicModel {
             AnthropicModel::ClaudeOpus41 => "claude-opus-4-1-20250805",
             AnthropicModel::ClaudeOpus4 => "claude-opus-4-20250514",
             AnthropicModel::ClaudeSonnet4 => "claude-sonnet-4-20250514",
-            AnthropicModel::Claude37Sonnet => "claude-3-7-sonnet-20250219",
-            AnthropicModel::Claude35Haiku => "claude-3-5-haiku-20241022",
-            AnthropicModel::Claude3Haiku => "claude-3-haiku-20240307",
-            AnthropicModel::Claude3Opus => "claude-3-opus-20240229",
             AnthropicModel::Custom(name) => name,
         }
     }
@@ -97,6 +88,7 @@ impl AnthropicModel {
     pub fn from_string(name: impl Into<String>) -> Self {
         let name = name.into();
         match name.as_str() {
+            "claude-opus-4-8" => AnthropicModel::ClaudeOpus48,
             "claude-opus-4-7" => AnthropicModel::ClaudeOpus47,
             "claude-sonnet-4-6" => AnthropicModel::ClaudeSonnet46,
             "claude-opus-4-6" => AnthropicModel::ClaudeOpus46,
@@ -106,10 +98,6 @@ impl AnthropicModel {
             "claude-opus-4-1-20250805" => AnthropicModel::ClaudeOpus41,
             "claude-opus-4-20250514" => AnthropicModel::ClaudeOpus4,
             "claude-sonnet-4-20250514" => AnthropicModel::ClaudeSonnet4,
-            "claude-3-7-sonnet-20250219" => AnthropicModel::Claude37Sonnet,
-            "claude-3-5-haiku-20241022" => AnthropicModel::Claude35Haiku,
-            "claude-3-haiku-20240307" => AnthropicModel::Claude3Haiku,
-            "claude-3-opus-20240229" => AnthropicModel::Claude3Opus,
             _ => AnthropicModel::Custom(name),
         }
     }

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -41,10 +41,10 @@ use crate::model::Instructor;
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Model {
-    /// Gemini 3.1 Pro Preview (latest Pro model, default)
-    Gemini31ProPreview,
-    /// Gemini 3.5 Flash (latest Flash model, best price/performance)
+    /// Gemini 3.5 Flash (latest Flash model, best price/performance, default)
     Gemini35Flash,
+    /// Gemini 3.1 Pro Preview (latest Pro model)
+    Gemini31ProPreview,
     /// Gemini 3.1 Pro Preview Custom Tools (agentic custom-tool variant)
     Gemini31ProPreviewCustomTools,
     /// Gemini 3 Flash Preview (preview Flash model)
@@ -84,8 +84,8 @@ pub enum Model {
 impl Model {
     pub fn as_str(&self) -> &str {
         match self {
-            Model::Gemini31ProPreview => "gemini-3.1-pro-preview",
             Model::Gemini35Flash => "gemini-3.5-flash",
+            Model::Gemini31ProPreview => "gemini-3.1-pro-preview",
             Model::Gemini31ProPreviewCustomTools => "gemini-3.1-pro-preview-customtools",
             Model::Gemini3FlashPreview => "gemini-3-flash-preview",
             Model::Gemini31FlashLite => "gemini-3.1-flash-lite",
@@ -113,8 +113,8 @@ impl Model {
     pub fn from_string(name: impl Into<String>) -> Self {
         let name = name.into();
         match name.as_str() {
-            "gemini-3.1-pro-preview" => Model::Gemini31ProPreview,
             "gemini-3.5-flash" => Model::Gemini35Flash,
+            "gemini-3.1-pro-preview" => Model::Gemini31ProPreview,
             "gemini-3.1-pro-preview-customtools" => Model::Gemini31ProPreviewCustomTools,
             "gemini-3-flash-preview" => Model::Gemini3FlashPreview,
             "gemini-3.1-flash-lite" => Model::Gemini31FlashLite,
@@ -293,7 +293,7 @@ impl GeminiClient {
     /// # Ok(())
     /// # }
     /// ```
-    #[instrument(name = "gemini_client_new", skip(api_key), fields(model = ?Model::Gemini31ProPreview))]
+    #[instrument(name = "gemini_client_new", skip(api_key), fields(model = ?Model::Gemini35Flash))]
     pub fn new(api_key: impl Into<String>) -> Result<Self> {
         let api_key = api_key.into();
         if api_key.is_empty() {
@@ -305,7 +305,7 @@ impl GeminiClient {
 
         let config = GeminiConfig {
             api_key,
-            model: Model::Gemini31ProPreview, // Default to Gemini 3.1 Pro Preview (latest Pro)
+            model: Model::Gemini35Flash, // Default to Gemini 3.5 Flash (latest Flash, best price/performance)
             temperature: 0.0,
             max_tokens: None,
             timeout: None,        // Default: no timeout (uses reqwest's default)
@@ -340,14 +340,14 @@ impl GeminiClient {
     /// # Ok(())
     /// # }
     /// ```
-    #[instrument(name = "gemini_client_from_env", fields(model = ?Model::Gemini31ProPreview))]
+    #[instrument(name = "gemini_client_from_env", fields(model = ?Model::Gemini35Flash))]
     pub fn from_env() -> Result<Self> {
         let api_key = std::env::var("GEMINI_API_KEY")
             .map_err(|_| RStructorError::api_error("Gemini", ApiErrorKind::AuthenticationFailed))?;
 
         let config = GeminiConfig {
             api_key,
-            model: Model::Gemini31ProPreview, // Default to Gemini 3.1 Pro Preview (latest Pro)
+            model: Model::Gemini35Flash, // Default to Gemini 3.5 Flash (latest Flash, best price/performance)
             temperature: 0.0,
             max_tokens: None,
             timeout: None,        // Default: no timeout (uses reqwest's default)

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -41,15 +41,19 @@ use crate::model::Instructor;
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Model {
-    /// Gemini 3.1 Pro Preview (latest preview Pro model)
+    /// Gemini 3.1 Pro Preview (latest Pro model, default)
     Gemini31ProPreview,
+    /// Gemini 3.5 Flash (latest Flash model, best price/performance)
+    Gemini35Flash,
     /// Gemini 3.1 Pro Preview Custom Tools (agentic custom-tool variant)
     Gemini31ProPreviewCustomTools,
-    /// Gemini 3 Flash Preview (latest preview Flash model)
+    /// Gemini 3 Flash Preview (preview Flash model)
     Gemini3FlashPreview,
-    /// Gemini 3.1 Flash-Lite Preview (latest cost-efficient multimodal model)
+    /// Gemini 3.1 Flash-Lite (cost-efficient multimodal model)
+    Gemini31FlashLite,
+    /// Gemini 3.1 Flash-Lite Preview (preview cost-efficient multimodal model)
     Gemini31FlashLitePreview,
-    /// Gemini 3 Pro Preview (shut down; use Gemini 3.1 Pro Preview instead)
+    /// Gemini 3 Pro Preview (previous preview Pro model)
     Gemini3ProPreview,
     /// Gemini 2.5 Pro (latest production Pro model)
     Gemini25Pro,
@@ -81,8 +85,10 @@ impl Model {
     pub fn as_str(&self) -> &str {
         match self {
             Model::Gemini31ProPreview => "gemini-3.1-pro-preview",
+            Model::Gemini35Flash => "gemini-3.5-flash",
             Model::Gemini31ProPreviewCustomTools => "gemini-3.1-pro-preview-customtools",
             Model::Gemini3FlashPreview => "gemini-3-flash-preview",
+            Model::Gemini31FlashLite => "gemini-3.1-flash-lite",
             Model::Gemini31FlashLitePreview => "gemini-3.1-flash-lite-preview",
             Model::Gemini3ProPreview => "gemini-3-pro-preview",
             Model::Gemini25Pro => "gemini-2.5-pro",
@@ -108,8 +114,10 @@ impl Model {
         let name = name.into();
         match name.as_str() {
             "gemini-3.1-pro-preview" => Model::Gemini31ProPreview,
+            "gemini-3.5-flash" => Model::Gemini35Flash,
             "gemini-3.1-pro-preview-customtools" => Model::Gemini31ProPreviewCustomTools,
             "gemini-3-flash-preview" => Model::Gemini3FlashPreview,
+            "gemini-3.1-flash-lite" => Model::Gemini31FlashLite,
             "gemini-3.1-flash-lite-preview" => Model::Gemini31FlashLitePreview,
             "gemini-3-pro-preview" => Model::Gemini3ProPreview,
             "gemini-2.5-pro" => Model::Gemini25Pro,

--- a/src/backend/grok.rs
+++ b/src/backend/grok.rs
@@ -40,26 +40,16 @@ use crate::model::Instructor;
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Model {
-    /// Grok 4.3 (latest recommended chat model)
+    /// Grok 4.3 (latest recommended chat model, multimodal text + image input)
     Grok43,
-    /// Grok-4 (previous flagship model with 256k context window)
-    Grok4,
-    /// Grok-4 Fast Reasoning (faster variant optimized for reasoning tasks)
-    Grok4FastReasoning,
-    /// Grok-4 Fast Non-Reasoning (faster variant optimized for non-reasoning tasks)
-    Grok4FastNonReasoning,
-    /// Grok-4.1 Fast Reasoning (previous frontier model with 2M context window)
-    Grok41FastReasoning,
-    /// Grok-4.1 Fast Non-Reasoning (previous frontier model with 2M context window)
-    Grok41FastNonReasoning,
-    /// Grok-3 (previous generation model with 131k context window)
-    Grok3,
-    /// Grok-3 Mini (efficient variant with 131k context window)
-    Grok3Mini,
-    /// Grok Code Fast 1 (optimized for coding tasks)
-    GrokCodeFast1,
-    /// Grok-2 Vision (multimodal vision model)
-    Grok2Vision,
+    /// Grok 4.20 Reasoning (reasoning-optimized variant)
+    Grok420Reasoning,
+    /// Grok 4.20 Non-Reasoning (lower-latency non-reasoning variant)
+    Grok420NonReasoning,
+    /// Grok 4.20 Multi-Agent (agentic multi-agent variant)
+    Grok420MultiAgent,
+    /// Grok Build 0.1 (coding-optimized model; supersedes grok-code-fast-1)
+    GrokBuild01,
     /// Custom model name (for new models or Grok-compatible endpoints)
     Custom(String),
 }
@@ -68,15 +58,10 @@ impl Model {
     pub fn as_str(&self) -> &str {
         match self {
             Model::Grok43 => "grok-4.3",
-            Model::Grok4 => "grok-4-0709",
-            Model::Grok4FastReasoning => "grok-4-fast-reasoning",
-            Model::Grok4FastNonReasoning => "grok-4-fast-non-reasoning",
-            Model::Grok41FastReasoning => "grok-4-1-fast-reasoning",
-            Model::Grok41FastNonReasoning => "grok-4-1-fast-non-reasoning",
-            Model::Grok3 => "grok-3",
-            Model::Grok3Mini => "grok-3-mini",
-            Model::GrokCodeFast1 => "grok-code-fast-1",
-            Model::Grok2Vision => "grok-2-vision-1212",
+            Model::Grok420Reasoning => "grok-4.20-0309-reasoning",
+            Model::Grok420NonReasoning => "grok-4.20-0309-non-reasoning",
+            Model::Grok420MultiAgent => "grok-4.20-multi-agent-0309",
+            Model::GrokBuild01 => "grok-build-0.1",
             Model::Custom(name) => name,
         }
     }
@@ -89,15 +74,10 @@ impl Model {
         let name = name.into();
         match name.as_str() {
             "grok-4.3" => Model::Grok43,
-            "grok-4-0709" => Model::Grok4,
-            "grok-4-fast-reasoning" => Model::Grok4FastReasoning,
-            "grok-4-fast-non-reasoning" => Model::Grok4FastNonReasoning,
-            "grok-4-1-fast-reasoning" => Model::Grok41FastReasoning,
-            "grok-4-1-fast-non-reasoning" => Model::Grok41FastNonReasoning,
-            "grok-3" => Model::Grok3,
-            "grok-3-mini" => Model::Grok3Mini,
-            "grok-code-fast-1" => Model::GrokCodeFast1,
-            "grok-2-vision-1212" => Model::Grok2Vision,
+            "grok-4.20-0309-reasoning" => Model::Grok420Reasoning,
+            "grok-4.20-0309-non-reasoning" => Model::Grok420NonReasoning,
+            "grok-4.20-multi-agent-0309" => Model::Grok420MultiAgent,
+            "grok-build-0.1" => Model::GrokBuild01,
             _ => Model::Custom(name),
         }
     }

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -43,12 +43,18 @@ pub enum Model {
     Gpt55Pro,
     /// GPT-5.5 (latest frontier model for complex professional work)
     Gpt55,
+    /// GPT-5.4 Pro (most capable GPT-5.4-class model)
+    Gpt54Pro,
     /// GPT-5.4 (more affordable frontier model for complex professional work)
     Gpt54,
     /// GPT-5.4 Mini (lower-latency, lower-cost GPT-5.4-class model)
     Gpt54Mini,
     /// GPT-5.4 Nano (cheapest GPT-5.4-class model for high-volume tasks)
     Gpt54Nano,
+    /// GPT-5.3 Chat Latest (ChatGPT GPT-5.3 model)
+    Gpt53ChatLatest,
+    /// GPT-5.3 Codex (coding-focused GPT-5.3 model)
+    Gpt53Codex,
     /// GPT-5.2 Pro (previous GPT-5.2 pro model)
     Gpt52Pro,
     /// GPT-5.2 (previous GPT-5.2 model)
@@ -93,8 +99,6 @@ pub enum Model {
     O3Mini,
     /// O1 (reasoning model optimized for complex problem-solving)
     O1,
-    /// O1 Mini (smaller reasoning model)
-    O1Mini,
     /// O1 Pro (most capable reasoning model)
     O1Pro,
     /// Custom model name (for new models, local LLMs, or OpenAI-compatible endpoints)
@@ -106,9 +110,12 @@ impl Model {
         match self {
             Model::Gpt55Pro => "gpt-5.5-pro",
             Model::Gpt55 => "gpt-5.5",
+            Model::Gpt54Pro => "gpt-5.4-pro",
             Model::Gpt54 => "gpt-5.4",
             Model::Gpt54Mini => "gpt-5.4-mini",
             Model::Gpt54Nano => "gpt-5.4-nano",
+            Model::Gpt53ChatLatest => "gpt-5.3-chat-latest",
+            Model::Gpt53Codex => "gpt-5.3-codex",
             Model::Gpt52Pro => "gpt-5.2-pro",
             Model::Gpt52 => "gpt-5.2",
             Model::Gpt52ChatLatest => "gpt-5.2-chat-latest",
@@ -131,7 +138,6 @@ impl Model {
             Model::O3 => "o3",
             Model::O3Mini => "o3-mini",
             Model::O1 => "o1",
-            Model::O1Mini => "o1-mini",
             Model::O1Pro => "o1-pro",
             Model::Custom(name) => name,
         }
@@ -146,9 +152,12 @@ impl Model {
         match name.as_str() {
             "gpt-5.5-pro" => Model::Gpt55Pro,
             "gpt-5.5" => Model::Gpt55,
+            "gpt-5.4-pro" => Model::Gpt54Pro,
             "gpt-5.4" => Model::Gpt54,
             "gpt-5.4-mini" => Model::Gpt54Mini,
             "gpt-5.4-nano" => Model::Gpt54Nano,
+            "gpt-5.3-chat-latest" => Model::Gpt53ChatLatest,
+            "gpt-5.3-codex" => Model::Gpt53Codex,
             "gpt-5.2-pro" => Model::Gpt52Pro,
             "gpt-5.2" => Model::Gpt52,
             "gpt-5.2-chat-latest" => Model::Gpt52ChatLatest,
@@ -171,7 +180,6 @@ impl Model {
             "o3" => Model::O3,
             "o3-mini" => Model::O3Mini,
             "o1" => Model::O1,
-            "o1-mini" => Model::O1Mini,
             "o1-pro" => Model::O1Pro,
             _ => Model::Custom(name),
         }

--- a/tests/model_string_test.rs
+++ b/tests/model_string_test.rs
@@ -55,15 +55,10 @@ mod tests {
     fn test_grok_model_as_str() {
         let models = vec![
             GrokModel::Grok43,
-            GrokModel::Grok4,
-            GrokModel::Grok4FastReasoning,
-            GrokModel::Grok4FastNonReasoning,
-            GrokModel::Grok41FastReasoning,
-            GrokModel::Grok41FastNonReasoning,
-            GrokModel::Grok3,
-            GrokModel::Grok3Mini,
-            GrokModel::GrokCodeFast1,
-            GrokModel::Grok2Vision,
+            GrokModel::Grok420Reasoning,
+            GrokModel::Grok420NonReasoning,
+            GrokModel::Grok420MultiAgent,
+            GrokModel::GrokBuild01,
         ];
 
         for model in models {
@@ -77,15 +72,10 @@ mod tests {
     fn test_grok_model_from_string() {
         let test_strings = vec![
             "grok-4.3",
-            "grok-4-0709",
-            "grok-4-fast-reasoning",
-            "grok-4-fast-non-reasoning",
-            "grok-4-1-fast-reasoning",
-            "grok-4-1-fast-non-reasoning",
-            "grok-3",
-            "grok-3-mini",
-            "grok-code-fast-1",
-            "grok-2-vision-1212",
+            "grok-4.20-0309-reasoning",
+            "grok-4.20-0309-non-reasoning",
+            "grok-4.20-multi-agent-0309",
+            "grok-build-0.1",
         ];
 
         for original_string in test_strings {


### PR DESCRIPTION
## Summary

Refreshes the convenience model enums (`OpenAIModel`, `AnthropicModel`, `GrokModel`, `GeminiModel`) to match each provider's current lineup. Every identifier was verified against the **official docs** and cross-checked against the **live provider model-list APIs** on 2026-05-28 (per the model-maintenance guidelines in `CLAUDE.md`).

## Changes by provider

### Anthropic
- ➕ **Claude Opus 4.8** (`claude-opus-4-8`) — new flagship / most capable model.
- ➖ Retired the **Claude 3.x family** (`claude-3-7-sonnet`, `claude-3-5-haiku`, `claude-3-haiku`, `claude-3-opus`) — no longer returned by `GET /v1/models` (API returns 10 models, all 4.x, `has_more: false`).
- Default unchanged: `claude-sonnet-4-6` (still the latest Sonnet).

### OpenAI
- ➕ `gpt-5.4-pro`, `gpt-5.3-chat-latest`, `gpt-5.3-codex` (mirrors the existing `gpt-5.2-codex` / `chat-latest` entries).
- ➖ Removed `o1-mini` — retired by OpenAI, absent from the API.
- Default unchanged: `gpt-5.5` (newest frontier model, `2026-04-23`).

### xAI / Grok
- ➕ **grok-4.20** family (`grok-4.20-0309-reasoning`, `grok-4.20-0309-non-reasoning`, `grok-4.20-multi-agent-0309`) and **`grok-build-0.1`** (coding model that supersedes grok-code-fast-1).
- ➖ Removed `grok-4-0709`, `grok-4-fast-*`, `grok-4-1-fast-*`, `grok-3`, `grok-3-mini`, `grok-code-fast-1` (the xAI API now resolves these only as **aliases** of `grok-4.3` / `grok-build-0.1`, not as first-class models) and `grok-2-vision-1212` (fully removed — not even an alias).
- **`grok-4.3` is retained as the default** and is now noted as multimodal (text + image input).

### Gemini
- ➕ `gemini-3.5-flash` (newest Flash) and the GA `gemini-3.1-flash-lite`.
- 🔄 **Default changed: `gemini-3.1-pro-preview` → `gemini-3.5-flash`** (latest Flash, best price/performance) in both `new()` and `from_env()`.
- 🛠 Fixed a stale doc comment claiming `gemini-3-pro-preview` was "shut down" — it is still served by the API.

## Notes
- Other providers' defaults are unchanged and each remains the latest in its tier (`gpt-5.5`, `claude-sonnet-4-6`, `grok-4.3`). Gemini's default now points to `gemini-3.5-flash`.
- Removed identifiers remain usable via the `Custom` variant / `FromStr` string path, so nothing becomes uncallable — the strings still resolve at the provider API (mostly as aliases).
- This touches public enum variants; since the crate is `0.x`, this is allowed under Cargo semver.

## Verification
- `cargo clippy --all-targets` — clean, no warnings.
- `cargo test --lib` — 55 passed.
- `cargo test --doc` — 59 passed, 0 ignored.
- `cargo test --test model_string_test` — 6 passed (`as_str` / `from_string` round-trips updated for the new Grok lineup).
- All new model identifiers confirmed present in the providers' authoritative `/models` list endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)