### PR TITLE
Fix validation: reask on any validator error + correct misleading docs

### DIFF
--- a/rstructor_derive/src/lib.rs
+++ b/rstructor_derive/src/lib.rs
@@ -12,7 +12,7 @@ mod type_utils;
 
 use container_attrs::ContainerAttributes;
 use proc_macro::TokenStream;
-use syn::{Data, DeriveInput, parse_macro_input};
+use syn::{Data, DeriveInput, Fields, parse_macro_input};
 
 /// Derive macro for implementing Instructor and SchemaType
 ///
@@ -166,25 +166,28 @@ pub fn derive_instructor(input: TokenStream) -> TokenStream {
         _ => panic!("Instructor can only be derived for structs and enums"),
     };
 
-    // Generate the Instructor trait implementation
-    let instructor_impl = if let Some(validate_fn) = &container_attrs.validate {
-        // Parse the validation function path
+    // Generate the Instructor trait implementation.
+    //
+    // `validate` first recurses into every field whose type implements
+    // `Instructor` (nested structs/enums, and their contents through `Option`,
+    // `Vec`, `Box`, and string-keyed maps), then runs this type's own
+    // `#[llm(validate = "...")]` function, if any.
+    let field_validation = generate_field_validation(&input.data);
+    let container_validate = if let Some(validate_fn) = &container_attrs.validate {
         let validate_path: syn::Path =
             syn::parse_str(validate_fn).expect("validate attribute must be a valid function path");
-        quote::quote! {
-            impl ::rstructor::model::Instructor for #name {
-                fn validate(&self) -> ::rstructor::error::Result<()> {
-                    #validate_path(self)
-                }
-            }
-        }
+        quote::quote! { #validate_path(self)?; }
     } else {
-        // Default implementation - validation passes
-        quote::quote! {
-            impl ::rstructor::model::Instructor for #name {
-                fn validate(&self) -> ::rstructor::error::Result<()> {
-                    ::rstructor::error::Result::Ok(())
-                }
+        quote::quote! {}
+    };
+    let instructor_impl = quote::quote! {
+        impl ::rstructor::model::Instructor for #name {
+            fn validate(&self) -> ::rstructor::error::Result<()> {
+                #[allow(unused_imports)]
+                use ::rstructor::model::__private::ProbeFallback as _;
+                #field_validation
+                #container_validate
+                ::rstructor::error::Result::Ok(())
             }
         }
     };
@@ -197,6 +200,75 @@ pub fn derive_instructor(input: TokenStream) -> TokenStream {
     };
 
     combined.into()
+}
+
+/// Generate statements that recursively validate every field of a struct or the
+/// active variant of an enum.
+///
+/// Each field is wrapped in `__private::Probe`, whose `rstructor_probe` resolves
+/// (via autoref specialization) to the field's `Instructor::validate` when the
+/// field type implements `Instructor`, and to a no-op otherwise — so primitive
+/// fields cost nothing while nested `Instructor` values are validated.
+fn generate_field_validation(data: &Data) -> proc_macro2::TokenStream {
+    match data {
+        Data::Struct(data_struct) => match &data_struct.fields {
+            Fields::Named(named) => {
+                let probes = named.named.iter().map(|f| {
+                    let ident = f.ident.as_ref().unwrap();
+                    quote::quote! {
+                        ::rstructor::model::__private::Probe(&self.#ident).rstructor_probe()?;
+                    }
+                });
+                quote::quote! { #(#probes)* }
+            }
+            Fields::Unnamed(unnamed) => {
+                let probes = unnamed.unnamed.iter().enumerate().map(|(i, _)| {
+                    let index = syn::Index::from(i);
+                    quote::quote! {
+                        ::rstructor::model::__private::Probe(&self.#index).rstructor_probe()?;
+                    }
+                });
+                quote::quote! { #(#probes)* }
+            }
+            Fields::Unit => quote::quote! {},
+        },
+        Data::Enum(data_enum) => {
+            let arms = data_enum.variants.iter().map(|variant| {
+                let vname = &variant.ident;
+                match &variant.fields {
+                    Fields::Named(named) => {
+                        let binds: Vec<_> = named
+                            .named
+                            .iter()
+                            .map(|f| f.ident.clone().unwrap())
+                            .collect();
+                        quote::quote! {
+                            Self::#vname { #(#binds),* } => {
+                                #( ::rstructor::model::__private::Probe(#binds).rstructor_probe()?; )*
+                            }
+                        }
+                    }
+                    Fields::Unnamed(unnamed) => {
+                        let binds: Vec<_> = (0..unnamed.unnamed.len())
+                            .map(|i| quote::format_ident!("field{}", i))
+                            .collect();
+                        quote::quote! {
+                            Self::#vname( #(#binds),* ) => {
+                                #( ::rstructor::model::__private::Probe(#binds).rstructor_probe()?; )*
+                            }
+                        }
+                    }
+                    Fields::Unit => quote::quote! { Self::#vname => {} },
+                }
+            });
+            quote::quote! {
+                match self {
+                    #(#arms)*
+                }
+            }
+        }
+        _ => quote::quote! {},
+    }
 }
 
 use quote::ToTokens;

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -1218,43 +1218,35 @@ where
             Err((err, validation_ctx)) => {
                 let is_last_attempt = attempt >= max_attempts - 1;
 
-                // Handle validation errors with conversation history
-                if let RStructorError::ValidationError(ref msg) = err {
+                // A validation failure — whether a schema/parse error or a custom
+                // validator returning ANY error variant — carries a
+                // `ValidationFailureContext` with the raw response. Reask with
+                // feedback whenever that context is present, rather than keying off
+                // a specific error variant (a validator that returns, say, a
+                // `SchemaError` should still trigger a retry).
+                if let Some(ctx) = validation_ctx {
                     if !is_last_attempt {
                         warn!(
                             attempt = attempt + 1,
-                            error = msg,
+                            error = %ctx.error_message,
                             "Validation error in generation attempt"
                         );
 
-                        // Build conversation history for retry with error feedback
-                        if let Some(ctx) = validation_ctx {
-                            // Add the failed assistant response to history
-                            messages.push(ChatMessage::assistant(&ctx.raw_response));
+                        // Build conversation history for retry with error feedback.
+                        // Add the failed assistant response to history.
+                        messages.push(ChatMessage::assistant(&ctx.raw_response));
 
-                            // Add user message with error feedback
-                            let error_feedback = format!(
-                                "Your previous response contained validation errors. Please provide a complete, valid JSON response that includes ALL required fields and follows the schema exactly.\n\nError details:\n{}\n\nPlease fix the issues in your response. Make sure to:\n1. Include ALL required fields exactly as specified in the schema\n2. For enum fields, use EXACTLY one of the allowed values from the description\n3. CRITICAL: For arrays where items.type = 'object':\n   - You MUST provide an array of OBJECTS, not strings or primitive values\n   - Each object must be a complete JSON object with all its required fields\n   - Include multiple items (at least 2-3) in arrays of objects\n4. Verify all nested objects have their complete structure\n5. Follow ALL type specifications (string, number, boolean, array, object)",
-                                ctx.error_message
-                            );
-                            messages.push(ChatMessage::user(error_feedback));
+                        // Add user message with error feedback
+                        let error_feedback = format!(
+                            "Your previous response contained validation errors. Please provide a complete, valid JSON response that includes ALL required fields and follows the schema exactly.\n\nError details:\n{}\n\nPlease fix the issues in your response. Make sure to:\n1. Include ALL required fields exactly as specified in the schema\n2. For enum fields, use EXACTLY one of the allowed values from the description\n3. CRITICAL: For arrays where items.type = 'object':\n   - You MUST provide an array of OBJECTS, not strings or primitive values\n   - Each object must be a complete JSON object with all its required fields\n   - Include multiple items (at least 2-3) in arrays of objects\n4. Verify all nested objects have their complete structure\n5. Follow ALL type specifications (string, number, boolean, array, object)",
+                            ctx.error_message
+                        );
+                        messages.push(ChatMessage::user(error_feedback));
 
-                            debug!(
-                                history_len = messages.len(),
-                                "Updated conversation history for retry"
-                            );
-                        } else {
-                            // Fallback: no raw response context available.
-                            // We cannot add error feedback without the raw response because:
-                            // 1. Adding only a user message would create consecutive user messages,
-                            //    violating the alternating user/assistant pattern expected by LLM APIs
-                            // 2. The error message references "your previous response" but we can't show it
-                            // Instead, we retry with the original conversation (no history modification)
-                            warn!(
-                                "Validation error occurred but no raw response context available. \
-                                 Retrying without error feedback in conversation history."
-                            );
-                        }
+                        debug!(
+                            history_len = messages.len(),
+                            "Updated conversation history for retry"
+                        );
 
                         // Wait briefly before retrying
                         sleep(Duration::from_millis(500)).await;
@@ -1262,7 +1254,7 @@ where
                     } else {
                         error!(
                             attempts = max_attempts,
-                            error = msg,
+                            error = %ctx.error_message,
                             "Failed after maximum retry attempts with validation errors"
                         );
                     }
@@ -2193,6 +2185,50 @@ mod tests {
         )
         .await
         .expect("generation should succeed after retry");
+
+        assert_eq!(attempts, 2);
+        assert_eq!(output.data, "ok");
+    }
+
+    #[tokio::test]
+    async fn test_reask_triggers_on_non_validation_error_variant() {
+        // A custom validator may return any `RStructorError` variant. As long as a
+        // `ValidationFailureContext` is present, the reask loop must retry with
+        // feedback rather than failing immediately. (Previously the loop only
+        // reasked on the `ValidationError` variant, so a validator returning, e.g.,
+        // `SchemaError` silently disabled retries.)
+        let mut attempts = 0usize;
+        let output = generate_with_retry_with_initial_messages(
+            |messages: Vec<ChatMessage>| {
+                attempts += 1;
+                async move {
+                    if attempts == 1 {
+                        Err((
+                            // NOT a ValidationError on purpose.
+                            RStructorError::SchemaError("custom validator rejected".to_string()),
+                            Some(ValidationFailureContext::new(
+                                "value out of range",
+                                "{\"n\":-1}",
+                            )),
+                        ))
+                    } else {
+                        // Reask appended the failed response + feedback to history.
+                        assert_eq!(messages.len(), 3);
+                        assert_eq!(messages[1].role, crate::backend::ChatRole::Assistant);
+                        assert_eq!(messages[2].role, crate::backend::ChatRole::User);
+                        Ok(MaterializeInternalOutput::new(
+                            "ok".to_string(),
+                            "{\"ok\":true}".to_string(),
+                            None,
+                        ))
+                    }
+                }
+            },
+            vec![ChatMessage::user("validate this")],
+            Some(1),
+        )
+        .await
+        .expect("non-ValidationError validator failure should still reask");
 
         assert_eq!(attempts, 2);
         assert_eq!(output.data, "ok");

--- a/src/model/instructor.rs
+++ b/src/model/instructor.rs
@@ -102,6 +102,11 @@ pub trait Instructor: SchemaType + DeserializeOwned + Serialize {
     /// returned by the LLM; a failure triggers an automatic re-ask with the error
     /// fed back to the model. The default implementation returns `Ok(())`.
     ///
+    /// The derive-generated implementation automatically recurses into nested
+    /// `Instructor` fields — directly, and through `Option`, `Vec`, `Box`, and
+    /// string-keyed maps — before running this type's own validator, so validating
+    /// a parent validates its entire tree.
+    ///
     /// To add custom validation, use the `#[llm(validate = "path")]` container
     /// attribute — the derive macro wires your function into this trait method:
     ///
@@ -141,6 +146,82 @@ pub trait Instructor: SchemaType + DeserializeOwned + Serialize {
 // The blanket implementation is removed
 // Instead, the derive macro will handle implementing Instructor for each type
 // This avoids the conflicting implementation errors
+
+// Container implementations so that validation recurses into nested values.
+// `#[derive(Instructor)]` validates each field via these impls, so a `Vec`,
+// `Option`, `Box`, or string-keyed map of validating types is validated
+// element-by-element as part of its parent.
+
+impl<T: Instructor> Instructor for Option<T> {
+    fn validate(&self) -> Result<()> {
+        match self {
+            Some(value) => value.validate(),
+            None => Ok(()),
+        }
+    }
+}
+
+impl<T: Instructor> Instructor for Vec<T> {
+    fn validate(&self) -> Result<()> {
+        for value in self {
+            value.validate()?;
+        }
+        Ok(())
+    }
+}
+
+impl<T: Instructor> Instructor for Box<T> {
+    fn validate(&self) -> Result<()> {
+        (**self).validate()
+    }
+}
+
+impl<V: Instructor> Instructor for std::collections::HashMap<String, V> {
+    fn validate(&self) -> Result<()> {
+        for value in self.values() {
+            value.validate()?;
+        }
+        Ok(())
+    }
+}
+
+/// Internal helpers used by `#[derive(Instructor)]`. Not part of the public API
+/// and exempt from semver guarantees.
+#[doc(hidden)]
+pub mod __private {
+    use super::Instructor;
+    use crate::error::Result;
+
+    /// Autoref-specialization wrapper that lets generated code validate a field
+    /// **iff** its type implements [`Instructor`], and otherwise do nothing —
+    /// without the derive macro having to know which field types are `Instructor`.
+    ///
+    /// `#[derive(Instructor)]` emits `Probe(&self.field).rstructor_probe()?` for
+    /// each field. When the field's type implements `Instructor`, the inherent
+    /// method below is selected (inherent methods take priority over trait
+    /// methods); otherwise method resolution falls back to the [`ProbeFallback`]
+    /// trait, which is a no-op.
+    pub struct Probe<'a, T>(pub &'a T);
+
+    /// Fallback for non-`Instructor` field types (e.g. `String`, `u32`).
+    pub trait ProbeFallback {
+        fn rstructor_probe(&self) -> Result<()>;
+    }
+
+    impl<T> ProbeFallback for Probe<'_, T> {
+        fn rstructor_probe(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<T: Instructor> Probe<'_, T> {
+        /// Validate the wrapped value (selected over the trait method when
+        /// `T: Instructor`).
+        pub fn rstructor_probe(&self) -> Result<()> {
+            self.0.validate()
+        }
+    }
+}
 
 /// Helper trait to mark a type as implementing custom validation.
 ///

--- a/src/model/instructor.rs
+++ b/src/model/instructor.rs
@@ -6,9 +6,9 @@ use crate::schema::SchemaType;
 
 /// The `Instructor` trait combines JSON schema generation, serialization, and validation.
 ///
-/// This trait is automatically implemented for any type that implements the required traits
-/// (SchemaType, DeserializeOwned, and Serialize), but you can also provide a custom
-/// implementation to add your own validation logic.
+/// It is implemented for your type by `#[derive(Instructor)]`, which also generates the
+/// [`SchemaType`] implementation. Add custom validation with the `#[llm(validate = "path")]`
+/// attribute (see [`validate`](Instructor::validate)); the derive wires it into the trait.
 ///
 /// # Nested Types and Schema Embedding
 ///
@@ -96,38 +96,43 @@ use crate::schema::SchemaType;
 /// # }
 /// ```
 pub trait Instructor: SchemaType + DeserializeOwned + Serialize {
-    /// Optional validation logic beyond type checking
+    /// Optional validation logic beyond type checking.
     ///
-    /// This method is called automatically by `materialize` to validate
-    /// the data returned by the LLM. The default implementation does nothing
-    /// and returns Ok(()), but you can override it to add your own validation logic.
+    /// This method is called automatically by `materialize` to validate the data
+    /// returned by the LLM; a failure triggers an automatic re-ask with the error
+    /// fed back to the model. The default implementation returns `Ok(())`.
     ///
-    /// # Example
+    /// To add custom validation, use the `#[llm(validate = "path")]` container
+    /// attribute — the derive macro wires your function into this trait method:
     ///
     /// ```
-    /// # use rstructor::{Instructor, RStructorError};
-    /// # use serde::{Serialize, Deserialize};
-    /// #
-    /// # #[derive(Instructor, Serialize, Deserialize, Debug)]
-    /// # struct Product {
-    /// #     name: String,
-    /// #     price: f64,
-    /// # }
-    /// #
-    /// // Just implement validate directly on the struct
-    /// // No need to manually implement the Instructor trait
-    /// impl Product {
-    ///     fn validate(&self) -> rstructor::Result<()> {
-    ///         // Price must be positive
-    ///         if self.price < 0.0 {
-    ///             return Err(RStructorError::ValidationError(
-    ///                 format!("Price must be positive, got {}", self.price)
-    ///             ));
-    ///         }
-    ///         Ok(())
+    /// use rstructor::{Instructor, RStructorError};
+    /// use serde::{Serialize, Deserialize};
+    ///
+    /// #[derive(Instructor, Serialize, Deserialize, Debug)]
+    /// #[llm(validate = "validate_product")]
+    /// struct Product {
+    ///     name: String,
+    ///     price: f64,
+    /// }
+    ///
+    /// fn validate_product(product: &Product) -> rstructor::Result<()> {
+    ///     if product.price < 0.0 {
+    ///         return Err(RStructorError::ValidationError(
+    ///             format!("Price must be positive, got {}", product.price),
+    ///         ));
     ///     }
+    ///     Ok(())
     /// }
     /// ```
+    ///
+    /// # Important: inherent methods do not work
+    ///
+    /// Writing an *inherent* `impl Product { fn validate(&self) {...} }` does **not**
+    /// hook into validation. `#[derive(Instructor)]` always generates this trait
+    /// method (defaulting to `Ok(())`), and trait dispatch ignores the inherent
+    /// method — so an inherent `validate` would silently never run. Always use the
+    /// `#[llm(validate = "...")]` attribute, or hand-write `impl Instructor`.
     fn validate(&self) -> Result<()> {
         Ok(())
     }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,3 +1,6 @@
 mod instructor;
 
 pub use instructor::{Instructor, Validatable};
+
+#[doc(hidden)]
+pub use instructor::__private;

--- a/tests/nested_validation_tests.rs
+++ b/tests/nested_validation_tests.rs
@@ -1,0 +1,101 @@
+//! Nested validation: a derived `validate` recurses into nested `Instructor`
+//! fields (directly, and through `Option`/`Vec`), then runs the container's own
+//! validator. Before this behavior, only the top-level type's validator ran.
+
+use rstructor::{Instructor, RStructorError, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+#[llm(validate = "validate_child")]
+struct Child {
+    value: i32,
+}
+
+fn validate_child(c: &Child) -> Result<()> {
+    if c.value < 0 {
+        return Err(RStructorError::ValidationError(format!(
+            "child.value must be >= 0, got {}",
+            c.value
+        )));
+    }
+    Ok(())
+}
+
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct Parent {
+    // primitive field: validation is a no-op, must not interfere
+    name: String,
+    // direct nested Instructor field
+    child: Child,
+    // nested through Option
+    maybe_child: Option<Child>,
+    // nested through Vec
+    children: Vec<Child>,
+}
+
+fn parent(child: i32, maybe: Option<i32>, vec: Vec<i32>) -> Parent {
+    Parent {
+        name: "p".to_string(),
+        child: Child { value: child },
+        maybe_child: maybe.map(|v| Child { value: v }),
+        children: vec.into_iter().map(|v| Child { value: v }).collect(),
+    }
+}
+
+#[test]
+fn direct_nested_field_is_validated() {
+    assert!(parent(-1, None, vec![]).validate().is_err());
+}
+
+#[test]
+fn nested_option_is_validated() {
+    assert!(parent(0, Some(-5), vec![]).validate().is_err());
+    // None must not error.
+    assert!(parent(0, None, vec![]).validate().is_ok());
+}
+
+#[test]
+fn nested_vec_elements_are_validated() {
+    assert!(parent(0, None, vec![1, 2, -9]).validate().is_err());
+    assert!(parent(0, None, vec![1, 2, 3]).validate().is_ok());
+}
+
+#[test]
+fn all_valid_passes() {
+    assert!(parent(0, Some(2), vec![3, 4]).validate().is_ok());
+}
+
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+enum Wrapper {
+    Tuple(Child),
+    Struct { inner: Child },
+    Empty,
+}
+
+#[test]
+fn enum_variant_fields_are_validated() {
+    assert!(Wrapper::Tuple(Child { value: -1 }).validate().is_err());
+    assert!(
+        Wrapper::Struct {
+            inner: Child { value: -1 }
+        }
+        .validate()
+        .is_err()
+    );
+    assert!(Wrapper::Tuple(Child { value: 1 }).validate().is_ok());
+    assert!(Wrapper::Empty.validate().is_ok());
+}
+
+/// Deeply nested: Parent inside a Vec inside another struct still validates.
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct GrandParent {
+    parents: Vec<Parent>,
+}
+
+#[test]
+fn deeply_nested_is_validated() {
+    let gp = GrandParent {
+        parents: vec![parent(0, None, vec![]), parent(0, None, vec![-1])],
+    };
+    assert!(gp.validate().is_err());
+}


### PR DESCRIPTION
## Summary

Three correctness fixes around custom validation, surfaced by a design review.

### 1. Reask now triggers for any validator error variant
`Instructor::validate` returns `Result<()>`, so a custom validator may return **any** `RStructorError` variant. The retry loop only reasked on the `ValidationError` variant, so a validator returning e.g. `SchemaError` fell through to `is_retryable()` (false) and **failed immediately with no retry**. The loop now reasks whenever a `ValidationFailureContext` is present (exactly when a parse/validation failure occurred), regardless of the error variant.

### 2. Validation now recurses into nested `Instructor` fields
Previously only the **top-level** type's validator ran — a validator on a nested struct/enum silently never executed, even though the docs encourage deriving `Instructor` on nested types. Now `#[derive(Instructor)]`'s generated `validate` recurses into every field whose type implements `Instructor`, then runs the container's own validator. Validating a parent validates its entire tree.

Mechanism:
- `Instructor` is implemented for `Option<T>`, `Vec<T>`, `Box<T>`, and `HashMap<String, V>` (inner type `Instructor`), recursing into contents — so nesting through these containers is validated too.
- A `__private::Probe` **autoref-specialization** helper lets the derive emit one probe per field that resolves to `Instructor::validate` when the field type is `Instructor` and to a no-op otherwise — so primitive fields cost nothing and the macro needs no knowledge of which field types are validatable.

### 3. Docs no longer recommend a validator that never runs
The `Instructor::validate` docs showed an **inherent** `impl T { fn validate }` and said "no need to implement the Instructor trait". That silently never runs: the derive always generates the *trait* method, and trait dispatch ignores the inherent method. Docs now standardize on the working `#[llm(validate = "path")]` attribute and explicitly warn against the inherent pattern; the stale "automatically implemented for any type" claim was also corrected.

## Tests
- `test_reask_triggers_on_non_validation_error_variant` — fails on the old code, passes now.
- `tests/nested_validation_tests.rs` — direct nested fields, `Option`/`Vec` nesting, enum variant fields, and deep nesting.
- Full `--lib` (56), `--doc` (0 ignored), and derive/validation integration suites pass; clippy clean.

## Compatibility
Nested recursion is a behavior change (nested validators now actually run) — this is the intended, correct default. Existing top-level validators are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)