### PR TITLE
Add streaming: list streaming (materialize_iter), text, and object (opt-in)

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -30,7 +30,7 @@ jobs:
           cache-on-failure: true
 
       - name: Build all examples
-        run: cargo build --examples
+        run: cargo build --all-features --examples
 
   # Run examples in parallel groups (using cached build artifacts)
   examples:
@@ -70,6 +70,6 @@ jobs:
               echo "=========================================="
               echo "Running example: ${examples[$i]}"
               echo "=========================================="
-              cargo run --example "${examples[$i]}"
+              cargo run --all-features --example "${examples[$i]}"
             fi
           done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ tracing-subscriber = { version = "0.3.23", features = [
 tracing-futures = { version = "0.2.5", optional = true }
 rstructor_derive = { version = "0.2.11", path = "./rstructor_derive", optional = true }
 base64 = { version = "0.22.1", optional = true }
+futures-util = { version = "0.3.31", default-features = false, optional = true }
+async-stream = { version = "0.3.6", optional = true }
 
 # Feature flags
 [features]
@@ -76,6 +78,13 @@ logging = ["tracing-subscriber", "tracing-futures"]
 # all providers yields a dependency-light, schema-only build (derive + schema, no
 # tokio/reqwest) suitable for generating JSON Schema without making API calls.
 _client = ["reqwest", "tokio", "base64"]
+# Opt-in streaming: raw text (`generate_stream`) and structured objects
+# (`materialize_stream`). Enable a provider feature too for the HTTP stack.
+streaming = ["_client", "reqwest/stream", "futures-util", "async-stream"]
+
+[[example]]
+name = "streaming_example"
+required-features = ["streaming"]
 
 [dev-dependencies]
 # Used only by examples and tests (date/time fields, custom types); not part of

--- a/README.md
+++ b/README.md
@@ -325,6 +325,42 @@ match client.materialize::<Movie>("...").await {
 }
 ```
 
+## Streaming
+
+Enable the `streaming` feature to stream responses as they are generated.
+
+```toml
+rstructor = { version = "0.2", features = ["streaming"] }
+```
+
+`materialize_stream` streams a **structured object**: progressive JSON snapshots of the object filling in, followed by a final, validated, typed value.
+
+```rust
+use futures_util::StreamExt;
+use rstructor::{LLMClient, OpenAIClient, Instructor, StreamedObject};
+
+let client = OpenAIClient::from_env()?;
+let mut stream = client.materialize_stream::<Recipe>("A simple pancake recipe");
+
+while let Some(item) = stream.next().await {
+    match item? {
+        StreamedObject::Partial(json) => update_ui(&json), // object filling in
+        StreamedObject::Complete(recipe) => done(recipe),  // typed + validated
+    }
+}
+```
+
+`generate_stream` streams raw text deltas:
+
+```rust
+let mut stream = client.generate_stream("Write a haiku");
+while let Some(chunk) = stream.next().await {
+    print!("{}", chunk?);
+}
+```
+
+Both are available on all providers (OpenAI, Anthropic, Grok, Gemini). See `examples/streaming_example.rs`.
+
 ## Feature Flags
 
 ```toml
@@ -335,6 +371,7 @@ rstructor = { version = "0.2", features = ["openai", "anthropic", "grok", "gemin
 - `openai`, `anthropic`, `grok`, `gemini` — Provider backends (each pulls in the shared HTTP/`tokio` stack)
 - `derive` — Derive macro (default)
 - `logging` — Tracing integration
+- `streaming` — Streaming via `generate_stream` / `materialize_stream` (opt-in)
 
 All features are on by default. For a **schema-only build** — generate JSON Schema from your types with no networking, `tokio`, or `reqwest` — disable the providers:
 

--- a/README.md
+++ b/README.md
@@ -333,20 +333,18 @@ Enable the `streaming` feature to stream responses as they are generated.
 rstructor = { version = "0.2", features = ["streaming"] }
 ```
 
-`materialize_stream` streams a **structured object**: progressive JSON snapshots of the object filling in, followed by a final, validated, typed value.
+`materialize_iter` streams a **list of structured objects**, yielding each item as soon as it is fully generated and validated — the common case where you want a long list without buffering the whole response:
 
 ```rust
 use futures_util::StreamExt;
-use rstructor::{LLMClient, OpenAIClient, Instructor, StreamedObject};
+use rstructor::{LLMClient, OpenAIClient, Instructor};
 
 let client = OpenAIClient::from_env()?;
-let mut stream = client.materialize_stream::<Recipe>("A simple pancake recipe");
+let mut stream = client.materialize_iter::<Invention>("List 10 important inventions.");
 
 while let Some(item) = stream.next().await {
-    match item? {
-        StreamedObject::Partial(json) => update_ui(&json), // object filling in
-        StreamedObject::Complete(recipe) => done(recipe),  // typed + validated
-    }
+    let invention = item?;          // each item: fully parsed + validated
+    println!("{} ({})", invention.name, invention.year);
 }
 ```
 
@@ -359,7 +357,9 @@ while let Some(chunk) = stream.next().await {
 }
 ```
 
-Both are available on all providers (OpenAI, Anthropic, Grok, Gemini). See `examples/streaming_example.rs`.
+There is also `materialize_stream`, which streams a single object as progressive `StreamedObject::Partial(json)` snapshots followed by a validated `Complete(T)`.
+
+All are available on every provider (OpenAI, Anthropic, Grok, Gemini). See `examples/streaming_example.rs`.
 
 ## Feature Flags
 

--- a/examples/streaming_example.rs
+++ b/examples/streaming_example.rs
@@ -1,0 +1,50 @@
+//! Streaming structured output.
+//!
+//! Run with:
+//!   cargo run --example streaming_example --features streaming
+//!
+//! `materialize_stream` yields progressively-completed JSON snapshots of the object
+//! as the model generates it, then a final, validated, typed value.
+
+use futures_util::StreamExt;
+use rstructor::{Instructor, LLMClient, OpenAIClient, StreamedObject};
+use serde::{Deserialize, Serialize};
+
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+#[llm(description = "A simple cooking recipe")]
+struct Recipe {
+    #[llm(description = "Name of the dish")]
+    name: String,
+    #[llm(description = "Ingredients with quantities")]
+    ingredients: Vec<String>,
+    #[llm(description = "Ordered preparation steps")]
+    steps: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = OpenAIClient::from_env()?;
+
+    println!("--- Streaming a structured Recipe ---\n");
+    let mut stream = client.materialize_stream::<Recipe>("Give me a simple recipe for pancakes.");
+
+    while let Some(item) = stream.next().await {
+        match item? {
+            // Progressive snapshots: the object filling in, field by field.
+            StreamedObject::Partial(json) => {
+                let name = json.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                let ingredients = json
+                    .get("ingredients")
+                    .and_then(|v| v.as_array())
+                    .map_or(0, |a| a.len());
+                println!("  partial: name={name:?}, ingredients so far={ingredients}");
+            }
+            // The final, fully parsed and validated value.
+            StreamedObject::Complete(recipe) => {
+                println!("\nDone! {recipe:#?}");
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/examples/streaming_example.rs
+++ b/examples/streaming_example.rs
@@ -1,50 +1,45 @@
-//! Streaming structured output.
+//! Streaming a list of structured objects.
 //!
 //! Run with:
 //!   cargo run --example streaming_example --features streaming
 //!
-//! `materialize_stream` yields progressively-completed JSON snapshots of the object
-//! as the model generates it, then a final, validated, typed value.
+//! `materialize_iter` streams a list, yielding each item as soon as it is fully
+//! generated and validated — ideal for long lists where you want to start
+//! processing (or rendering) items without waiting for the whole response.
 
 use futures_util::StreamExt;
-use rstructor::{Instructor, LLMClient, OpenAIClient, StreamedObject};
+use rstructor::{Instructor, LLMClient, OpenAIClient};
 use serde::{Deserialize, Serialize};
 
 #[derive(Instructor, Serialize, Deserialize, Debug)]
-#[llm(description = "A simple cooking recipe")]
-struct Recipe {
-    #[llm(description = "Name of the dish")]
+#[llm(description = "A notable invention")]
+struct Invention {
+    #[llm(description = "Name of the invention")]
     name: String,
-    #[llm(description = "Ingredients with quantities")]
-    ingredients: Vec<String>,
-    #[llm(description = "Ordered preparation steps")]
-    steps: Vec<String>,
+    #[llm(description = "Year it was invented")]
+    year: i32,
+    #[llm(description = "Who invented it")]
+    inventor: String,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = OpenAIClient::from_env()?;
 
-    println!("--- Streaming a structured Recipe ---\n");
-    let mut stream = client.materialize_stream::<Recipe>("Give me a simple recipe for pancakes.");
+    println!("--- Streaming a list of inventions (one at a time) ---\n");
+    let mut stream =
+        client.materialize_iter::<Invention>("List 8 important inventions of the 20th century.");
 
+    let mut n = 0;
     while let Some(item) = stream.next().await {
-        match item? {
-            // Progressive snapshots: the object filling in, field by field.
-            StreamedObject::Partial(json) => {
-                let name = json.get("name").and_then(|v| v.as_str()).unwrap_or("");
-                let ingredients = json
-                    .get("ingredients")
-                    .and_then(|v| v.as_array())
-                    .map_or(0, |a| a.len());
-                println!("  partial: name={name:?}, ingredients so far={ingredients}");
-            }
-            // The final, fully parsed and validated value.
-            StreamedObject::Complete(recipe) => {
-                println!("\nDone! {recipe:#?}");
-            }
-        }
+        let invention = item?; // each item is fully parsed and validated
+        n += 1;
+        println!(
+            "  {n}. {} ({}) — {}",
+            invention.name, invention.year, invention.inventor
+        );
     }
 
+    println!("\nStreamed {n} items.");
     Ok(())
 }

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -484,6 +484,80 @@ impl AnthropicClient {
     }
 }
 
+#[cfg(feature = "streaming")]
+impl AnthropicClient {
+    /// Build the JSON request body for a streaming call (`stream: true`),
+    /// optionally with a structured-output `output_format`.
+    fn stream_body(
+        &self,
+        prompt: &str,
+        output_format: Option<serde_json::Value>,
+    ) -> serde_json::Value {
+        let is_thinking_model = self.config.model.as_str().contains("sonnet-4")
+            || self.config.model.as_str().contains("opus-4");
+        let thinking_config = self.config.thinking_level.and_then(|level| {
+            if is_thinking_model && level.claude_thinking_enabled() {
+                Some(ClaudeThinkingConfig {
+                    thinking_type: "enabled".to_string(),
+                    budget_tokens: level.claude_budget_tokens(),
+                })
+            } else {
+                None
+            }
+        });
+        let effective_temp = if thinking_config.is_some() {
+            1.0
+        } else {
+            self.config.temperature
+        };
+        let max_tokens = effective_max_tokens(self.config.max_tokens, thinking_config.as_ref());
+
+        let mut body = serde_json::json!({
+            "model": self.config.model.as_str(),
+            "messages": [{ "role": "user", "content": prompt }],
+            "temperature": effective_temp,
+            "max_tokens": max_tokens,
+            "stream": true,
+        });
+        if let Some(tc) = thinking_config {
+            body["thinking"] =
+                serde_json::json!({ "type": tc.thinking_type, "budget_tokens": tc.budget_tokens });
+        }
+        if let Some(of) = output_format {
+            body["output_format"] = of;
+        }
+        body
+    }
+
+    /// Send a streaming request and return the raw SSE response.
+    fn send_stream(
+        &self,
+        body: serde_json::Value,
+    ) -> impl std::future::Future<Output = Result<reqwest::Response>> + Send + 'static {
+        let client = self.client.clone();
+        let api_key = self.config.api_key.clone();
+        let base_url = self
+            .config
+            .base_url
+            .clone()
+            .unwrap_or_else(|| "https://api.anthropic.com/v1".to_string());
+        async move {
+            let url = format!("{}/messages", base_url);
+            let resp = client
+                .post(&url)
+                .header("x-api-key", &api_key)
+                .header("anthropic-version", "2023-06-01")
+                .header("anthropic-beta", "structured-outputs-2025-11-13")
+                .header("Content-Type", "application/json")
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| handle_http_error(e, "Anthropic"))?;
+            check_response_status(resp, "Anthropic").await
+        }
+    }
+}
+
 #[async_trait]
 impl LLMClient for AnthropicClient {
     fn from_env() -> Result<Self> {
@@ -693,6 +767,39 @@ impl LLMClient for AnthropicClient {
             "Successfully extracted text content"
         );
         Ok(GenerateResult::new(content, usage))
+    }
+
+    #[cfg(feature = "streaming")]
+    fn generate_stream<'a>(&'a self, prompt: &'a str) -> crate::backend::streaming::TextStream<'a>
+    where
+        Self: Sync,
+    {
+        let body = self.stream_body(prompt, None);
+        crate::backend::streaming::sse_text_stream(
+            self.send_stream(body),
+            crate::backend::streaming::anthropic_delta,
+        )
+    }
+
+    #[cfg(feature = "streaming")]
+    fn materialize_stream<'a, T>(
+        &'a self,
+        prompt: &'a str,
+    ) -> crate::backend::streaming::ObjectStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        let schema_json = prepare_strict_schema(&T::schema());
+        let output_format = serde_json::json!({
+            "type": "json_schema",
+            "schema": schema_json,
+        });
+        let body = self.stream_body(prompt, Some(output_format));
+        crate::backend::streaming::object_stream(
+            self.send_stream(body),
+            crate::backend::streaming::anthropic_delta,
+        )
     }
 
     /// Fetch available models from Anthropic's API.

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -802,6 +802,26 @@ impl LLMClient for AnthropicClient {
         )
     }
 
+    #[cfg(feature = "streaming")]
+    fn materialize_iter<'a, T>(
+        &'a self,
+        prompt: &'a str,
+    ) -> crate::backend::streaming::ItemStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        let item_schema = prepare_strict_schema(&T::schema());
+        let wrapper = crate::backend::streaming::array_wrapper_schema(item_schema, true);
+        let output_format = serde_json::json!({ "type": "json_schema", "schema": wrapper });
+        let body = self.stream_body(prompt, Some(output_format));
+        crate::backend::streaming::iter_stream(
+            self.send_stream(body),
+            crate::backend::streaming::anthropic_delta,
+            crate::backend::streaming::finalize_item::<T>,
+        )
+    }
+
     /// Fetch available models from Anthropic's API.
     ///
     /// Returns a list of Claude models available for chat completions.

--- a/src/backend/client.rs
+++ b/src/backend/client.rs
@@ -351,6 +351,32 @@ pub trait LLMClient {
         })
     }
 
+    /// Stream a **list** of structured objects, yielding each `T` as soon as that
+    /// element of the response array is fully generated and validated.
+    ///
+    /// This is the primary streaming use case: extracting a long list of items
+    /// without buffering the whole response. The model is asked for a JSON object
+    /// with an `items` array of `T`; elements are parsed and validated one at a
+    /// time.
+    ///
+    /// The default implementation has no streaming fallback (it errors); the
+    /// built-in providers override it. Requires the `streaming` feature.
+    #[cfg(feature = "streaming")]
+    fn materialize_iter<'a, T>(
+        &'a self,
+        _prompt: &'a str,
+    ) -> crate::backend::streaming::ItemStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        Box::pin(futures_util::stream::once(async move {
+            Err::<T, crate::error::RStructorError>(crate::error::RStructorError::Unsupported(
+                "materialize_iter is not implemented for this client".to_string(),
+            ))
+        }))
+    }
+
     /// Create a new client by reading the API key from an environment variable.
     ///
     /// This is a required associated function that all `LLMClient` implementations must provide.

--- a/src/backend/client.rs
+++ b/src/backend/client.rs
@@ -304,6 +304,53 @@ pub trait LLMClient {
     /// ```
     async fn generate_with_metadata(&self, prompt: &str) -> Result<GenerateResult>;
 
+    /// Stream a raw text completion as a sequence of token deltas.
+    ///
+    /// Returns a [`Stream`](futures_util::Stream) of text chunks; concatenating
+    /// every `Ok` item yields the full response. The default implementation falls
+    /// back to a single chunk from [`generate`](Self::generate); the built-in
+    /// providers override it with true server-sent-events streaming.
+    ///
+    /// Requires the `streaming` feature.
+    #[cfg(feature = "streaming")]
+    fn generate_stream<'a>(&'a self, prompt: &'a str) -> crate::backend::streaming::TextStream<'a>
+    where
+        Self: Sync,
+    {
+        Box::pin(async_stream::try_stream! {
+            let text = self.generate(prompt).await?;
+            yield text;
+        })
+    }
+
+    /// Stream a structured object as it is generated.
+    ///
+    /// Yields [`StreamedObject::Partial`](crate::StreamedObject::Partial) snapshots
+    /// (the object's JSON filling in) as the response streams, followed by a single
+    /// [`StreamedObject::Complete`](crate::StreamedObject::Complete) carrying the
+    /// fully parsed and validated `T`. The default implementation falls back to a
+    /// single `Complete` from [`materialize`](Self::materialize); the built-in
+    /// providers override it with true streaming.
+    ///
+    /// Note: unlike [`materialize`](Self::materialize), streaming is single-shot —
+    /// a validation failure ends the stream with an error rather than re-asking.
+    ///
+    /// Requires the `streaming` feature.
+    #[cfg(feature = "streaming")]
+    fn materialize_stream<'a, T>(
+        &'a self,
+        prompt: &'a str,
+    ) -> crate::backend::streaming::ObjectStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        Box::pin(async_stream::try_stream! {
+            let value: T = self.materialize(prompt).await?;
+            yield crate::backend::streaming::StreamedObject::Complete(value);
+        })
+    }
+
     /// Create a new client by reading the API key from an environment variable.
     ///
     /// This is a required associated function that all `LLMClient` implementations must provide.

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -892,6 +892,41 @@ impl LLMClient for GeminiClient {
         )
     }
 
+    #[cfg(feature = "streaming")]
+    fn materialize_iter<'a, T>(
+        &'a self,
+        prompt: &'a str,
+    ) -> crate::backend::streaming::ItemStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        let schema = T::schema();
+        let adjacently_tagged_info =
+            crate::backend::utils::extract_adjacently_tagged_info(&schema.to_json());
+        let item_schema = crate::backend::utils::prepare_gemini_schema(&schema);
+        let wrapper = crate::backend::streaming::array_wrapper_schema(item_schema, false);
+        let body = self.stream_body(prompt, Some(wrapper));
+
+        // Each streamed array element is a `T`; transform internally-tagged enums
+        // back before deserializing.
+        let finalize = move |mut value: Value| -> Result<T> {
+            if let Some(ref info) = adjacently_tagged_info {
+                crate::backend::utils::transform_internally_to_adjacently_tagged(&mut value, info);
+            }
+            let item: T = serde_json::from_value(value)
+                .map_err(|e| RStructorError::SerializationError(e.to_string()))?;
+            item.validate()?;
+            Ok(item)
+        };
+
+        crate::backend::streaming::iter_stream(
+            self.send_stream(body),
+            crate::backend::streaming::gemini_delta,
+            finalize,
+        )
+    }
+
     /// Fetch available models from Gemini's API.
     ///
     /// Returns a list of Gemini models that support content generation.

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -561,6 +561,70 @@ impl GeminiClient {
     }
 }
 
+#[cfg(feature = "streaming")]
+impl GeminiClient {
+    /// Build the JSON request body for a streaming call, optionally with a
+    /// structured-output `response_schema`. (Gemini streams via the
+    /// `:streamGenerateContent?alt=sse` endpoint; the body itself is unchanged.)
+    fn stream_body(&self, prompt: &str, response_schema: Option<Value>) -> Value {
+        let is_gemini3 = self.config.model.as_str().starts_with("gemini-3");
+        let thinking_config = if is_gemini3 {
+            self.config.thinking_level.and_then(|level| {
+                level.gemini_level().map(|l| ThinkingConfig {
+                    thinking_level: l.to_string(),
+                })
+            })
+        } else {
+            None
+        };
+        let request = GenerateContentRequest {
+            contents: vec![Content {
+                role: Some("user".to_string()),
+                parts: vec![Part::Text {
+                    text: prompt.to_string(),
+                }],
+            }],
+            generation_config: GenerationConfig {
+                temperature: self.config.temperature,
+                max_output_tokens: self.config.max_tokens,
+                response_mime_type: response_schema
+                    .as_ref()
+                    .map(|_| "application/json".to_string()),
+                response_schema,
+                thinking_config,
+            },
+        };
+        serde_json::to_value(&request).unwrap_or_else(|_| serde_json::json!({}))
+    }
+
+    /// Send a streaming request and return the raw SSE response.
+    fn send_stream(
+        &self,
+        body: Value,
+    ) -> impl std::future::Future<Output = Result<reqwest::Response>> + Send + 'static {
+        let client = self.client.clone();
+        let api_key = self.config.api_key.clone();
+        let base_url = self
+            .config
+            .base_url
+            .clone()
+            .unwrap_or_else(|| "https://generativelanguage.googleapis.com/v1beta".to_string());
+        let model = self.config.model.as_str().to_string();
+        async move {
+            let url = format!("{}/models/{}:streamGenerateContent", base_url, model);
+            let resp = client
+                .post(&url)
+                .query(&[("alt", "sse"), ("key", api_key.as_str())])
+                .header("Content-Type", "application/json")
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| handle_http_error(e, "Gemini"))?;
+            check_response_status(resp, "Gemini").await
+        }
+    }
+}
+
 #[async_trait]
 impl LLMClient for GeminiClient {
     fn from_env() -> Result<Self> {
@@ -779,6 +843,53 @@ impl LLMClient for GeminiClient {
                 ))
             }
         }
+    }
+
+    #[cfg(feature = "streaming")]
+    fn generate_stream<'a>(&'a self, prompt: &'a str) -> crate::backend::streaming::TextStream<'a>
+    where
+        Self: Sync,
+    {
+        let body = self.stream_body(prompt, None);
+        crate::backend::streaming::sse_text_stream(
+            self.send_stream(body),
+            crate::backend::streaming::gemini_delta,
+        )
+    }
+
+    #[cfg(feature = "streaming")]
+    fn materialize_stream<'a, T>(
+        &'a self,
+        prompt: &'a str,
+    ) -> crate::backend::streaming::ObjectStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        let schema = T::schema();
+        // Gemini may return internally-tagged enums; capture the mapping so the
+        // final buffer can be transformed back before deserializing into `T`.
+        let adjacently_tagged_info =
+            crate::backend::utils::extract_adjacently_tagged_info(&schema.to_json());
+        let gemini_schema = crate::backend::utils::prepare_gemini_schema(&schema);
+        let body = self.stream_body(prompt, Some(gemini_schema));
+
+        let finalize = move |raw: &str| -> Result<T> {
+            let mut json = raw.to_string();
+            if let Some(ref info) = adjacently_tagged_info
+                && let Ok(mut value) = serde_json::from_str::<Value>(raw)
+            {
+                crate::backend::utils::transform_internally_to_adjacently_tagged(&mut value, info);
+                json = serde_json::to_string(&value).unwrap_or(json);
+            }
+            crate::backend::utils::parse_and_validate_response::<T>(&json).map_err(|(e, _)| e)
+        };
+
+        crate::backend::streaming::object_stream_with(
+            self.send_stream(body),
+            crate::backend::streaming::gemini_delta,
+            finalize,
+        )
     }
 
     /// Fetch available models from Gemini's API.

--- a/src/backend/grok.rs
+++ b/src/backend/grok.rs
@@ -595,6 +595,26 @@ impl LLMClient for GrokClient {
         )
     }
 
+    #[cfg(feature = "streaming")]
+    fn materialize_iter<'a, T>(
+        &'a self,
+        prompt: &'a str,
+    ) -> crate::backend::streaming::ItemStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        let item_schema = prepare_strict_schema(&T::schema());
+        let wrapper = crate::backend::streaming::array_wrapper_schema(item_schema, true);
+        let response_format = ResponseFormat::json_schema("items".to_string(), wrapper, None);
+        let body = self.stream_body(prompt, Some(response_format));
+        crate::backend::streaming::iter_stream(
+            self.send_stream(body),
+            crate::backend::streaming::openai_delta,
+            crate::backend::streaming::finalize_item::<T>,
+        )
+    }
+
     /// Fetch available models from Grok's API.
     ///
     /// Returns a list of Grok models available for chat completions.

--- a/src/backend/grok.rs
+++ b/src/backend/grok.rs
@@ -323,6 +323,58 @@ impl GrokClient {
     }
 }
 
+#[cfg(feature = "streaming")]
+impl GrokClient {
+    /// Build the JSON request body for a streaming call (`stream: true`),
+    /// optionally with a structured-output `response_format`.
+    fn stream_body(
+        &self,
+        prompt: &str,
+        response_format: Option<ResponseFormat>,
+    ) -> serde_json::Value {
+        let request = OpenAICompatibleChatCompletionRequest {
+            model: self.config.model.as_str().to_string(),
+            messages: vec![OpenAICompatibleChatMessage {
+                role: "user".to_string(),
+                content: OpenAICompatibleMessageContent::Text(prompt.to_string()),
+            }],
+            response_format,
+            temperature: self.config.temperature,
+            max_tokens: self.config.max_tokens,
+            reasoning_effort: None,
+        };
+        let mut body = serde_json::to_value(&request).unwrap_or_else(|_| serde_json::json!({}));
+        body["stream"] = serde_json::Value::Bool(true);
+        body
+    }
+
+    /// Send a streaming request and return the raw SSE response.
+    fn send_stream(
+        &self,
+        body: serde_json::Value,
+    ) -> impl std::future::Future<Output = Result<reqwest::Response>> + Send + 'static {
+        let client = self.client.clone();
+        let api_key = self.config.api_key.clone();
+        let base_url = self
+            .config
+            .base_url
+            .clone()
+            .unwrap_or_else(|| "https://api.x.ai/v1".to_string());
+        async move {
+            let url = format!("{}/chat/completions", base_url);
+            let resp = client
+                .post(&url)
+                .header("Authorization", format!("Bearer {api_key}"))
+                .header("Content-Type", "application/json")
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| handle_http_error(e, "Grok"))?;
+            check_response_status(resp, "Grok").await
+        }
+    }
+}
+
 #[async_trait]
 impl LLMClient for GrokClient {
     fn from_env() -> Result<Self> {
@@ -509,6 +561,38 @@ impl LLMClient for GrokClient {
                 },
             ))
         }
+    }
+
+    #[cfg(feature = "streaming")]
+    fn generate_stream<'a>(&'a self, prompt: &'a str) -> crate::backend::streaming::TextStream<'a>
+    where
+        Self: Sync,
+    {
+        let body = self.stream_body(prompt, None);
+        crate::backend::streaming::sse_text_stream(
+            self.send_stream(body),
+            crate::backend::streaming::openai_delta,
+        )
+    }
+
+    #[cfg(feature = "streaming")]
+    fn materialize_stream<'a, T>(
+        &'a self,
+        prompt: &'a str,
+    ) -> crate::backend::streaming::ObjectStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        let schema = T::schema();
+        let schema_name = T::schema_name().unwrap_or_else(|| "output".to_string());
+        let schema_json = prepare_strict_schema(&schema);
+        let response_format = ResponseFormat::json_schema(schema_name, schema_json, None);
+        let body = self.stream_body(prompt, Some(response_format));
+        crate::backend::streaming::object_stream(
+            self.send_stream(body),
+            crate::backend::streaming::openai_delta,
+        )
     }
 
     /// Fetch available models from Grok's API.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -30,7 +30,7 @@ pub use messages::{ChatMessage, ChatRole};
 #[cfg(feature = "_client")]
 pub use messages::{MaterializeInternalOutput, ValidationFailureContext};
 #[cfg(feature = "streaming")]
-pub use streaming::{ObjectStream, StreamedObject, TextStream};
+pub use streaming::{ItemStream, ObjectStream, StreamedObject, TextStream};
 pub use usage::{GenerateResult, MaterializeResult, TokenUsage};
 
 /// Information about an available model from an LLM provider.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -8,6 +8,8 @@ mod messages;
 mod model_macro;
 #[cfg(feature = "_client")]
 mod openai_compatible;
+#[cfg(feature = "streaming")]
+pub mod streaming;
 pub mod usage;
 #[cfg(feature = "_client")]
 mod utils;
@@ -27,6 +29,8 @@ pub use client::{LLMClient, MediaFile};
 pub use messages::{ChatMessage, ChatRole};
 #[cfg(feature = "_client")]
 pub use messages::{MaterializeInternalOutput, ValidationFailureContext};
+#[cfg(feature = "streaming")]
+pub use streaming::{ObjectStream, StreamedObject, TextStream};
 pub use usage::{GenerateResult, MaterializeResult, TokenUsage};
 
 /// Information about an available model from an LLM provider.

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -757,6 +757,30 @@ impl LLMClient for OpenAIClient {
         )
     }
 
+    #[cfg(feature = "streaming")]
+    fn materialize_iter<'a, T>(
+        &'a self,
+        prompt: &'a str,
+    ) -> crate::backend::streaming::ItemStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        let item_schema = prepare_strict_schema(&T::schema());
+        let wrapper = crate::backend::streaming::array_wrapper_schema(item_schema, true);
+        let response_format = ResponseFormat::json_schema(
+            "items".to_string(),
+            wrapper,
+            Some("Return a JSON object with an `items` array; each element must follow the item schema exactly.".to_string()),
+        );
+        let body = self.stream_body(prompt, Some(response_format));
+        crate::backend::streaming::iter_stream(
+            self.send_stream(body),
+            crate::backend::streaming::openai_delta,
+            crate::backend::streaming::finalize_item::<T>,
+        )
+    }
+
     /// Fetch available models from OpenAI's API.
     ///
     /// Returns a list of GPT models available for chat completions.

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -451,6 +451,71 @@ impl OpenAIClient {
     }
 }
 
+#[cfg(feature = "streaming")]
+impl OpenAIClient {
+    /// Build the JSON request body for a streaming call (`stream: true`),
+    /// optionally with a structured-output `response_format`.
+    fn stream_body(
+        &self,
+        prompt: &str,
+        response_format: Option<ResponseFormat>,
+    ) -> serde_json::Value {
+        let is_gpt5 = self.config.model.as_str().starts_with("gpt-5");
+        let reasoning_effort = if is_gpt5 {
+            self.config
+                .thinking_level
+                .and_then(|level| level.openai_reasoning_effort().map(|s| s.to_string()))
+        } else {
+            None
+        };
+        let effective_temp = if reasoning_effort.is_some() {
+            1.0
+        } else {
+            self.config.temperature
+        };
+        let request = OpenAICompatibleChatCompletionRequest {
+            model: self.config.model.as_str().to_string(),
+            messages: vec![OpenAICompatibleChatMessage {
+                role: "user".to_string(),
+                content: OpenAICompatibleMessageContent::Text(prompt.to_string()),
+            }],
+            response_format,
+            temperature: effective_temp,
+            max_tokens: self.config.max_tokens,
+            reasoning_effort,
+        };
+        let mut body = serde_json::to_value(&request).unwrap_or_else(|_| serde_json::json!({}));
+        body["stream"] = serde_json::Value::Bool(true);
+        body
+    }
+
+    /// Send a streaming request and return the raw SSE response.
+    fn send_stream(
+        &self,
+        body: serde_json::Value,
+    ) -> impl std::future::Future<Output = Result<reqwest::Response>> + Send + 'static {
+        let client = self.client.clone();
+        let api_key = self.config.api_key.clone();
+        let base_url = self
+            .config
+            .base_url
+            .clone()
+            .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
+        async move {
+            let url = format!("{}/chat/completions", base_url);
+            let resp = client
+                .post(&url)
+                .header("Authorization", format!("Bearer {api_key}"))
+                .header("Content-Type", "application/json")
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| handle_http_error(e, "OpenAI"))?;
+            check_response_status(resp, "OpenAI").await
+        }
+    }
+}
+
 #[async_trait]
 impl LLMClient for OpenAIClient {
     fn from_env() -> Result<Self> {
@@ -654,6 +719,42 @@ impl LLMClient for OpenAIClient {
                 },
             ))
         }
+    }
+
+    #[cfg(feature = "streaming")]
+    fn generate_stream<'a>(&'a self, prompt: &'a str) -> crate::backend::streaming::TextStream<'a>
+    where
+        Self: Sync,
+    {
+        let body = self.stream_body(prompt, None);
+        crate::backend::streaming::sse_text_stream(
+            self.send_stream(body),
+            crate::backend::streaming::openai_delta,
+        )
+    }
+
+    #[cfg(feature = "streaming")]
+    fn materialize_stream<'a, T>(
+        &'a self,
+        prompt: &'a str,
+    ) -> crate::backend::streaming::ObjectStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        let schema = T::schema();
+        let schema_name = T::schema_name().unwrap_or_else(|| "output".to_string());
+        let schema_json = prepare_strict_schema(&schema);
+        let response_format = ResponseFormat::json_schema(
+            schema_name,
+            schema_json,
+            Some("Output in the specified format. Include ALL required fields and follow the schema exactly.".to_string()),
+        );
+        let body = self.stream_body(prompt, Some(response_format));
+        crate::backend::streaming::object_stream(
+            self.send_stream(body),
+            crate::backend::streaming::openai_delta,
+        )
     }
 
     /// Fetch available models from OpenAI's API.

--- a/src/backend/streaming.rs
+++ b/src/backend/streaming.rs
@@ -1,0 +1,497 @@
+//! Shared infrastructure for streaming responses over server-sent events (SSE).
+//!
+//! All four providers stream chat/text responses as an SSE body: a sequence of
+//! `data: <json>` lines separated by blank lines, optionally terminated by a
+//! `data: [DONE]` sentinel (OpenAI/Grok). The JSON shape differs per provider, so
+//! each backend supplies a small `extract` closure that pulls the incremental text
+//! out of one parsed event; the SSE framing and chunk-boundary buffering are shared
+//! here.
+//!
+//! Two kinds of stream are built on this:
+//!
+//! - **Text streaming** ([`sse_text_stream`]) yields raw text deltas.
+//! - **Object streaming** ([`object_stream`]) accumulates the streamed text (which
+//!   for a structured request is partial JSON), and after each delta tries to
+//!   repair the buffer into valid JSON and yield a [`StreamedObject::Partial`]
+//!   snapshot; when the stream ends it parses and validates the full buffer into
+//!   the target type and yields [`StreamedObject::Complete`].
+//!
+//! This module is only compiled with the `streaming` feature.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use async_stream::try_stream;
+use futures_util::{Stream, StreamExt};
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::error::{RStructorError, Result};
+use crate::model::Instructor;
+
+/// A boxed stream of text deltas. Each item is either an incremental piece of the
+/// model's text output or a transport/decode error.
+pub type TextStream<'a> = Pin<Box<dyn Stream<Item = Result<String>> + Send + 'a>>;
+
+/// A boxed stream of [`StreamedObject`] items for a streaming structured request.
+pub type ObjectStream<'a, T> = Pin<Box<dyn Stream<Item = Result<StreamedObject<T>>> + Send + 'a>>;
+
+/// An item yielded by a streaming structured ("object") request.
+#[derive(Debug, Clone)]
+pub enum StreamedObject<T> {
+    /// A progressively-completed snapshot of the object as raw JSON, emitted as
+    /// more of the response arrives. Fields not yet generated are simply absent.
+    Partial(Value),
+    /// The final, fully parsed and validated value. Always the last item on a
+    /// successful stream.
+    Complete(T),
+}
+
+impl<T> StreamedObject<T> {
+    /// The final value, if this is the [`Complete`](StreamedObject::Complete) item.
+    pub fn complete(self) -> Option<T> {
+        match self {
+            StreamedObject::Complete(value) => Some(value),
+            StreamedObject::Partial(_) => None,
+        }
+    }
+}
+
+/// One decoded SSE event of interest.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum SseEvent {
+    /// The payload of a `data:` line (raw, usually JSON).
+    Data(String),
+    /// The `[DONE]` sentinel that ends an OpenAI-style stream.
+    Done,
+}
+
+/// Incremental SSE line decoder.
+///
+/// Bytes arrive in arbitrary HTTP chunks that do not respect line boundaries, so
+/// the decoder buffers a partial trailing line between [`push`](Self::push) calls
+/// and only emits events for lines it has seen in full.
+#[derive(Default)]
+pub(crate) struct SseDecoder {
+    buf: Vec<u8>,
+}
+
+impl SseDecoder {
+    /// Feed a chunk of bytes, returning any complete `data:` events it completed.
+    pub(crate) fn push(&mut self, chunk: &[u8]) -> Vec<SseEvent> {
+        self.buf.extend_from_slice(chunk);
+        let mut events = Vec::new();
+
+        while let Some(nl) = self.buf.iter().position(|&b| b == b'\n') {
+            let line_bytes: Vec<u8> = self.buf.drain(..=nl).collect();
+            let line = String::from_utf8_lossy(&line_bytes);
+            let line = line.trim_end_matches(['\r', '\n']);
+
+            // SSE: only `data:` fields carry content. Ignore `event:`, `id:`,
+            // `retry:`, comment lines (`:`...), and blank separators.
+            if let Some(rest) = line.strip_prefix("data:") {
+                let data = rest.trim();
+                if data == "[DONE]" {
+                    events.push(SseEvent::Done);
+                } else if !data.is_empty() {
+                    events.push(SseEvent::Data(data.to_string()));
+                }
+            }
+        }
+
+        events
+    }
+}
+
+/// Build a raw-text stream from an SSE HTTP response.
+///
+/// `send` is the (async) request that yields the streaming response; deferring it
+/// lets this function return a `Stream` synchronously. `extract` pulls the
+/// incremental text out of each parsed `data:` JSON event.
+pub(crate) fn sse_text_stream<'a, Fut, F>(send: Fut, extract: F) -> TextStream<'a>
+where
+    Fut: Future<Output = Result<reqwest::Response>> + Send + 'a,
+    F: Fn(&Value) -> Option<String> + Send + 'a,
+{
+    Box::pin(try_stream! {
+        let response = send.await?;
+        let mut bytes = response.bytes_stream();
+        let mut decoder = SseDecoder::default();
+
+        'outer: while let Some(chunk) = bytes.next().await {
+            let chunk = chunk.map_err(RStructorError::from)?;
+            for event in decoder.push(chunk.as_ref()) {
+                match event {
+                    SseEvent::Done => break 'outer,
+                    SseEvent::Data(data) => {
+                        if let Ok(json) = serde_json::from_str::<Value>(&data)
+                            && let Some(text) = extract(&json)
+                            && !text.is_empty()
+                        {
+                            yield text;
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// Build a structured "object" stream from an SSE HTTP response, parsing and
+/// validating the final buffer into `T`.
+///
+/// The streamed text is the model's (partial) JSON. After each delta the buffer is
+/// repaired into valid JSON (best effort) and, when that succeeds and the snapshot
+/// changed, a [`StreamedObject::Partial`] is yielded. When the stream ends the full
+/// buffer is parsed and validated into `T` and yielded as
+/// [`StreamedObject::Complete`].
+pub(crate) fn object_stream<'a, T, Fut, F>(send: Fut, extract: F) -> ObjectStream<'a, T>
+where
+    T: Instructor + DeserializeOwned + Send + 'a,
+    Fut: Future<Output = Result<reqwest::Response>> + Send + 'a,
+    F: Fn(&Value) -> Option<String> + Send + 'a,
+{
+    object_stream_with(send, extract, |raw: &str| {
+        super::utils::parse_and_validate_response::<T>(raw).map_err(|(err, _ctx)| err)
+    })
+}
+
+/// Like [`object_stream`], but with a caller-supplied `finalize` that turns the
+/// complete raw buffer into the validated `T`. Used by providers (e.g. Gemini)
+/// that must transform the response before deserializing.
+pub(crate) fn object_stream_with<'a, T, Fut, F, Fin>(
+    send: Fut,
+    extract: F,
+    finalize: Fin,
+) -> ObjectStream<'a, T>
+where
+    T: Send + 'a,
+    Fut: Future<Output = Result<reqwest::Response>> + Send + 'a,
+    F: Fn(&Value) -> Option<String> + Send + 'a,
+    Fin: FnOnce(&str) -> Result<T> + Send + 'a,
+{
+    Box::pin(try_stream! {
+        let response = send.await?;
+        let mut bytes = response.bytes_stream();
+        let mut decoder = SseDecoder::default();
+        let mut buf = String::new();
+        let mut last_partial: Option<Value> = None;
+
+        'outer: while let Some(chunk) = bytes.next().await {
+            let chunk = chunk.map_err(RStructorError::from)?;
+            for event in decoder.push(chunk.as_ref()) {
+                match event {
+                    SseEvent::Done => break 'outer,
+                    SseEvent::Data(data) => {
+                        if let Ok(json) = serde_json::from_str::<Value>(&data)
+                            && let Some(text) = extract(&json)
+                        {
+                            buf.push_str(&text);
+                            if let Some(partial) = complete_json(&buf)
+                                && last_partial.as_ref() != Some(&partial)
+                            {
+                                last_partial = Some(partial.clone());
+                                yield StreamedObject::Partial(partial);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let value: T = finalize(buf.trim())?;
+        yield StreamedObject::Complete(value);
+    })
+}
+
+/// Extract the text delta from an OpenAI/Grok streaming chunk
+/// (`{"choices":[{"delta":{"content":"..."}}]}`).
+pub(crate) fn openai_delta(event: &Value) -> Option<String> {
+    event
+        .get("choices")?
+        .get(0)?
+        .get("delta")?
+        .get("content")?
+        .as_str()
+        .map(str::to_owned)
+}
+
+/// Extract the text delta from an Anthropic streaming event
+/// (`{"type":"content_block_delta","delta":{"text":"..."}}`). Also accepts
+/// `input_json_delta.partial_json`, used when streaming structured output.
+pub(crate) fn anthropic_delta(event: &Value) -> Option<String> {
+    if event.get("type")?.as_str()? != "content_block_delta" {
+        return None;
+    }
+    let delta = event.get("delta")?;
+    delta
+        .get("text")
+        .and_then(Value::as_str)
+        .or_else(|| delta.get("partial_json").and_then(Value::as_str))
+        .map(str::to_owned)
+}
+
+/// Extract the text delta from a Gemini streaming chunk
+/// (`{"candidates":[{"content":{"parts":[{"text":"..."}]}}]}`). Concatenates the
+/// text of every part in the chunk.
+pub(crate) fn gemini_delta(event: &Value) -> Option<String> {
+    let parts = event
+        .get("candidates")?
+        .get(0)?
+        .get("content")?
+        .get("parts")?
+        .as_array()?;
+
+    let text: String = parts
+        .iter()
+        .filter_map(|p| p.get("text").and_then(Value::as_str))
+        .collect();
+
+    if text.is_empty() { None } else { Some(text) }
+}
+
+/// Repair a possibly-truncated JSON prefix into a parseable JSON value.
+///
+/// Returns `Some(value)` only when the repaired text actually parses, so callers
+/// never see invalid JSON; when the prefix is too incomplete to safely complete
+/// (e.g. a half-written number) it returns `None` and the caller simply waits for
+/// more input. This is intended for emitting progressive snapshots of streamed
+/// structured output — the authoritative final parse always uses the raw buffer.
+pub(crate) fn complete_json(s: &str) -> Option<Value> {
+    let repaired = repair_json(s)?;
+    serde_json::from_str(&repaired).ok()
+}
+
+/// Best-effort completion of a truncated JSON prefix: close an open string, drop a
+/// dangling key/comma, and close any open objects/arrays. The result is validated
+/// by [`complete_json`] before use, so imperfect repairs are simply discarded.
+fn repair_json(s: &str) -> Option<String> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+
+    let mut out = String::with_capacity(s.len() + 8);
+    let mut stack: Vec<char> = Vec::new();
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for c in s.chars() {
+        if in_string {
+            out.push(c);
+            if escaped {
+                escaped = false;
+            } else if c == '\\' {
+                escaped = true;
+            } else if c == '"' {
+                in_string = false;
+            }
+        } else {
+            match c {
+                '"' => {
+                    in_string = true;
+                    out.push(c);
+                }
+                '{' => {
+                    stack.push('{');
+                    out.push(c);
+                }
+                '[' => {
+                    stack.push('[');
+                    out.push(c);
+                }
+                '}' => {
+                    if stack.pop() != Some('{') {
+                        return None;
+                    }
+                    out.push(c);
+                }
+                ']' => {
+                    if stack.pop() != Some('[') {
+                        return None;
+                    }
+                    out.push(c);
+                }
+                _ => out.push(c),
+            }
+        }
+    }
+
+    // A trailing incomplete escape (`...\`) inside a string: drop the backslash.
+    if in_string && escaped {
+        out.pop();
+    }
+    // Close an open string.
+    if in_string {
+        out.push('"');
+    }
+
+    // Trim trailing structural debris that can't be completed: a dangling comma,
+    // or a dangling object key (`"key":` with no value yet).
+    loop {
+        let trimmed_len = out.trim_end().len();
+        out.truncate(trimmed_len);
+        if out.ends_with(',') {
+            out.pop();
+            continue;
+        }
+        if out.ends_with(':') {
+            // Drop the dangling `"key":` back to the previous `{` or `,`.
+            if let Some(cut) = out.rfind(['{', ',']) {
+                out.truncate(cut + 1);
+            } else {
+                return None;
+            }
+            continue;
+        }
+        break;
+    }
+
+    // Close any still-open containers, innermost first.
+    for &opener in stack.iter().rev() {
+        out.push(if opener == '{' { '}' } else { ']' });
+    }
+
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn decoder_emits_complete_data_event() {
+        let mut d = SseDecoder::default();
+        assert_eq!(
+            d.push(b"data: {\"a\":1}\n\n"),
+            vec![SseEvent::Data("{\"a\":1}".to_string())]
+        );
+    }
+
+    #[test]
+    fn decoder_buffers_across_chunk_boundary() {
+        let mut d = SseDecoder::default();
+        assert_eq!(d.push(b"data: {\"hel"), vec![]);
+        assert_eq!(d.push(b"lo\":1"), vec![]);
+        assert_eq!(
+            d.push(b"}\n"),
+            vec![SseEvent::Data("{\"hello\":1}".to_string())]
+        );
+    }
+
+    #[test]
+    fn decoder_handles_crlf_and_ignores_non_data_lines() {
+        let mut d = SseDecoder::default();
+        assert_eq!(
+            d.push(b"event: message\r\ndata: {\"x\":1}\r\n\r\n: keep-alive\r\n"),
+            vec![SseEvent::Data("{\"x\":1}".to_string())]
+        );
+    }
+
+    #[test]
+    fn decoder_recognizes_done_sentinel() {
+        let mut d = SseDecoder::default();
+        assert_eq!(d.push(b"data: [DONE]\n\n"), vec![SseEvent::Done]);
+    }
+
+    #[test]
+    fn openai_delta_extracts_content() {
+        assert_eq!(
+            openai_delta(&json!({"choices":[{"delta":{"content":"Hi"}}]})),
+            Some("Hi".to_string())
+        );
+        assert_eq!(
+            openai_delta(&json!({"choices":[{"delta":{"role":"assistant"}}]})),
+            None
+        );
+    }
+
+    #[test]
+    fn anthropic_delta_extracts_text_and_partial_json() {
+        assert_eq!(
+            anthropic_delta(
+                &json!({"type":"content_block_delta","delta":{"type":"text_delta","text":"Hi"}})
+            ),
+            Some("Hi".to_string())
+        );
+        assert_eq!(
+            anthropic_delta(
+                &json!({"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{\"a\":"}})
+            ),
+            Some("{\"a\":".to_string())
+        );
+        assert_eq!(anthropic_delta(&json!({"type":"message_start"})), None);
+    }
+
+    #[test]
+    fn gemini_delta_concatenates_parts() {
+        assert_eq!(
+            gemini_delta(
+                &json!({"candidates":[{"content":{"parts":[{"text":"a"},{"text":"b"}]}}]})
+            ),
+            Some("ab".to_string())
+        );
+    }
+
+    #[test]
+    fn complete_json_closes_open_string_and_object() {
+        assert_eq!(
+            complete_json(r#"{"name": "Ali"#).unwrap(),
+            json!({"name": "Ali"})
+        );
+    }
+
+    #[test]
+    fn complete_json_drops_dangling_key_and_comma() {
+        assert_eq!(complete_json(r#"{"a": 1, "b":"#).unwrap(), json!({"a": 1}));
+        assert_eq!(complete_json(r#"{"a": 1, "#).unwrap(), json!({"a": 1}));
+        assert_eq!(complete_json(r#"{"a": 1,"#).unwrap(), json!({"a": 1}));
+    }
+
+    #[test]
+    fn complete_json_closes_nested_and_arrays() {
+        assert_eq!(
+            complete_json(r#"{"items":[{"x":1},{"x":2"#).unwrap(),
+            json!({"items":[{"x":1},{"x":2}]})
+        );
+        assert_eq!(complete_json(r#"[1, 2, 3"#).unwrap(), json!([1, 2, 3]));
+        assert_eq!(complete_json(r#"[1, 2, "#).unwrap(), json!([1, 2]));
+    }
+
+    #[test]
+    fn complete_json_skips_incomplete_primitive() {
+        // A half-written number/keyword can't be safely completed → None.
+        assert!(complete_json(r#"{"a": tr"#).is_none());
+        assert!(complete_json(r#"{"a": 12."#).is_none());
+        assert!(complete_json("").is_none());
+    }
+
+    #[test]
+    fn complete_json_handles_escapes() {
+        assert_eq!(
+            complete_json(r#"{"s": "line\"#).unwrap(),
+            json!({"s": "line"})
+        );
+        assert_eq!(
+            complete_json(r#"{"s": "a\nb"#).unwrap(),
+            json!({"s": "a\nb"})
+        );
+    }
+
+    #[test]
+    fn complete_json_progressive_prefixes_converge() {
+        let full = r#"{"name":"Alice","age":30,"tags":["x","y"]}"#;
+        // Every prefix either yields None or a valid JSON value, and the full
+        // string yields the exact object.
+        for i in 1..=full.len() {
+            if let Some(v) = complete_json(&full[..i]) {
+                assert!(v.is_object() || v.is_array());
+            }
+        }
+        assert_eq!(
+            complete_json(full).unwrap(),
+            json!({"name":"Alice","age":30,"tags":["x","y"]})
+        );
+    }
+}

--- a/src/backend/streaming.rs
+++ b/src/backend/streaming.rs
@@ -495,3 +495,193 @@ mod tests {
         );
     }
 }
+
+/// A boxed stream of fully-parsed items, one per element of a streamed JSON array.
+pub type ItemStream<'a, T> = Pin<Box<dyn Stream<Item = Result<T>> + Send + 'a>>;
+
+/// Incrementally extracts complete top-level elements from a streaming JSON array.
+///
+/// Used by `materialize_iter` to yield each element of a list as soon as it is
+/// fully received, rather than buffering the whole array. The model is asked for a
+/// wrapper object `{"items": [ ... ]}`; the streamer skips to the first `[` (the
+/// `items` array) and then emits each complete element (object or scalar) as a
+/// `serde_json::Value`.
+#[derive(Default)]
+pub(crate) struct JsonArrayStreamer {
+    in_array: bool,
+    depth: i32,
+    in_string: bool,
+    escaped: bool,
+    started_element: bool,
+    current: String,
+}
+
+impl JsonArrayStreamer {
+    pub(crate) fn push_str(&mut self, s: &str) -> Vec<Value> {
+        let mut out = Vec::new();
+        for c in s.chars() {
+            if !self.in_array {
+                if c == '[' {
+                    self.in_array = true;
+                }
+                continue;
+            }
+            if self.in_string {
+                self.current.push(c);
+                if self.escaped {
+                    self.escaped = false;
+                } else if c == '\\' {
+                    self.escaped = true;
+                } else if c == '"' {
+                    self.in_string = false;
+                }
+                continue;
+            }
+            match c {
+                '"' => {
+                    self.started_element = true;
+                    self.in_string = true;
+                    self.current.push(c);
+                }
+                '{' | '[' => {
+                    self.started_element = true;
+                    self.depth += 1;
+                    self.current.push(c);
+                }
+                '}' | ']' if self.depth > 0 => {
+                    self.depth -= 1;
+                    self.current.push(c);
+                }
+                ']' => {
+                    // End of the items array.
+                    if let Some(v) = self.finish_element() {
+                        out.push(v);
+                    }
+                    self.in_array = false;
+                }
+                ',' if self.depth == 0 => {
+                    if let Some(v) = self.finish_element() {
+                        out.push(v);
+                    }
+                }
+                c if c.is_whitespace() && !self.started_element => {}
+                _ => {
+                    self.started_element = true;
+                    self.current.push(c);
+                }
+            }
+        }
+        out
+    }
+
+    fn finish_element(&mut self) -> Option<Value> {
+        let text = std::mem::take(&mut self.current);
+        self.started_element = false;
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        serde_json::from_str(trimmed).ok()
+    }
+}
+
+/// Build a streaming-array request: yields each element of the response's `items`
+/// array as a validated `T`, as soon as it is fully received.
+///
+/// `finalize_item` turns each element's `serde_json::Value` into a validated `T`
+/// (deserialize + validate, plus any provider-specific transform).
+pub(crate) fn iter_stream<'a, T, Fut, F, Fin>(
+    send: Fut,
+    extract: F,
+    finalize_item: Fin,
+) -> ItemStream<'a, T>
+where
+    T: Send + 'a,
+    Fut: Future<Output = Result<reqwest::Response>> + Send + 'a,
+    F: Fn(&Value) -> Option<String> + Send + 'a,
+    Fin: Fn(Value) -> Result<T> + Send + 'a,
+{
+    Box::pin(try_stream! {
+        let response = send.await?;
+        let mut bytes = response.bytes_stream();
+        let mut decoder = SseDecoder::default();
+        let mut array = JsonArrayStreamer::default();
+
+        'outer: while let Some(chunk) = bytes.next().await {
+            let chunk = chunk.map_err(RStructorError::from)?;
+            for event in decoder.push(chunk.as_ref()) {
+                match event {
+                    SseEvent::Done => break 'outer,
+                    SseEvent::Data(data) => {
+                        if let Ok(json) = serde_json::from_str::<Value>(&data)
+                            && let Some(text) = extract(&json)
+                        {
+                            for element in array.push_str(&text) {
+                                yield finalize_item(element)?;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// Default per-element finalizer for [`iter_stream`]: deserialize a streamed array
+/// element into `T` and run its validation.
+pub(crate) fn finalize_item<T: Instructor + DeserializeOwned>(value: Value) -> Result<T> {
+    let item: T = serde_json::from_value(value)
+        .map_err(|e| RStructorError::SerializationError(e.to_string()))?;
+    item.validate()?;
+    Ok(item)
+}
+
+/// Wrap a (prepared) item schema into the `{ "items": [ <item> ] }` object schema
+/// used for streaming arrays. `strict` adds `additionalProperties: false`
+/// (OpenAI/Anthropic); Gemini passes `false`.
+pub(crate) fn array_wrapper_schema(item_schema: Value, strict: bool) -> Value {
+    let mut wrapper = serde_json::json!({
+        "type": "object",
+        "properties": { "items": { "type": "array", "items": item_schema } },
+        "required": ["items"],
+    });
+    if strict {
+        wrapper["additionalProperties"] = Value::Bool(false);
+    }
+    wrapper
+}
+
+#[cfg(test)]
+mod array_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn streams_object_elements_as_they_complete() {
+        let mut s = JsonArrayStreamer::default();
+        // Wrapper prefix + first complete element, split across pushes.
+        assert_eq!(s.push_str(r#"{"items":["#), Vec::<Value>::new());
+        assert_eq!(s.push_str(r#"{"n":1},{"n":2}"#), vec![json!({"n":1})]);
+        assert_eq!(
+            s.push_str(r#",{"n":3}]}"#),
+            vec![json!({"n":2}), json!({"n":3})]
+        );
+    }
+
+    #[test]
+    fn handles_scalars_strings_and_nesting() {
+        let mut s = JsonArrayStreamer::default();
+        let got = s.push_str(r#"{"items":[1, "a,b", {"x":[1,2]}, true]}"#);
+        assert_eq!(
+            got,
+            vec![json!(1), json!("a,b"), json!({"x":[1,2]}), json!(true)]
+        );
+    }
+
+    #[test]
+    fn ignores_strings_containing_brackets_before_array() {
+        let mut s = JsonArrayStreamer::default();
+        // The first '[' is the items array; nothing emitted until an element completes.
+        assert_eq!(s.push_str(r#"{"items":[{"v":"#), Vec::<Value>::new());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,3 +76,5 @@ pub use backend::{AnyClient, Provider};
 pub use backend::{
     ChatMessage, ChatRole, GenerateResult, MaterializeResult, MediaFile, TokenUsage,
 };
+#[cfg(feature = "streaming")]
+pub use backend::{ObjectStream, StreamedObject, TextStream};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,4 +77,4 @@ pub use backend::{
     ChatMessage, ChatRole, GenerateResult, MaterializeResult, MediaFile, TokenUsage,
 };
 #[cfg(feature = "streaming")]
-pub use backend::{ObjectStream, StreamedObject, TextStream};
+pub use backend::{ItemStream, ObjectStream, StreamedObject, TextStream};

--- a/tests/streaming_tests.rs
+++ b/tests/streaming_tests.rs
@@ -1,0 +1,92 @@
+//! Live streaming tests. Only compiled with `--features streaming` (not a default
+//! feature), so the default `cargo test` run does not hit the network.
+#![cfg(feature = "streaming")]
+
+use futures_util::StreamExt;
+use rstructor::{Instructor, LLMClient, StreamedObject};
+use serde::{Deserialize, Serialize};
+
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct Movie {
+    title: String,
+    year: u16,
+    director: String,
+}
+
+/// Drive an object stream to completion, returning (partial_count, final_value).
+async fn drive<C: LLMClient + Sync>(client: &C, prompt: &str) -> (usize, Movie) {
+    let mut stream = client.materialize_stream::<Movie>(prompt);
+    let mut partials = 0usize;
+    let mut complete: Option<Movie> = None;
+    while let Some(item) = stream.next().await {
+        match item.expect("stream item should not error") {
+            StreamedObject::Partial(value) => {
+                assert!(value.is_object(), "partial should be a JSON object");
+                partials += 1;
+            }
+            StreamedObject::Complete(movie) => complete = Some(movie),
+        }
+    }
+    (partials, complete.expect("stream should end with Complete"))
+}
+
+const PROMPT: &str = "Describe the movie Inception: title, year, director.";
+
+#[cfg(feature = "openai")]
+#[tokio::test]
+async fn openai_text_stream_yields_text() {
+    use rstructor::OpenAIClient;
+    let client = OpenAIClient::from_env().unwrap().model("gpt-4.1-mini");
+    let mut stream = client.generate_stream("Say hello in exactly three words.");
+    let mut chunks = 0usize;
+    let mut text = String::new();
+    while let Some(item) = stream.next().await {
+        text.push_str(&item.expect("stream item should not error"));
+        chunks += 1;
+    }
+    assert!(chunks >= 1, "expected at least one streamed chunk");
+    assert!(!text.trim().is_empty());
+}
+
+#[cfg(feature = "openai")]
+#[tokio::test]
+async fn openai_object_stream() {
+    use rstructor::OpenAIClient;
+    let client = OpenAIClient::from_env().unwrap().model("gpt-4.1-mini");
+    let (partials, movie) = drive(&client, PROMPT).await;
+    assert!(!movie.title.trim().is_empty());
+    assert!(movie.year > 1900, "unexpected year: {}", movie.year);
+    assert!(partials >= 1, "expected partial snapshots, got {partials}");
+}
+
+#[cfg(feature = "anthropic")]
+#[tokio::test]
+async fn anthropic_object_stream() {
+    use rstructor::AnthropicClient;
+    let client = AnthropicClient::from_env()
+        .unwrap()
+        .model("claude-haiku-4-5-20251001");
+    let (_partials, movie) = drive(&client, PROMPT).await;
+    assert!(!movie.title.trim().is_empty());
+    assert!(movie.year > 1900, "unexpected year: {}", movie.year);
+}
+
+#[cfg(feature = "gemini")]
+#[tokio::test]
+async fn gemini_object_stream() {
+    use rstructor::GeminiClient;
+    let client = GeminiClient::from_env().unwrap().model("gemini-2.5-flash");
+    let (_partials, movie) = drive(&client, PROMPT).await;
+    assert!(!movie.title.trim().is_empty());
+    assert!(movie.year > 1900, "unexpected year: {}", movie.year);
+}
+
+#[cfg(feature = "grok")]
+#[tokio::test]
+async fn grok_object_stream() {
+    use rstructor::GrokClient;
+    let client = GrokClient::from_env().unwrap();
+    let (_partials, movie) = drive(&client, PROMPT).await;
+    assert!(!movie.title.trim().is_empty());
+    assert!(movie.year > 1900, "unexpected year: {}", movie.year);
+}

--- a/tests/streaming_tests.rs
+++ b/tests/streaming_tests.rs
@@ -90,3 +90,65 @@ async fn grok_object_stream() {
     assert!(!movie.title.trim().is_empty());
     assert!(movie.year > 1900, "unexpected year: {}", movie.year);
 }
+
+// ---- materialize_iter: stream a list, one validated item at a time ----
+
+const LIST_PROMPT: &str = "List 3 acclaimed movies, each with title, year, and director.";
+
+async fn collect_iter<C: LLMClient + Sync>(client: &C) -> Vec<Movie> {
+    let mut stream = client.materialize_iter::<Movie>(LIST_PROMPT);
+    let mut movies = Vec::new();
+    while let Some(item) = stream.next().await {
+        movies.push(item.expect("iter item should not error"));
+    }
+    movies
+}
+
+fn assert_movie_list(movies: &[Movie]) {
+    assert!(
+        movies.len() >= 2,
+        "expected several streamed movies, got {}",
+        movies.len()
+    );
+    assert!(
+        movies
+            .iter()
+            .all(|m| !m.title.trim().is_empty() && m.year > 1900),
+        "every streamed movie should be valid: {movies:?}"
+    );
+}
+
+#[cfg(feature = "openai")]
+#[tokio::test]
+async fn openai_materialize_iter() {
+    use rstructor::OpenAIClient;
+    let client = OpenAIClient::from_env().unwrap().model("gpt-4.1-mini");
+    assert_movie_list(&collect_iter(&client).await);
+}
+
+#[cfg(feature = "grok")]
+#[tokio::test]
+async fn grok_materialize_iter() {
+    use rstructor::GrokClient;
+    let client = GrokClient::from_env().unwrap();
+    assert_movie_list(&collect_iter(&client).await);
+}
+
+#[cfg(feature = "anthropic")]
+#[tokio::test]
+async fn anthropic_materialize_iter() {
+    use rstructor::AnthropicClient;
+    let client = AnthropicClient::from_env()
+        .unwrap()
+        .model("claude-haiku-4-5-20251001")
+        .max_tokens(2048);
+    assert_movie_list(&collect_iter(&client).await);
+}
+
+#[cfg(feature = "gemini")]
+#[tokio::test]
+async fn gemini_materialize_iter() {
+    use rstructor::GeminiClient;
+    let client = GeminiClient::from_env().unwrap().model("gemini-2.5-flash");
+    assert_movie_list(&collect_iter(&client).await);
+}


### PR DESCRIPTION
## Summary

Adds streaming behind an opt-in **`streaming`** feature (off by default). The headline is **list streaming** — the common reason to stream structured extraction is a long list of items.

### `materialize_iter` — stream a list, item by item (primary)
Yields each `T` as soon as that element of the response array is fully generated and validated, without buffering the whole response:

```rust
let mut stream = client.materialize_iter::<Invention>("List 10 important inventions.");
while let Some(item) = stream.next().await {
    let invention = item?;          // fully parsed + validated
    println!("{} ({})", invention.name, invention.year);
}
```

### `generate_stream` — raw text deltas
### `materialize_stream` — a single object as progressive `Partial(json)` snapshots → `Complete(T)`

## Design

- Shared, unit-tested SSE core (`backend/streaming.rs`): an incremental `SseDecoder` (chunk-boundary / CRLF / `[DONE]`), per-provider delta extractors, a `JsonArrayStreamer` that emits complete top-level array elements as they arrive, and a lenient JSON completer for the object-snapshot mode.
- `materialize_iter` asks the model for a `{ "items": [T, ...] }` wrapper schema so it works with strict structured-output modes (OpenAI/Anthropic) and Gemini's `responseSchema`; each element is parsed + validated (Gemini transforms internally-tagged enums per element).
- All three are implemented for **all four providers**; trait methods have safe defaults so third-party `LLMClient` impls keep compiling.

## Verification

- **Live end-to-end tests across all four providers** (`tests/streaming_tests.rs`, `--features streaming`): text streaming, object streaming, and `materialize_iter` lists.
- Unit tests: SSE decoder, delta extractors, the JSON completer, and the array streamer.
- `clippy --all-targets` clean with/without the feature; default `--lib`/`--doc` (0 ignored) unchanged. Adds `examples/streaming_example.rs` + README. CI examples run with `--all-features`.

## Follow-ups
Typed partial structs (`Partial<T>`) for the object-snapshot mode — deliberately deferred (format snapshots as `serde_json::Value` cover the use case; typed partials need recursive companion-type generation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)