### PR TITLE
Core ergonomics: runtime AnyClient, dependency/feature hygiene, media safety, model-enum dedup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,18 +59,28 @@ tracing-subscriber = { version = "0.3.23", features = [
 ], optional = true }
 tracing-futures = { version = "0.2.5", optional = true }
 rstructor_derive = { version = "0.2.11", path = "./rstructor_derive", optional = true }
-chrono = "0.4.44" # For date/time validation in examples
-base64 = "0.22.1"
+base64 = { version = "0.22.1", optional = true }
 
 # Feature flags
 [features]
 default = ["openai", "anthropic", "grok", "gemini", "derive", "logging"]
-openai = ["reqwest", "tokio"]
-anthropic = ["reqwest", "tokio"]
-grok = ["reqwest", "tokio"]
-gemini = ["reqwest", "tokio"]
+# Each provider pulls in the shared networking + media stack via `_client`.
+openai = ["_client"]
+anthropic = ["_client"]
+grok = ["_client"]
+gemini = ["_client"]
 derive = ["rstructor_derive"]
 logging = ["tracing-subscriber", "tracing-futures"]
+# Internal: the HTTP client + media stack shared by every networked provider.
+# Not meant to be enabled directly — enable a provider feature instead. Disabling
+# all providers yields a dependency-light, schema-only build (derive + schema, no
+# tokio/reqwest) suitable for generating JSON Schema without making API calls.
+_client = ["reqwest", "tokio", "base64"]
+
+[dev-dependencies]
+# Used only by examples and tests (date/time fields, custom types); not part of
+# the public dependency closure.
+chrono = { version = "0.4.44", features = ["serde"] }
 
 [workspace]
 members = ["rstructor_derive"]

--- a/README.md
+++ b/README.md
@@ -79,6 +79,25 @@ let client = OpenAIClient::new("key")?
     .model("llama-3.1-70b");
 ```
 
+### Selecting a provider at runtime
+
+`LLMClient::materialize` is generic, so the trait isn't object-safe (`Box<dyn LLMClient>` is impossible). Use `AnyClient` when the provider is decided at runtime (CLI flag, config, env) and you want to store it in a single type:
+
+```rust
+use rstructor::{AnyClient, Provider, LLMClient};
+
+// Pick a provider dynamically, reading its key from the environment.
+let provider = Provider::Anthropic; // e.g. parsed from a config file
+let client = AnyClient::from_env_for(provider)?;
+let movie: Movie = client.materialize("Describe Inception").await?;
+
+// Or auto-detect from whichever API key is set:
+let client = AnyClient::from_env()?;
+
+// Or wrap a pre-configured client:
+let client: AnyClient = OpenAIClient::from_env()?.model("gpt-5.5").into();
+```
+
 ## Validation
 
 Add custom validation with automatic retry on failure:
@@ -313,9 +332,18 @@ match client.materialize::<Movie>("...").await {
 rstructor = { version = "0.2", features = ["openai", "anthropic", "grok", "gemini"] }
 ```
 
-- `openai`, `anthropic`, `grok`, `gemini` — Provider backends
+- `openai`, `anthropic`, `grok`, `gemini` — Provider backends (each pulls in the shared HTTP/`tokio` stack)
 - `derive` — Derive macro (default)
 - `logging` — Tracing integration
+
+All features are on by default. For a **schema-only build** — generate JSON Schema from your types with no networking, `tokio`, or `reqwest` — disable the providers:
+
+```toml
+[dependencies]
+rstructor = { version = "0.2", default-features = false, features = ["derive"] }
+```
+
+This keeps the derive macro, `SchemaType`, the `Instructor` trait, and the `LLMClient` trait (so you can implement your own backend) without the async/HTTP dependency tree.
 
 ## Examples
 

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -2,10 +2,10 @@ use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::str::FromStr;
 use std::time::Duration;
 use tracing::{debug, error, info, instrument, trace, warn};
 
+use crate::backend::model_macro::define_model_enum;
 use crate::backend::{
     AnthropicMessageContent, ChatMessage, GenerateResult, LLMClient, MaterializeInternalOutput,
     MaterializeResult, ModelInfo, ThinkingLevel, TokenUsage, ValidationFailureContext,
@@ -16,110 +16,50 @@ use crate::backend::{
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
 
-/// Anthropic models available for completion
-///
-/// For the latest available models and their identifiers, check the
-/// [Anthropic Models Documentation](https://docs.anthropic.com/en/docs/about-claude/models/all-models).
-///
-/// # Using Custom Models
-///
-/// You can specify any model name as a string using `Custom` variant or `FromStr`:
-///
-/// ```rust
-/// use rstructor::AnthropicModel;
-/// use std::str::FromStr;
-///
-/// // Using Custom variant
-/// let model = AnthropicModel::Custom("claude-custom".to_string());
-///
-/// // Using FromStr (useful for config files)
-/// let model = AnthropicModel::from_str("claude-custom").unwrap();
-///
-/// // Or use the convenience method
-/// let model = AnthropicModel::from_string("claude-custom");
-/// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum AnthropicModel {
-    /// Claude Opus 4.8 (latest most capable generally available model)
-    ClaudeOpus48,
-    /// Claude Opus 4.7 (previous most capable model)
-    ClaudeOpus47,
-    /// Claude Sonnet 4.6 (latest balanced model)
-    ClaudeSonnet46,
-    /// Claude Opus 4.6 (previous most capable model)
-    ClaudeOpus46,
-    /// Claude Opus 4.5 (enhanced Opus 4.5)
-    ClaudeOpus45,
-    /// Claude Haiku 4.5 (latest fastest model)
-    ClaudeHaiku45,
-    /// Claude Sonnet 4.5 (previous balanced model)
-    ClaudeSonnet45,
-    /// Claude Opus 4.1 (enhanced reasoning capabilities)
-    ClaudeOpus41,
-    /// Claude Opus 4 (high-intelligence model)
-    ClaudeOpus4,
-    /// Claude Sonnet 4 (balanced performance model)
-    ClaudeSonnet4,
-    /// Custom model name (for new models or Anthropic-compatible endpoints)
-    Custom(String),
-}
-
-impl AnthropicModel {
-    pub fn as_str(&self) -> &str {
-        match self {
-            AnthropicModel::ClaudeOpus48 => "claude-opus-4-8",
-            AnthropicModel::ClaudeOpus47 => "claude-opus-4-7",
-            AnthropicModel::ClaudeSonnet46 => "claude-sonnet-4-6",
-            AnthropicModel::ClaudeOpus46 => "claude-opus-4-6",
-            AnthropicModel::ClaudeOpus45 => "claude-opus-4-5-20251101",
-            AnthropicModel::ClaudeHaiku45 => "claude-haiku-4-5-20251001",
-            AnthropicModel::ClaudeSonnet45 => "claude-sonnet-4-5-20250929",
-            AnthropicModel::ClaudeOpus41 => "claude-opus-4-1-20250805",
-            AnthropicModel::ClaudeOpus4 => "claude-opus-4-20250514",
-            AnthropicModel::ClaudeSonnet4 => "claude-sonnet-4-20250514",
-            AnthropicModel::Custom(name) => name,
-        }
-    }
-
-    /// Create a model from a string. This is a convenience method that always succeeds.
+define_model_enum! {
+    /// Anthropic models available for completion
     ///
-    /// If the string matches a known model variant, it returns that variant.
-    /// Otherwise, it returns `Custom(name)`.
-    pub fn from_string(name: impl Into<String>) -> Self {
-        let name = name.into();
-        match name.as_str() {
-            "claude-opus-4-8" => AnthropicModel::ClaudeOpus48,
-            "claude-opus-4-7" => AnthropicModel::ClaudeOpus47,
-            "claude-sonnet-4-6" => AnthropicModel::ClaudeSonnet46,
-            "claude-opus-4-6" => AnthropicModel::ClaudeOpus46,
-            "claude-opus-4-5-20251101" => AnthropicModel::ClaudeOpus45,
-            "claude-haiku-4-5-20251001" => AnthropicModel::ClaudeHaiku45,
-            "claude-sonnet-4-5-20250929" => AnthropicModel::ClaudeSonnet45,
-            "claude-opus-4-1-20250805" => AnthropicModel::ClaudeOpus41,
-            "claude-opus-4-20250514" => AnthropicModel::ClaudeOpus4,
-            "claude-sonnet-4-20250514" => AnthropicModel::ClaudeSonnet4,
-            _ => AnthropicModel::Custom(name),
-        }
-    }
-}
-
-impl FromStr for AnthropicModel {
-    type Err = std::convert::Infallible;
-
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        Ok(AnthropicModel::from_string(s))
-    }
-}
-
-impl From<&str> for AnthropicModel {
-    fn from(s: &str) -> Self {
-        AnthropicModel::from_string(s)
-    }
-}
-
-impl From<String> for AnthropicModel {
-    fn from(s: String) -> Self {
-        AnthropicModel::from_string(s)
+    /// For the latest available models and their identifiers, check the
+    /// [Anthropic Models Documentation](https://docs.anthropic.com/en/docs/about-claude/models/all-models).
+    ///
+    /// # Using Custom Models
+    ///
+    /// You can specify any model name as a string using `Custom` variant or `FromStr`:
+    ///
+    /// ```rust
+    /// use rstructor::AnthropicModel;
+    /// use std::str::FromStr;
+    ///
+    /// // Using Custom variant
+    /// let model = AnthropicModel::Custom("claude-custom".to_string());
+    ///
+    /// // Using FromStr (useful for config files)
+    /// let model = AnthropicModel::from_str("claude-custom").unwrap();
+    ///
+    /// // Or use the convenience method
+    /// let model = AnthropicModel::from_string("claude-custom");
+    /// ```
+    pub enum AnthropicModel {
+        /// Claude Opus 4.8 (latest most capable generally available model)
+        ClaudeOpus48 => "claude-opus-4-8",
+        /// Claude Opus 4.7 (previous most capable model)
+        ClaudeOpus47 => "claude-opus-4-7",
+        /// Claude Sonnet 4.6 (latest balanced model)
+        ClaudeSonnet46 => "claude-sonnet-4-6",
+        /// Claude Opus 4.6 (previous most capable model)
+        ClaudeOpus46 => "claude-opus-4-6",
+        /// Claude Opus 4.5 (enhanced Opus 4.5)
+        ClaudeOpus45 => "claude-opus-4-5-20251101",
+        /// Claude Haiku 4.5 (latest fastest model)
+        ClaudeHaiku45 => "claude-haiku-4-5-20251001",
+        /// Claude Sonnet 4.5 (previous balanced model)
+        ClaudeSonnet45 => "claude-sonnet-4-5-20250929",
+        /// Claude Opus 4.1 (enhanced reasoning capabilities)
+        ClaudeOpus41 => "claude-opus-4-1-20250805",
+        /// Claude Opus 4 (high-intelligence model)
+        ClaudeOpus4 => "claude-opus-4-20250514",
+        /// Claude Sonnet 4 (balanced performance model)
+        ClaudeSonnet4 => "claude-sonnet-4-20250514",
     }
 }
 

--- a/src/backend/any_client.rs
+++ b/src/backend/any_client.rs
@@ -1,0 +1,252 @@
+//! A provider-agnostic client selectable at runtime.
+//!
+//! [`LLMClient::materialize`](crate::LLMClient::materialize) is generic over the
+//! target type, which makes the `LLMClient` trait non-object-safe — you cannot
+//! store a provider behind `Box<dyn LLMClient>` or pick one dynamically through a
+//! trait object. [`AnyClient`] solves the common need behind that limitation
+//! ("choose a provider at runtime and keep it in a single type") by wrapping each
+//! concrete client in an enum that itself implements [`LLMClient`].
+
+use async_trait::async_trait;
+use serde::de::DeserializeOwned;
+
+use crate::backend::usage::{GenerateResult, MaterializeResult};
+use crate::backend::{LLMClient, MediaFile, ModelInfo};
+use crate::error::{ApiErrorKind, RStructorError, Result};
+use crate::model::Instructor;
+
+#[cfg(feature = "anthropic")]
+use crate::backend::anthropic::AnthropicClient;
+#[cfg(feature = "gemini")]
+use crate::backend::gemini::GeminiClient;
+#[cfg(feature = "grok")]
+use crate::backend::grok::GrokClient;
+#[cfg(feature = "openai")]
+use crate::backend::openai::OpenAIClient;
+
+/// Identifies an LLM provider for runtime selection via [`AnyClient`].
+///
+/// Only providers enabled via Cargo features are present as variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Provider {
+    /// OpenAI (reads `OPENAI_API_KEY`).
+    #[cfg(feature = "openai")]
+    OpenAI,
+    /// Anthropic (reads `ANTHROPIC_API_KEY`).
+    #[cfg(feature = "anthropic")]
+    Anthropic,
+    /// xAI / Grok (reads `XAI_API_KEY`).
+    #[cfg(feature = "grok")]
+    Grok,
+    /// Google Gemini (reads `GEMINI_API_KEY`).
+    #[cfg(feature = "gemini")]
+    Gemini,
+}
+
+/// A provider-agnostic client chosen at runtime.
+///
+/// Because [`LLMClient`] has a generic `materialize` method it is not
+/// object-safe, so `Box<dyn LLMClient>` is impossible. `AnyClient` is an enum
+/// over the concrete clients that itself implements [`LLMClient`], giving you a
+/// single, `Clone`, `Send + Sync` type that can hold whichever provider you
+/// selected at runtime (from a CLI flag, config file, env, etc.).
+///
+/// Construct it with [`from_env_for`](Self::from_env_for), with
+/// [`LLMClient::from_env`] (which auto-detects from the environment), or with
+/// `From<ConcreteClient>` when you need custom configuration:
+///
+/// ```no_run
+/// # async fn ex() -> Result<(), Box<dyn std::error::Error>> {
+/// use rstructor::{AnyClient, Provider, LLMClient, Instructor};
+/// use serde::{Serialize, Deserialize};
+///
+/// #[derive(Instructor, Serialize, Deserialize, Debug)]
+/// struct Movie {
+///     title: String,
+/// }
+///
+/// // Provider decided at runtime.
+/// let provider = Provider::Anthropic;
+/// let client = AnyClient::from_env_for(provider)?;
+///
+/// let movie: Movie = client.materialize("Describe Inception").await?;
+/// println!("{}", movie.title);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Wrapping a pre-configured client:
+///
+/// ```no_run
+/// # fn ex() -> Result<(), Box<dyn std::error::Error>> {
+/// use rstructor::{AnyClient, OpenAIClient, OpenAIModel};
+///
+/// let configured = OpenAIClient::from_env()?.model(OpenAIModel::Gpt55);
+/// let client: AnyClient = configured.into();
+/// # let _ = client;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone)]
+pub enum AnyClient {
+    /// An OpenAI client.
+    #[cfg(feature = "openai")]
+    OpenAI(OpenAIClient),
+    /// An Anthropic client.
+    #[cfg(feature = "anthropic")]
+    Anthropic(AnthropicClient),
+    /// A Grok client.
+    #[cfg(feature = "grok")]
+    Grok(GrokClient),
+    /// A Gemini client.
+    #[cfg(feature = "gemini")]
+    Gemini(GeminiClient),
+}
+
+impl AnyClient {
+    /// Build a client for `provider`, reading its API key from the environment.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the provider's environment variable is not set.
+    pub fn from_env_for(provider: Provider) -> Result<Self> {
+        match provider {
+            #[cfg(feature = "openai")]
+            Provider::OpenAI => Ok(Self::OpenAI(OpenAIClient::from_env()?)),
+            #[cfg(feature = "anthropic")]
+            Provider::Anthropic => Ok(Self::Anthropic(AnthropicClient::from_env()?)),
+            #[cfg(feature = "grok")]
+            Provider::Grok => Ok(Self::Grok(GrokClient::from_env()?)),
+            #[cfg(feature = "gemini")]
+            Provider::Gemini => Ok(Self::Gemini(GeminiClient::from_env()?)),
+        }
+    }
+
+    /// Return the [`Provider`] backing this client.
+    #[must_use]
+    pub fn provider(&self) -> Provider {
+        match self {
+            #[cfg(feature = "openai")]
+            Self::OpenAI(_) => Provider::OpenAI,
+            #[cfg(feature = "anthropic")]
+            Self::Anthropic(_) => Provider::Anthropic,
+            #[cfg(feature = "grok")]
+            Self::Grok(_) => Provider::Grok,
+            #[cfg(feature = "gemini")]
+            Self::Gemini(_) => Provider::Gemini,
+        }
+    }
+}
+
+#[cfg(feature = "openai")]
+impl From<OpenAIClient> for AnyClient {
+    fn from(client: OpenAIClient) -> Self {
+        Self::OpenAI(client)
+    }
+}
+
+#[cfg(feature = "anthropic")]
+impl From<AnthropicClient> for AnyClient {
+    fn from(client: AnthropicClient) -> Self {
+        Self::Anthropic(client)
+    }
+}
+
+#[cfg(feature = "grok")]
+impl From<GrokClient> for AnyClient {
+    fn from(client: GrokClient) -> Self {
+        Self::Grok(client)
+    }
+}
+
+#[cfg(feature = "gemini")]
+impl From<GeminiClient> for AnyClient {
+    fn from(client: GeminiClient) -> Self {
+        Self::Gemini(client)
+    }
+}
+
+/// Dispatch a method call to whichever provider this `AnyClient` wraps.
+macro_rules! dispatch {
+    ($self:expr, $client:ident => $call:expr) => {
+        match $self {
+            #[cfg(feature = "openai")]
+            Self::OpenAI($client) => $call,
+            #[cfg(feature = "anthropic")]
+            Self::Anthropic($client) => $call,
+            #[cfg(feature = "grok")]
+            Self::Grok($client) => $call,
+            #[cfg(feature = "gemini")]
+            Self::Gemini($client) => $call,
+        }
+    };
+}
+
+#[async_trait]
+impl LLMClient for AnyClient {
+    async fn materialize<T>(&self, prompt: &str) -> Result<T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        dispatch!(self, c => c.materialize(prompt).await)
+    }
+
+    async fn materialize_with_media<T>(&self, prompt: &str, media: &[MediaFile]) -> Result<T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        dispatch!(self, c => c.materialize_with_media(prompt, media).await)
+    }
+
+    async fn materialize_with_metadata<T>(&self, prompt: &str) -> Result<MaterializeResult<T>>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        dispatch!(self, c => c.materialize_with_metadata(prompt).await)
+    }
+
+    async fn generate(&self, prompt: &str) -> Result<String> {
+        dispatch!(self, c => c.generate(prompt).await)
+    }
+
+    async fn generate_with_metadata(&self, prompt: &str) -> Result<GenerateResult> {
+        dispatch!(self, c => c.generate_with_metadata(prompt).await)
+    }
+
+    /// Auto-detect a provider from the environment.
+    ///
+    /// Enabled providers are tried in order (OpenAI, Anthropic, Grok, Gemini)
+    /// and the first one whose API-key variable is set is used. For deterministic
+    /// selection, prefer [`AnyClient::from_env_for`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`ApiErrorKind::AuthenticationFailed`] error if none of the
+    /// enabled providers' API-key variables are set.
+    fn from_env() -> Result<Self> {
+        #[cfg(feature = "openai")]
+        if std::env::var("OPENAI_API_KEY").is_ok() {
+            return Ok(Self::OpenAI(OpenAIClient::from_env()?));
+        }
+        #[cfg(feature = "anthropic")]
+        if std::env::var("ANTHROPIC_API_KEY").is_ok() {
+            return Ok(Self::Anthropic(AnthropicClient::from_env()?));
+        }
+        #[cfg(feature = "grok")]
+        if std::env::var("XAI_API_KEY").is_ok() {
+            return Ok(Self::Grok(GrokClient::from_env()?));
+        }
+        #[cfg(feature = "gemini")]
+        if std::env::var("GEMINI_API_KEY").is_ok() {
+            return Ok(Self::Gemini(GeminiClient::from_env()?));
+        }
+        Err(RStructorError::api_error(
+            "AnyClient",
+            ApiErrorKind::AuthenticationFailed,
+        ))
+    }
+
+    async fn list_models(&self) -> Result<Vec<ModelInfo>> {
+        dispatch!(self, c => c.list_models().await)
+    }
+}

--- a/src/backend/client.rs
+++ b/src/backend/client.rs
@@ -81,6 +81,7 @@ impl MediaFile {
     /// assert!(media.data.is_some());
     /// assert!(media.uri.is_empty());
     /// ```
+    #[cfg(feature = "_client")]
     #[must_use]
     pub fn from_bytes(data: impl AsRef<[u8]>, mime_type: impl Into<String>) -> Self {
         use base64::Engine;
@@ -215,12 +216,22 @@ pub trait LLMClient {
 
     /// Materialize a structured object with media references (if supported).
     ///
-    /// Providers that do not support media inputs ignore the `media` parameter.
-    async fn materialize_with_media<T>(&self, prompt: &str, _media: &[MediaFile]) -> Result<T>
+    /// The default implementation forwards to [`materialize`](Self::materialize)
+    /// when no media is provided, and otherwise returns
+    /// [`RStructorError::Unsupported`](crate::RStructorError::Unsupported) so that
+    /// media is never silently dropped. Providers with media support override this
+    /// method. All four built-in clients (OpenAI, Anthropic, Grok, Gemini) support media.
+    async fn materialize_with_media<T>(&self, prompt: &str, media: &[MediaFile]) -> Result<T>
     where
         T: Instructor + DeserializeOwned + Send + 'static,
     {
-        self.materialize(prompt).await
+        if media.is_empty() {
+            self.materialize(prompt).await
+        } else {
+            Err(crate::error::RStructorError::Unsupported(
+                "this client does not support media inputs".to_string(),
+            ))
+        }
     }
 
     /// Materialize a structured object with metadata (token usage).

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -2,10 +2,10 @@ use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::str::FromStr;
 use std::time::Duration;
 use tracing::{debug, error, info, instrument, trace, warn};
 
+use crate::backend::model_macro::define_model_enum;
 use crate::backend::{
     ChatMessage, GenerateResult, LLMClient, MaterializeInternalOutput, MaterializeResult,
     ModelInfo, ThinkingLevel, TokenUsage, ValidationFailureContext, check_response_status,
@@ -15,144 +15,68 @@ use crate::backend::{
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
 
-/// Gemini models available for completion
-///
-/// For the latest available models and their identifiers, check the
-/// [Google AI Models Documentation](https://ai.google.dev/models).
-/// Use the API endpoint `GET https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY`
-/// to get the current list of available models.
-///
-/// # Using Custom Models
-///
-/// You can specify any model name as a string using `Custom` variant or `FromStr`:
-///
-/// ```rust
-/// use rstructor::GeminiModel;
-/// use std::str::FromStr;
-///
-/// // Using Custom variant
-/// let model = GeminiModel::Custom("gemini-custom".to_string());
-///
-/// // Using FromStr (useful for config files)
-/// let model = GeminiModel::from_str("gemini-custom").unwrap();
-///
-/// // Or use the convenience method
-/// let model = GeminiModel::from_string("gemini-custom");
-/// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Model {
-    /// Gemini 3.5 Flash (latest Flash model, best price/performance, default)
-    Gemini35Flash,
-    /// Gemini 3.1 Pro Preview (latest Pro model)
-    Gemini31ProPreview,
-    /// Gemini 3.1 Pro Preview Custom Tools (agentic custom-tool variant)
-    Gemini31ProPreviewCustomTools,
-    /// Gemini 3 Flash Preview (preview Flash model)
-    Gemini3FlashPreview,
-    /// Gemini 3.1 Flash-Lite (cost-efficient multimodal model)
-    Gemini31FlashLite,
-    /// Gemini 3.1 Flash-Lite Preview (preview cost-efficient multimodal model)
-    Gemini31FlashLitePreview,
-    /// Gemini 3 Pro Preview (previous preview Pro model)
-    Gemini3ProPreview,
-    /// Gemini 2.5 Pro (latest production Pro model)
-    Gemini25Pro,
-    /// Gemini 2.5 Flash (latest production Flash model, best price/performance)
-    Gemini25Flash,
-    /// Gemini 2.5 Flash Lite (smaller, faster variant)
-    Gemini25FlashLite,
-    /// Gemini 2.5 Flash Image (image generation/analysis tuned variant)
-    Gemini25FlashImage,
-    /// Gemini 2.0 Flash (deprecated 2.0 Flash model)
-    Gemini20Flash,
-    /// Gemini 2.0 Flash 001 (deprecated specific version of 2.0 Flash)
-    Gemini20Flash001,
-    /// Gemini 2.0 Flash Lite (deprecated smaller 2.0 Flash variant)
-    Gemini20FlashLite,
-    /// Gemini 2.0 Flash Lite 001 (deprecated specific version of 2.0 Flash Lite)
-    Gemini20FlashLite001,
-    /// Gemini Pro Latest (alias for latest Pro model)
-    GeminiProLatest,
-    /// Gemini Flash Latest (alias for latest Flash model)
-    GeminiFlashLatest,
-    /// Gemini Flash Lite Latest (alias for latest Flash Lite model)
-    GeminiFlashLiteLatest,
-    /// Custom model name (for new models or Gemini-compatible endpoints)
-    Custom(String),
-}
-
-impl Model {
-    pub fn as_str(&self) -> &str {
-        match self {
-            Model::Gemini35Flash => "gemini-3.5-flash",
-            Model::Gemini31ProPreview => "gemini-3.1-pro-preview",
-            Model::Gemini31ProPreviewCustomTools => "gemini-3.1-pro-preview-customtools",
-            Model::Gemini3FlashPreview => "gemini-3-flash-preview",
-            Model::Gemini31FlashLite => "gemini-3.1-flash-lite",
-            Model::Gemini31FlashLitePreview => "gemini-3.1-flash-lite-preview",
-            Model::Gemini3ProPreview => "gemini-3-pro-preview",
-            Model::Gemini25Pro => "gemini-2.5-pro",
-            Model::Gemini25Flash => "gemini-2.5-flash",
-            Model::Gemini25FlashLite => "gemini-2.5-flash-lite",
-            Model::Gemini25FlashImage => "gemini-2.5-flash-image",
-            Model::Gemini20Flash => "gemini-2.0-flash",
-            Model::Gemini20Flash001 => "gemini-2.0-flash-001",
-            Model::Gemini20FlashLite => "gemini-2.0-flash-lite",
-            Model::Gemini20FlashLite001 => "gemini-2.0-flash-lite-001",
-            Model::GeminiProLatest => "gemini-pro-latest",
-            Model::GeminiFlashLatest => "gemini-flash-latest",
-            Model::GeminiFlashLiteLatest => "gemini-flash-lite-latest",
-            Model::Custom(name) => name,
-        }
-    }
-
-    /// Create a model from a string. This is a convenience method that always succeeds.
+define_model_enum! {
+    /// Gemini models available for completion
     ///
-    /// If the string matches a known model variant, it returns that variant.
-    /// Otherwise, it returns `Custom(name)`.
-    pub fn from_string(name: impl Into<String>) -> Self {
-        let name = name.into();
-        match name.as_str() {
-            "gemini-3.5-flash" => Model::Gemini35Flash,
-            "gemini-3.1-pro-preview" => Model::Gemini31ProPreview,
-            "gemini-3.1-pro-preview-customtools" => Model::Gemini31ProPreviewCustomTools,
-            "gemini-3-flash-preview" => Model::Gemini3FlashPreview,
-            "gemini-3.1-flash-lite" => Model::Gemini31FlashLite,
-            "gemini-3.1-flash-lite-preview" => Model::Gemini31FlashLitePreview,
-            "gemini-3-pro-preview" => Model::Gemini3ProPreview,
-            "gemini-2.5-pro" => Model::Gemini25Pro,
-            "gemini-2.5-flash" => Model::Gemini25Flash,
-            "gemini-2.5-flash-lite" => Model::Gemini25FlashLite,
-            "gemini-2.5-flash-image" => Model::Gemini25FlashImage,
-            "gemini-2.0-flash" => Model::Gemini20Flash,
-            "gemini-2.0-flash-001" => Model::Gemini20Flash001,
-            "gemini-2.0-flash-lite" => Model::Gemini20FlashLite,
-            "gemini-2.0-flash-lite-001" => Model::Gemini20FlashLite001,
-            "gemini-pro-latest" => Model::GeminiProLatest,
-            "gemini-flash-latest" => Model::GeminiFlashLatest,
-            "gemini-flash-lite-latest" => Model::GeminiFlashLiteLatest,
-            _ => Model::Custom(name),
-        }
-    }
-}
-
-impl FromStr for Model {
-    type Err = std::convert::Infallible;
-
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        Ok(Model::from_string(s))
-    }
-}
-
-impl From<&str> for Model {
-    fn from(s: &str) -> Self {
-        Model::from_string(s)
-    }
-}
-
-impl From<String> for Model {
-    fn from(s: String) -> Self {
-        Model::from_string(s)
+    /// For the latest available models and their identifiers, check the
+    /// [Google AI Models Documentation](https://ai.google.dev/models).
+    /// Use the API endpoint `GET https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY`
+    /// to get the current list of available models.
+    ///
+    /// # Using Custom Models
+    ///
+    /// You can specify any model name as a string using `Custom` variant or `FromStr`:
+    ///
+    /// ```rust
+    /// use rstructor::GeminiModel;
+    /// use std::str::FromStr;
+    ///
+    /// // Using Custom variant
+    /// let model = GeminiModel::Custom("gemini-custom".to_string());
+    ///
+    /// // Using FromStr (useful for config files)
+    /// let model = GeminiModel::from_str("gemini-custom").unwrap();
+    ///
+    /// // Or use the convenience method
+    /// let model = GeminiModel::from_string("gemini-custom");
+    /// ```
+    pub enum Model {
+        /// Gemini 3.5 Flash (latest Flash model, best price/performance, default)
+        Gemini35Flash => "gemini-3.5-flash",
+        /// Gemini 3.1 Pro Preview (latest Pro model)
+        Gemini31ProPreview => "gemini-3.1-pro-preview",
+        /// Gemini 3.1 Pro Preview Custom Tools (agentic custom-tool variant)
+        Gemini31ProPreviewCustomTools => "gemini-3.1-pro-preview-customtools",
+        /// Gemini 3 Flash Preview (preview Flash model)
+        Gemini3FlashPreview => "gemini-3-flash-preview",
+        /// Gemini 3.1 Flash-Lite (cost-efficient multimodal model)
+        Gemini31FlashLite => "gemini-3.1-flash-lite",
+        /// Gemini 3.1 Flash-Lite Preview (preview cost-efficient multimodal model)
+        Gemini31FlashLitePreview => "gemini-3.1-flash-lite-preview",
+        /// Gemini 3 Pro Preview (previous preview Pro model)
+        Gemini3ProPreview => "gemini-3-pro-preview",
+        /// Gemini 2.5 Pro (latest production Pro model)
+        Gemini25Pro => "gemini-2.5-pro",
+        /// Gemini 2.5 Flash (latest production Flash model, best price/performance)
+        Gemini25Flash => "gemini-2.5-flash",
+        /// Gemini 2.5 Flash Lite (smaller, faster variant)
+        Gemini25FlashLite => "gemini-2.5-flash-lite",
+        /// Gemini 2.5 Flash Image (image generation/analysis tuned variant)
+        Gemini25FlashImage => "gemini-2.5-flash-image",
+        /// Gemini 2.0 Flash (deprecated 2.0 Flash model)
+        Gemini20Flash => "gemini-2.0-flash",
+        /// Gemini 2.0 Flash 001 (deprecated specific version of 2.0 Flash)
+        Gemini20Flash001 => "gemini-2.0-flash-001",
+        /// Gemini 2.0 Flash Lite (deprecated smaller 2.0 Flash variant)
+        Gemini20FlashLite => "gemini-2.0-flash-lite",
+        /// Gemini 2.0 Flash Lite 001 (deprecated specific version of 2.0 Flash Lite)
+        Gemini20FlashLite001 => "gemini-2.0-flash-lite-001",
+        /// Gemini Pro Latest (alias for latest Pro model)
+        GeminiProLatest => "gemini-pro-latest",
+        /// Gemini Flash Latest (alias for latest Flash model)
+        GeminiFlashLatest => "gemini-flash-latest",
+        /// Gemini Flash Lite Latest (alias for latest Flash Lite model)
+        GeminiFlashLiteLatest => "gemini-flash-lite-latest",
     }
 }
 

--- a/src/backend/grok.rs
+++ b/src/backend/grok.rs
@@ -1,9 +1,9 @@
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
-use std::str::FromStr;
 use std::time::Duration;
 use tracing::{debug, error, info, instrument, trace, warn};
 
+use crate::backend::model_macro::define_model_enum;
 use crate::backend::{
     ChatMessage, GenerateResult, LLMClient, MaterializeInternalOutput, MaterializeResult,
     ModelInfo, OpenAICompatibleChatCompletionRequest, OpenAICompatibleChatCompletionResponse,
@@ -15,91 +15,41 @@ use crate::backend::{
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
 
-/// Grok models available for completion
-///
-/// These are convenience variants for common Grok models.
-/// For the latest available models and their identifiers, check the
-/// [xAI Models Documentation](https://docs.x.ai/docs/models).
-///
-/// # Using Custom Models
-///
-/// You can specify any model name as a string using `Custom` variant or `FromStr`:
-///
-/// ```rust
-/// use rstructor::GrokModel;
-/// use std::str::FromStr;
-///
-/// // Using Custom variant
-/// let model = GrokModel::Custom("grok-custom".to_string());
-///
-/// // Using FromStr (useful for config files)
-/// let model = GrokModel::from_str("grok-custom").unwrap();
-///
-/// // Or use the convenience method
-/// let model = GrokModel::from_string("grok-custom");
-/// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Model {
-    /// Grok 4.3 (latest recommended chat model, multimodal text + image input)
-    Grok43,
-    /// Grok 4.20 Reasoning (reasoning-optimized variant)
-    Grok420Reasoning,
-    /// Grok 4.20 Non-Reasoning (lower-latency non-reasoning variant)
-    Grok420NonReasoning,
-    /// Grok 4.20 Multi-Agent (agentic multi-agent variant)
-    Grok420MultiAgent,
-    /// Grok Build 0.1 (coding-optimized model; supersedes grok-code-fast-1)
-    GrokBuild01,
-    /// Custom model name (for new models or Grok-compatible endpoints)
-    Custom(String),
-}
-
-impl Model {
-    pub fn as_str(&self) -> &str {
-        match self {
-            Model::Grok43 => "grok-4.3",
-            Model::Grok420Reasoning => "grok-4.20-0309-reasoning",
-            Model::Grok420NonReasoning => "grok-4.20-0309-non-reasoning",
-            Model::Grok420MultiAgent => "grok-4.20-multi-agent-0309",
-            Model::GrokBuild01 => "grok-build-0.1",
-            Model::Custom(name) => name,
-        }
-    }
-
-    /// Create a model from a string. This is a convenience method that always succeeds.
+define_model_enum! {
+    /// Grok models available for completion
     ///
-    /// If the string matches a known model variant, it returns that variant.
-    /// Otherwise, it returns `Custom(name)`.
-    pub fn from_string(name: impl Into<String>) -> Self {
-        let name = name.into();
-        match name.as_str() {
-            "grok-4.3" => Model::Grok43,
-            "grok-4.20-0309-reasoning" => Model::Grok420Reasoning,
-            "grok-4.20-0309-non-reasoning" => Model::Grok420NonReasoning,
-            "grok-4.20-multi-agent-0309" => Model::Grok420MultiAgent,
-            "grok-build-0.1" => Model::GrokBuild01,
-            _ => Model::Custom(name),
-        }
-    }
-}
-
-impl FromStr for Model {
-    type Err = std::convert::Infallible;
-
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        Ok(Model::from_string(s))
-    }
-}
-
-impl From<&str> for Model {
-    fn from(s: &str) -> Self {
-        Model::from_string(s)
-    }
-}
-
-impl From<String> for Model {
-    fn from(s: String) -> Self {
-        Model::from_string(s)
+    /// These are convenience variants for common Grok models.
+    /// For the latest available models and their identifiers, check the
+    /// [xAI Models Documentation](https://docs.x.ai/docs/models).
+    ///
+    /// # Using Custom Models
+    ///
+    /// You can specify any model name as a string using `Custom` variant or `FromStr`:
+    ///
+    /// ```rust
+    /// use rstructor::GrokModel;
+    /// use std::str::FromStr;
+    ///
+    /// // Using Custom variant
+    /// let model = GrokModel::Custom("grok-custom".to_string());
+    ///
+    /// // Using FromStr (useful for config files)
+    /// let model = GrokModel::from_str("grok-custom").unwrap();
+    ///
+    /// // Or use the convenience method
+    /// let model = GrokModel::from_string("grok-custom");
+    /// ```
+    pub enum Model {
+        /// Grok 4.3 (latest recommended chat model, multimodal text + image input)
+        Grok43 => "grok-4.3",
+        /// Grok 4.20 Reasoning (reasoning-optimized variant)
+        Grok420Reasoning => "grok-4.20-0309-reasoning",
+        /// Grok 4.20 Non-Reasoning (lower-latency non-reasoning variant)
+        Grok420NonReasoning => "grok-4.20-0309-non-reasoning",
+        /// Grok 4.20 Multi-Agent (agentic multi-agent variant)
+        Grok420MultiAgent => "grok-4.20-multi-agent-0309",
+        /// Grok Build 0.1 (coding-optimized model; supersedes grok-code-fast-1)
+        GrokBuild01 => "grok-build-0.1",
     }
 }
 

--- a/src/backend/messages.rs
+++ b/src/backend/messages.rs
@@ -105,6 +105,7 @@ impl ChatMessage {
 ///
 /// This struct captures both the successfully parsed data and the raw response string,
 /// which is needed for building conversation history during retries.
+#[cfg(feature = "_client")]
 #[derive(Debug)]
 pub struct MaterializeInternalOutput<T> {
     /// The parsed and validated data
@@ -118,6 +119,7 @@ pub struct MaterializeInternalOutput<T> {
     pub usage: Option<crate::backend::TokenUsage>,
 }
 
+#[cfg(feature = "_client")]
 impl<T> MaterializeInternalOutput<T> {
     /// Create a new output with all fields.
     pub fn new(data: T, raw_response: String, usage: Option<crate::backend::TokenUsage>) -> Self {
@@ -133,6 +135,7 @@ impl<T> MaterializeInternalOutput<T> {
 ///
 /// This allows the retry logic to include the failed response in the conversation
 /// history, enabling the model to see what it generated wrong.
+#[cfg(feature = "_client")]
 #[derive(Debug, Clone)]
 pub struct ValidationFailureContext {
     /// The validation error message
@@ -141,6 +144,7 @@ pub struct ValidationFailureContext {
     pub raw_response: String,
 }
 
+#[cfg(feature = "_client")]
 impl ValidationFailureContext {
     /// Create a new validation failure context.
     pub fn new(error_message: impl Into<String>, raw_response: impl Into<String>) -> Self {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,8 +1,15 @@
+#[cfg(feature = "_client")]
+mod any_client;
 pub mod client;
+#[cfg(feature = "_client")]
 mod media;
 mod messages;
+#[cfg(feature = "_client")]
+mod model_macro;
+#[cfg(feature = "_client")]
 mod openai_compatible;
 pub mod usage;
+#[cfg(feature = "_client")]
 mod utils;
 
 #[cfg(feature = "anthropic")]
@@ -14,8 +21,12 @@ pub mod grok;
 #[cfg(feature = "openai")]
 pub mod openai;
 
+#[cfg(feature = "_client")]
+pub use any_client::{AnyClient, Provider};
 pub use client::{LLMClient, MediaFile};
-pub use messages::{ChatMessage, ChatRole, MaterializeInternalOutput, ValidationFailureContext};
+pub use messages::{ChatMessage, ChatRole};
+#[cfg(feature = "_client")]
+pub use messages::{MaterializeInternalOutput, ValidationFailureContext};
 pub use usage::{GenerateResult, MaterializeResult, TokenUsage};
 
 /// Information about an available model from an LLM provider.
@@ -46,14 +57,17 @@ pub struct ModelInfo {
     /// Description of the model's capabilities
     pub description: Option<String>,
 }
+#[cfg(feature = "_client")]
 pub(crate) use media::{
     AnthropicMessageContent, OpenAICompatibleMessageContent, build_anthropic_message_content,
     build_openai_compatible_message_content,
 };
+#[cfg(feature = "_client")]
 pub(crate) use openai_compatible::{
     OpenAICompatibleChatCompletionRequest, OpenAICompatibleChatCompletionResponse,
     OpenAICompatibleChatMessage, convert_openai_compatible_chat_messages,
 };
+#[cfg(feature = "_client")]
 pub(crate) use utils::{
     ResponseFormat, check_response_status, generate_with_retry_with_history, handle_http_error,
     materialize_with_media_with_retry, parse_validate_and_create_output, prepare_strict_schema,

--- a/src/backend/model_macro.rs
+++ b/src/backend/model_macro.rs
@@ -1,0 +1,99 @@
+//! Internal helper for declaring provider model enums without repetition.
+//!
+//! Every backend (OpenAI, Anthropic, Grok, Gemini) exposes a `Model` enum that
+//! maps a set of named variants to their exact API identifiers and back. Before
+//! this macro, each backend hand-wrote the enum, `as_str`, `from_string`,
+//! `FromStr`, `From<&str>` and `From<String>` — roughly 60 lines of identical
+//! boilerplate per provider, four times over, each a place to drift out of sync.
+//!
+//! [`define_model_enum!`] generates all of that from a single declaration, so a
+//! backend only states its variants and their identifiers.
+
+/// Generate a provider `Model` enum plus its string conversions.
+///
+/// Produces the enum (with the given doc comments and a trailing
+/// `Custom(String)` variant), and implementations of `as_str`, `from_string`,
+/// [`FromStr`](std::str::FromStr), `From<&str>` and `From<String>`.
+///
+/// Each named variant maps to/from its exact API identifier; any unrecognized
+/// string round-trips losslessly through `Custom`.
+///
+/// ```text
+/// define_model_enum! {
+///     /// Example models.
+///     pub enum Model {
+///         /// The flagship model.
+///         Flagship => "vendor-flagship",
+///         /// A faster, cheaper model.
+///         Mini => "vendor-mini",
+///     }
+/// }
+/// ```
+macro_rules! define_model_enum {
+    (
+        $(#[$enum_meta:meta])*
+        $vis:vis enum $name:ident {
+            $(
+                $(#[$variant_meta:meta])*
+                $variant:ident => $model_id:literal,
+            )+
+        }
+    ) => {
+        $(#[$enum_meta])*
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        $vis enum $name {
+            $(
+                $(#[$variant_meta])*
+                $variant,
+            )+
+            /// Custom model identifier — for new models, local LLMs, or
+            /// provider-compatible endpoints not covered by a named variant.
+            Custom(String),
+        }
+
+        impl $name {
+            /// Return the exact API model identifier for this model.
+            pub fn as_str(&self) -> &str {
+                match self {
+                    $( $name::$variant => $model_id, )+
+                    $name::Custom(name) => name,
+                }
+            }
+
+            /// Create a model from a string.
+            ///
+            /// This convenience constructor always succeeds: a known identifier
+            /// maps to its variant, and anything else becomes
+            /// [`Custom`](Self::Custom).
+            pub fn from_string(name: impl Into<String>) -> Self {
+                let name = name.into();
+                match name.as_str() {
+                    $( $model_id => $name::$variant, )+
+                    _ => $name::Custom(name),
+                }
+            }
+        }
+
+        impl ::std::str::FromStr for $name {
+            type Err = ::std::convert::Infallible;
+
+            fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
+                Ok($name::from_string(s))
+            }
+        }
+
+        impl ::std::convert::From<&str> for $name {
+            fn from(s: &str) -> Self {
+                $name::from_string(s)
+            }
+        }
+
+        impl ::std::convert::From<String> for $name {
+            fn from(s: String) -> Self {
+                $name::from_string(s)
+            }
+        }
+    };
+}
+
+pub(crate) use define_model_enum;

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -1,9 +1,9 @@
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
-use std::str::FromStr;
 use std::time::Duration;
 use tracing::{debug, error, info, instrument, trace, warn};
 
+use crate::backend::model_macro::define_model_enum;
 use crate::backend::{
     ChatMessage, GenerateResult, LLMClient, MaterializeInternalOutput, MaterializeResult,
     ModelInfo, OpenAICompatibleChatCompletionRequest, OpenAICompatibleChatCompletionResponse,
@@ -15,194 +15,92 @@ use crate::backend::{
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
 
-/// OpenAI models available for completion
-///
-/// For the latest available models and their identifiers, check the
-/// [OpenAI Models Documentation](https://platform.openai.com/docs/models).
-///
-/// # Using Custom Models
-///
-/// You can specify any model name as a string using `Custom` variant or `FromStr`:
-///
-/// ```rust
-/// use rstructor::OpenAIModel;
-/// use std::str::FromStr;
-///
-/// // Using Custom variant
-/// let model = OpenAIModel::Custom("gpt-4-custom".to_string());
-///
-/// // Using FromStr (useful for config files)
-/// let model = OpenAIModel::from_str("gpt-4-custom").unwrap();
-///
-/// // Or use the convenience method
-/// let model = OpenAIModel::from_string("gpt-4-custom");
-/// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Model {
-    /// GPT-5.5 Pro (most capable GPT-5.5 model)
-    Gpt55Pro,
-    /// GPT-5.5 (latest frontier model for complex professional work)
-    Gpt55,
-    /// GPT-5.4 Pro (most capable GPT-5.4-class model)
-    Gpt54Pro,
-    /// GPT-5.4 (more affordable frontier model for complex professional work)
-    Gpt54,
-    /// GPT-5.4 Mini (lower-latency, lower-cost GPT-5.4-class model)
-    Gpt54Mini,
-    /// GPT-5.4 Nano (cheapest GPT-5.4-class model for high-volume tasks)
-    Gpt54Nano,
-    /// GPT-5.3 Chat Latest (ChatGPT GPT-5.3 model)
-    Gpt53ChatLatest,
-    /// GPT-5.3 Codex (coding-focused GPT-5.3 model)
-    Gpt53Codex,
-    /// GPT-5.2 Pro (previous GPT-5.2 pro model)
-    Gpt52Pro,
-    /// GPT-5.2 (previous GPT-5.2 model)
-    Gpt52,
-    /// GPT-5.2 Chat Latest (ChatGPT GPT-5.2 model)
-    Gpt52ChatLatest,
-    /// GPT-5.2 Codex (coding-focused GPT-5.2 model)
-    Gpt52Codex,
-    /// GPT-5.1 (GPT-5.1 model)
-    Gpt51,
-    /// GPT-5 Chat Latest (ChatGPT GPT-5 model)
-    Gpt5ChatLatest,
-    /// GPT-5 Pro (most capable GPT-5 model)
-    Gpt5Pro,
-    /// GPT-5 (standard GPT-5 model)
-    Gpt5,
-    /// GPT-5 Nano (smallest GPT-5 model)
-    Gpt5Nano,
-    /// GPT-5 Mini (smaller, faster GPT-5 model)
-    Gpt5Mini,
-    /// GPT-4.1 (GPT-4.1 model)
-    Gpt41,
-    /// GPT-4.1 Mini (smaller GPT-4.1)
-    Gpt41Mini,
-    /// GPT-4.1 Nano (smallest GPT-4.1)
-    Gpt41Nano,
-    /// GPT-4o (previous GPT-4o model, optimized for chat)
-    Gpt4O,
-    /// GPT-4o Mini (smaller, faster, more cost-effective version)
-    Gpt4OMini,
-    /// GPT-4 Turbo (high-intelligence model)
-    Gpt4Turbo,
-    /// GPT-4 (standard GPT-4 model)
-    Gpt4,
-    /// GPT-3.5 Turbo (efficient model for simple tasks)
-    Gpt35Turbo,
-    /// O4 Mini (previous small reasoning model)
-    O4Mini,
-    /// O3 (reasoning model)
-    O3,
-    /// O3 Mini (smaller reasoning model)
-    O3Mini,
-    /// O1 (reasoning model optimized for complex problem-solving)
-    O1,
-    /// O1 Pro (most capable reasoning model)
-    O1Pro,
-    /// Custom model name (for new models, local LLMs, or OpenAI-compatible endpoints)
-    Custom(String),
-}
-
-impl Model {
-    pub fn as_str(&self) -> &str {
-        match self {
-            Model::Gpt55Pro => "gpt-5.5-pro",
-            Model::Gpt55 => "gpt-5.5",
-            Model::Gpt54Pro => "gpt-5.4-pro",
-            Model::Gpt54 => "gpt-5.4",
-            Model::Gpt54Mini => "gpt-5.4-mini",
-            Model::Gpt54Nano => "gpt-5.4-nano",
-            Model::Gpt53ChatLatest => "gpt-5.3-chat-latest",
-            Model::Gpt53Codex => "gpt-5.3-codex",
-            Model::Gpt52Pro => "gpt-5.2-pro",
-            Model::Gpt52 => "gpt-5.2",
-            Model::Gpt52ChatLatest => "gpt-5.2-chat-latest",
-            Model::Gpt52Codex => "gpt-5.2-codex",
-            Model::Gpt51 => "gpt-5.1",
-            Model::Gpt5ChatLatest => "gpt-5-chat-latest",
-            Model::Gpt5Pro => "gpt-5-pro",
-            Model::Gpt5 => "gpt-5",
-            Model::Gpt5Nano => "gpt-5-nano",
-            Model::Gpt5Mini => "gpt-5-mini",
-            Model::Gpt41 => "gpt-4.1",
-            Model::Gpt41Mini => "gpt-4.1-mini",
-            Model::Gpt41Nano => "gpt-4.1-nano",
-            Model::Gpt4O => "gpt-4o",
-            Model::Gpt4OMini => "gpt-4o-mini",
-            Model::Gpt4Turbo => "gpt-4-turbo",
-            Model::Gpt4 => "gpt-4",
-            Model::Gpt35Turbo => "gpt-3.5-turbo",
-            Model::O4Mini => "o4-mini",
-            Model::O3 => "o3",
-            Model::O3Mini => "o3-mini",
-            Model::O1 => "o1",
-            Model::O1Pro => "o1-pro",
-            Model::Custom(name) => name,
-        }
-    }
-
-    /// Create a model from a string. This is a convenience method that always succeeds.
+define_model_enum! {
+    /// OpenAI models available for completion
     ///
-    /// If the string matches a known model variant, it returns that variant.
-    /// Otherwise, it returns `Custom(name)`.
-    pub fn from_string(name: impl Into<String>) -> Self {
-        let name = name.into();
-        match name.as_str() {
-            "gpt-5.5-pro" => Model::Gpt55Pro,
-            "gpt-5.5" => Model::Gpt55,
-            "gpt-5.4-pro" => Model::Gpt54Pro,
-            "gpt-5.4" => Model::Gpt54,
-            "gpt-5.4-mini" => Model::Gpt54Mini,
-            "gpt-5.4-nano" => Model::Gpt54Nano,
-            "gpt-5.3-chat-latest" => Model::Gpt53ChatLatest,
-            "gpt-5.3-codex" => Model::Gpt53Codex,
-            "gpt-5.2-pro" => Model::Gpt52Pro,
-            "gpt-5.2" => Model::Gpt52,
-            "gpt-5.2-chat-latest" => Model::Gpt52ChatLatest,
-            "gpt-5.2-codex" => Model::Gpt52Codex,
-            "gpt-5.1" => Model::Gpt51,
-            "gpt-5-chat-latest" => Model::Gpt5ChatLatest,
-            "gpt-5-pro" => Model::Gpt5Pro,
-            "gpt-5" => Model::Gpt5,
-            "gpt-5-nano" => Model::Gpt5Nano,
-            "gpt-5-mini" => Model::Gpt5Mini,
-            "gpt-4.1" => Model::Gpt41,
-            "gpt-4.1-mini" => Model::Gpt41Mini,
-            "gpt-4.1-nano" => Model::Gpt41Nano,
-            "gpt-4o" => Model::Gpt4O,
-            "gpt-4o-mini" => Model::Gpt4OMini,
-            "gpt-4-turbo" => Model::Gpt4Turbo,
-            "gpt-4" => Model::Gpt4,
-            "gpt-3.5-turbo" => Model::Gpt35Turbo,
-            "o4-mini" => Model::O4Mini,
-            "o3" => Model::O3,
-            "o3-mini" => Model::O3Mini,
-            "o1" => Model::O1,
-            "o1-pro" => Model::O1Pro,
-            _ => Model::Custom(name),
-        }
-    }
-}
-
-impl FromStr for Model {
-    type Err = std::convert::Infallible;
-
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        Ok(Model::from_string(s))
-    }
-}
-
-impl From<&str> for Model {
-    fn from(s: &str) -> Self {
-        Model::from_string(s)
-    }
-}
-
-impl From<String> for Model {
-    fn from(s: String) -> Self {
-        Model::from_string(s)
+    /// For the latest available models and their identifiers, check the
+    /// [OpenAI Models Documentation](https://platform.openai.com/docs/models).
+    ///
+    /// # Using Custom Models
+    ///
+    /// You can specify any model name as a string using `Custom` variant or `FromStr`:
+    ///
+    /// ```rust
+    /// use rstructor::OpenAIModel;
+    /// use std::str::FromStr;
+    ///
+    /// // Using Custom variant
+    /// let model = OpenAIModel::Custom("gpt-4-custom".to_string());
+    ///
+    /// // Using FromStr (useful for config files)
+    /// let model = OpenAIModel::from_str("gpt-4-custom").unwrap();
+    ///
+    /// // Or use the convenience method
+    /// let model = OpenAIModel::from_string("gpt-4-custom");
+    /// ```
+    pub enum Model {
+        /// GPT-5.5 Pro (most capable GPT-5.5 model)
+        Gpt55Pro => "gpt-5.5-pro",
+        /// GPT-5.5 (latest frontier model for complex professional work)
+        Gpt55 => "gpt-5.5",
+        /// GPT-5.4 Pro (most capable GPT-5.4-class model)
+        Gpt54Pro => "gpt-5.4-pro",
+        /// GPT-5.4 (more affordable frontier model for complex professional work)
+        Gpt54 => "gpt-5.4",
+        /// GPT-5.4 Mini (lower-latency, lower-cost GPT-5.4-class model)
+        Gpt54Mini => "gpt-5.4-mini",
+        /// GPT-5.4 Nano (cheapest GPT-5.4-class model for high-volume tasks)
+        Gpt54Nano => "gpt-5.4-nano",
+        /// GPT-5.3 Chat Latest (ChatGPT GPT-5.3 model)
+        Gpt53ChatLatest => "gpt-5.3-chat-latest",
+        /// GPT-5.3 Codex (coding-focused GPT-5.3 model)
+        Gpt53Codex => "gpt-5.3-codex",
+        /// GPT-5.2 Pro (previous GPT-5.2 pro model)
+        Gpt52Pro => "gpt-5.2-pro",
+        /// GPT-5.2 (previous GPT-5.2 model)
+        Gpt52 => "gpt-5.2",
+        /// GPT-5.2 Chat Latest (ChatGPT GPT-5.2 model)
+        Gpt52ChatLatest => "gpt-5.2-chat-latest",
+        /// GPT-5.2 Codex (coding-focused GPT-5.2 model)
+        Gpt52Codex => "gpt-5.2-codex",
+        /// GPT-5.1 (GPT-5.1 model)
+        Gpt51 => "gpt-5.1",
+        /// GPT-5 Chat Latest (ChatGPT GPT-5 model)
+        Gpt5ChatLatest => "gpt-5-chat-latest",
+        /// GPT-5 Pro (most capable GPT-5 model)
+        Gpt5Pro => "gpt-5-pro",
+        /// GPT-5 (standard GPT-5 model)
+        Gpt5 => "gpt-5",
+        /// GPT-5 Nano (smallest GPT-5 model)
+        Gpt5Nano => "gpt-5-nano",
+        /// GPT-5 Mini (smaller, faster GPT-5 model)
+        Gpt5Mini => "gpt-5-mini",
+        /// GPT-4.1 (GPT-4.1 model)
+        Gpt41 => "gpt-4.1",
+        /// GPT-4.1 Mini (smaller GPT-4.1)
+        Gpt41Mini => "gpt-4.1-mini",
+        /// GPT-4.1 Nano (smallest GPT-4.1)
+        Gpt41Nano => "gpt-4.1-nano",
+        /// GPT-4o (previous GPT-4o model, optimized for chat)
+        Gpt4O => "gpt-4o",
+        /// GPT-4o Mini (smaller, faster, more cost-effective version)
+        Gpt4OMini => "gpt-4o-mini",
+        /// GPT-4 Turbo (high-intelligence model)
+        Gpt4Turbo => "gpt-4-turbo",
+        /// GPT-4 (standard GPT-4 model)
+        Gpt4 => "gpt-4",
+        /// GPT-3.5 Turbo (efficient model for simple tasks)
+        Gpt35Turbo => "gpt-3.5-turbo",
+        /// O4 Mini (previous small reasoning model)
+        O4Mini => "o4-mini",
+        /// O3 (reasoning model)
+        O3 => "o3",
+        /// O3 Mini (smaller reasoning model)
+        O3Mini => "o3-mini",
+        /// O1 (reasoning model optimized for complex problem-solving)
+        O1 => "o1",
+        /// O1 Pro (most capable reasoning model)
+        O1Pro => "o1-pro",
     }
 }
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -312,7 +312,13 @@ pub enum RStructorError {
     #[error("Timeout error")]
     Timeout,
 
+    /// A requested capability is not supported by this client/provider
+    /// (for example, passing media to a backend that has no media support).
+    #[error("Unsupported operation: {0}")]
+    Unsupported(String),
+
     /// HTTP client error (from reqwest)
+    #[cfg(feature = "_client")]
     #[error("HTTP client error: {0}")]
     HttpError(#[from] reqwest::Error),
 
@@ -415,8 +421,10 @@ impl PartialEq for RStructorError {
             (Self::ValidationError(a), Self::ValidationError(b)) => a == b,
             (Self::SchemaError(a), Self::SchemaError(b)) => a == b,
             (Self::SerializationError(a), Self::SerializationError(b)) => a == b,
+            (Self::Unsupported(a), Self::Unsupported(b)) => a == b,
             (Self::Timeout, Self::Timeout) => true,
             // HttpError and JsonError don't implement PartialEq, so we always return false
+            #[cfg(feature = "_client")]
             (Self::HttpError(_), Self::HttpError(_)) => false,
             (Self::JsonError(_), Self::JsonError(_)) => false,
             _ => false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,8 @@ pub use rstructor_derive::Instructor;
 pub use backend::LLMClient;
 pub use backend::ModelInfo;
 pub use backend::ThinkingLevel;
+#[cfg(feature = "_client")]
+pub use backend::{AnyClient, Provider};
 pub use backend::{
     ChatMessage, ChatRole, GenerateResult, MaterializeResult, MediaFile, TokenUsage,
 };

--- a/tests/core_ergonomics_test.rs
+++ b/tests/core_ergonomics_test.rs
@@ -1,0 +1,119 @@
+//! Tests for the core ergonomics improvements: the media-drop default,
+//! and the runtime-selectable `AnyClient`.
+#![cfg(feature = "_client")]
+
+use async_trait::async_trait;
+use rstructor::{
+    GenerateResult, Instructor, LLMClient, MaterializeResult, MediaFile, ModelInfo, RStructorError,
+    Result,
+};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct Dummy {
+    value: String,
+}
+
+/// A custom client with no media support: it relies entirely on the default
+/// `materialize_with_media` implementation provided by the `LLMClient` trait.
+struct NoMediaClient;
+
+#[async_trait]
+impl LLMClient for NoMediaClient {
+    async fn materialize<T>(&self, _prompt: &str) -> Result<T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        // Sentinel error so callers can confirm this path was taken.
+        Err(RStructorError::ValidationError("materialize-called".into()))
+    }
+
+    async fn materialize_with_metadata<T>(&self, _prompt: &str) -> Result<MaterializeResult<T>>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        Err(RStructorError::ValidationError("materialize-called".into()))
+    }
+
+    async fn generate(&self, _prompt: &str) -> Result<String> {
+        Err(RStructorError::ValidationError("generate-called".into()))
+    }
+
+    async fn generate_with_metadata(&self, _prompt: &str) -> Result<GenerateResult> {
+        Err(RStructorError::ValidationError("generate-called".into()))
+    }
+
+    fn from_env() -> Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(NoMediaClient)
+    }
+
+    async fn list_models(&self) -> Result<Vec<ModelInfo>> {
+        Ok(vec![])
+    }
+}
+
+#[tokio::test]
+async fn media_default_passes_through_when_empty() {
+    // With no media, the default delegates to `materialize`.
+    let client = NoMediaClient;
+    let result = client.materialize_with_media::<Dummy>("hi", &[]).await;
+    assert!(
+        matches!(result, Err(RStructorError::ValidationError(m)) if m == "materialize-called"),
+        "empty media should delegate to materialize()"
+    );
+}
+
+#[tokio::test]
+async fn media_default_errors_instead_of_silently_dropping() {
+    // With media, a client lacking media support must error loudly rather than
+    // silently discard the media.
+    let client = NoMediaClient;
+    let media = [MediaFile::new("https://example.com/cat.png", "image/png")];
+    let result = client
+        .materialize_with_media::<Dummy>("describe", &media)
+        .await;
+    assert!(
+        matches!(result, Err(RStructorError::Unsupported(_))),
+        "non-empty media on an unsupported client should return Unsupported, got {result:?}"
+    );
+}
+
+#[cfg(feature = "openai")]
+#[test]
+fn any_client_wraps_and_reports_openai() {
+    use rstructor::{AnyClient, OpenAIClient, Provider};
+
+    let client: AnyClient = OpenAIClient::new("test-key").unwrap().into();
+    assert_eq!(client.provider(), Provider::OpenAI);
+}
+
+#[cfg(feature = "anthropic")]
+#[test]
+fn any_client_wraps_and_reports_anthropic() {
+    use rstructor::{AnthropicClient, AnyClient, Provider};
+
+    let client: AnyClient = AnthropicClient::new("test-key").unwrap().into();
+    assert_eq!(client.provider(), Provider::Anthropic);
+}
+
+#[cfg(feature = "gemini")]
+#[test]
+fn any_client_wraps_and_reports_gemini() {
+    use rstructor::{AnyClient, GeminiClient, Provider};
+
+    let client: AnyClient = GeminiClient::new("test-key").unwrap().into();
+    assert_eq!(client.provider(), Provider::Gemini);
+}
+
+#[cfg(feature = "grok")]
+#[test]
+fn any_client_wraps_and_reports_grok() {
+    use rstructor::{AnyClient, GrokClient, Provider};
+
+    let client: AnyClient = GrokClient::new("test-key").unwrap().into();
+    assert_eq!(client.provider(), Provider::Grok);
+}


### PR DESCRIPTION
## Summary

A focused, **non-breaking** pass addressing four first-principles issues surfaced by a design review of the codebase. Streaming and tool-calling — the two larger, greenfield items — are intentionally **deferred to separate follow-up PRs** (each is a multi-provider feature deserving its own design).

## What's in this PR

### 1. Runtime-selectable client — `AnyClient`
`LLMClient::materialize` is generic, which makes the trait **not object-safe** — `Box<dyn LLMClient>` is impossible, so there was no way to choose a provider at runtime and store it in one type.

Adds `AnyClient`, an enum over the concrete clients that itself implements `LLMClient`:
```rust
let provider = Provider::Anthropic;            // decided at runtime
let client = AnyClient::from_env_for(provider)?;
let movie: Movie = client.materialize("Describe Inception").await?;

let client = AnyClient::from_env()?;            // auto-detect from env keys
let client: AnyClient = OpenAIClient::from_env()?.into();  // wrap a configured client
```
Provides `Provider`, `from_env_for`, an env-autodetecting `from_env`, `provider()`, and `From<ConcreteClient>` impls. A single `Clone + Send + Sync` type.

### 2. Dependency / feature hygiene + schema-only build
- **`chrono` → `dev-dependencies`** — only examples/tests used it; it now leaves the public dependency closure entirely.
- **`base64` is now optional**, pulled in only with the client stack.
- The networked stack (`utils`, `media`, `openai_compatible`, the `reqwest`-backed `HttpError` variant, `MediaFile::from_bytes`) is gated behind an internal `_client` feature that each provider feature enables.
- **New schema-only build**: `default-features = false, features = ["derive"]` now compiles with **no `tokio`/`reqwest`** — generate JSON Schema from your types with a dependency-light build that still exposes the derive macro, `SchemaType`, `Instructor`, and the `LLMClient` trait.

### 3. Media is never silently dropped
The default `materialize_with_media` previously **ignored** media for clients without media support (silent data loss). It now forwards to `materialize` only when no media is given, and otherwise returns the new `RStructorError::Unsupported`. All four built-in clients already override this method, so their behavior is unchanged — only third-party `LLMClient` impls are affected, and now they fail loudly instead of silently.

### 4. De-duplicate the per-provider `Model` enums
Adds an internal `define_model_enum!` macro that generates each provider's `Model` enum plus `as_str`, `from_string`, `FromStr`, `From<&str>`, and `From<String>`. Replaces ~60 lines of byte-identical boilerplate in **each** of the four backends with a single declaration. Model identifiers and behavior are unchanged (round-trip tests still pass).

## Compatibility
Non-breaking for existing users: provider features still pull in the same dependencies, defaults and model identifiers are unchanged, and all additions are additive. `RStructorError` gains one variant (`Unsupported`).

## Verification
- `cargo clippy --all-targets` — clean.
- Builds across the full feature matrix: default, `--no-default-features --features derive` (schema-only), and each single provider.
- `cargo test --lib` (55), `--doc` (61, **0 ignored**), `model_string_test` (6), `rstructor_derive` tests, and non-network schema/derive integration suites — all pass.
- New `tests/core_ergonomics_test.rs` covers the media-default behavior and `AnyClient` wrapping/`provider()`.

## Follow-ups (not in this PR)
From the same review: a `Provider` trait + single generic engine to collapse the byte-identical backends and make the unified API truly object-safe; streaming (partial objects / iterables); selectable structured-output mode with fallback; and a correctness fix for the documented inherent-fn `validate` pattern (it currently never runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)