### PR TITLE
Add tool (function) calling for all providers (opt-in feature)

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -30,7 +30,7 @@ jobs:
           cache-on-failure: true
 
       - name: Build all examples
-        run: cargo build --examples
+        run: cargo build --all-features --examples
 
   # Run examples in parallel groups (using cached build artifacts)
   examples:
@@ -70,6 +70,6 @@ jobs:
               echo "=========================================="
               echo "Running example: ${examples[$i]}"
               echo "=========================================="
-              cargo run --example "${examples[$i]}"
+              cargo run --all-features --example "${examples[$i]}"
             fi
           done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,8 +76,8 @@ logging = ["tracing-subscriber", "tracing-futures"]
 # all providers yields a dependency-light, schema-only build (derive + schema, no
 # tokio/reqwest) suitable for generating JSON Schema without making API calls.
 _client = ["reqwest", "tokio", "base64"]
-# Opt-in tool/function calling (`Tool`, `Toolbox`, `run_with_tools`). The agentic
-# loop is currently implemented for the OpenAI-compatible providers (OpenAI, Grok).
+# Opt-in tool/function calling (`Tool`, `Toolbox`, `client.with_tools(..).run(..)`).
+# The agentic loop is implemented for all providers (OpenAI, Anthropic, Grok, Gemini).
 tools = ["_client"]
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,13 @@ logging = ["tracing-subscriber", "tracing-futures"]
 # all providers yields a dependency-light, schema-only build (derive + schema, no
 # tokio/reqwest) suitable for generating JSON Schema without making API calls.
 _client = ["reqwest", "tokio", "base64"]
+# Opt-in tool/function calling (`Tool`, `Toolbox`, `run_with_tools`). The agentic
+# loop is currently implemented for the OpenAI-compatible providers (OpenAI, Grok).
+tools = ["_client"]
+
+[[example]]
+name = "tool_calling_example"
+required-features = ["tools", "openai"]
 
 [dev-dependencies]
 # Used only by examples and tests (date/time fields, custom types); not part of

--- a/README.md
+++ b/README.md
@@ -353,10 +353,14 @@ let toolbox = Toolbox::new().with(FnTool::new(
 ));
 
 let client = OpenAIClient::from_env()?;
-let answer = client.run_with_tools("What's the weather in Paris?", &toolbox).await?;
+let answer = client
+    .with_tools(&toolbox)
+    .system("Use tools when relevant.")   // optional
+    .run("What's the weather in Paris?")
+    .await?;
 ```
 
-The agentic loop is currently implemented for the OpenAI-compatible providers (OpenAI, Grok). See `examples/tool_calling_example.rs`.
+Works with all providers (OpenAI, Anthropic, Grok, Gemini). See `examples/tool_calling_example.rs`.
 
 ## Feature Flags
 
@@ -368,7 +372,7 @@ rstructor = { version = "0.2", features = ["openai", "anthropic", "grok", "gemin
 - `openai`, `anthropic`, `grok`, `gemini` — Provider backends (each pulls in the shared HTTP/`tokio` stack)
 - `derive` — Derive macro (default)
 - `logging` — Tracing integration
-- `tools` — Tool/function calling via `Toolbox` + `run_with_tools` (opt-in)
+- `tools` — Tool/function calling via `Toolbox` + `client.with_tools(..).run(..)` (opt-in)
 
 All features are on by default. For a **schema-only build** — generate JSON Schema from your types with no networking, `tokio`, or `reqwest` — disable the providers:
 

--- a/README.md
+++ b/README.md
@@ -325,6 +325,39 @@ match client.materialize::<Movie>("...").await {
 }
 ```
 
+## Tool Calling
+
+Enable the `tools` feature to let the model call your typed Rust functions and feed the results back, looping until it produces a final answer. Tool argument types derive `Instructor`, so their JSON Schema is generated automatically.
+
+```toml
+rstructor = { version = "0.2", features = ["tools"] }
+```
+
+```rust
+use rstructor::{OpenAIClient, Toolbox, FnTool, Instructor};
+use serde::{Serialize, Deserialize};
+use serde_json::json;
+
+#[derive(Instructor, Serialize, Deserialize)]
+struct WeatherArgs {
+    #[llm(description = "City name")]
+    city: String,
+}
+
+let toolbox = Toolbox::new().with(FnTool::new(
+    "get_weather",
+    "Get the current weather for a city",
+    |args: WeatherArgs| async move {
+        Ok(json!({ "city": args.city, "temp_f": 72 }))   // call a real API here
+    },
+));
+
+let client = OpenAIClient::from_env()?;
+let answer = client.run_with_tools("What's the weather in Paris?", &toolbox).await?;
+```
+
+The agentic loop is currently implemented for the OpenAI-compatible providers (OpenAI, Grok). See `examples/tool_calling_example.rs`.
+
 ## Feature Flags
 
 ```toml
@@ -335,6 +368,7 @@ rstructor = { version = "0.2", features = ["openai", "anthropic", "grok", "gemin
 - `openai`, `anthropic`, `grok`, `gemini` — Provider backends (each pulls in the shared HTTP/`tokio` stack)
 - `derive` — Derive macro (default)
 - `logging` — Tracing integration
+- `tools` — Tool/function calling via `Toolbox` + `run_with_tools` (opt-in)
 
 All features are on by default. For a **schema-only build** — generate JSON Schema from your types with no networking, `tokio`, or `reqwest` — disable the providers:
 

--- a/examples/tool_calling_example.rs
+++ b/examples/tool_calling_example.rs
@@ -1,0 +1,56 @@
+//! Tool (function) calling.
+//!
+//! Run with:
+//!   cargo run --example tool_calling_example --features tools
+//!
+//! The model is given two tools and decides which to call (with typed,
+//! schema-validated arguments); rstructor runs them and feeds the results back
+//! until the model produces a final answer.
+
+use rstructor::{FnTool, Instructor, OpenAIClient, Toolbox};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(Instructor, Serialize, Deserialize)]
+struct WeatherArgs {
+    #[llm(description = "City name, e.g. 'Paris'")]
+    city: String,
+}
+
+#[derive(Instructor, Serialize, Deserialize)]
+struct AddArgs {
+    #[llm(description = "First addend")]
+    a: f64,
+    #[llm(description = "Second addend")]
+    b: f64,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let toolbox = Toolbox::new()
+        .with(FnTool::new(
+            "get_weather",
+            "Get the current weather (Fahrenheit) for a city",
+            |args: WeatherArgs| async move {
+                // A real tool would call a weather API here.
+                Ok(json!({ "city": args.city, "temp_f": 68, "conditions": "sunny" }))
+            },
+        ))
+        .with(FnTool::new(
+            "add",
+            "Add two numbers",
+            |args: AddArgs| async move { Ok(json!({ "sum": args.a + args.b })) },
+        ));
+
+    let client = OpenAIClient::from_env()?;
+
+    let answer = client
+        .run_with_tools(
+            "What's the weather in Paris, and what is 21 + 21?",
+            &toolbox,
+        )
+        .await?;
+
+    println!("{answer}");
+    Ok(())
+}

--- a/examples/tool_calling_example.rs
+++ b/examples/tool_calling_example.rs
@@ -45,10 +45,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = OpenAIClient::from_env()?;
 
     let answer = client
-        .run_with_tools(
-            "What's the weather in Paris, and what is 21 + 21?",
-            &toolbox,
-        )
+        .with_tools(&toolbox)
+        .system("You are a helpful assistant. Use the provided tools when relevant.")
+        .run("What's the weather in Paris, and what is 21 + 21?")
         .await?;
 
     println!("{answer}");

--- a/examples/tool_calling_example.rs
+++ b/examples/tool_calling_example.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             |args: AddArgs| async move { Ok(json!({ "sum": args.a + args.b })) },
         ));
 
-    let client = OpenAIClient::from_env()?;
+    let client = OpenAIClient::from_env()?.model("gpt-4.1-mini");
 
     let answer = client
         .with_tools(&toolbox)

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -484,6 +484,52 @@ impl AnthropicClient {
     }
 }
 
+#[cfg(feature = "tools")]
+impl AnthropicClient {
+    /// Begin a tool-calling request: `client.with_tools(&toolbox).run("...").await?`.
+    ///
+    /// Requires the `tools` feature.
+    pub fn with_tools<'a>(
+        &'a self,
+        toolbox: &'a crate::backend::tools::Toolbox,
+    ) -> crate::backend::tools::ToolRequest<'a, Self> {
+        crate::backend::tools::ToolRequest::new(self, toolbox)
+    }
+}
+
+#[cfg(feature = "tools")]
+#[async_trait]
+impl crate::backend::tools::ToolRunner for AnthropicClient {
+    async fn run_tool_loop(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        toolbox: &crate::backend::tools::Toolbox,
+        max_iterations: usize,
+    ) -> Result<String> {
+        let base_url = self
+            .config
+            .base_url
+            .as_deref()
+            .unwrap_or("https://api.anthropic.com/v1");
+        crate::backend::tools::run_anthropic_tools(
+            &self.client,
+            base_url,
+            &self.config.api_key,
+            self.config.model.as_str(),
+            self.config.temperature,
+            self.config
+                .max_tokens
+                .unwrap_or(DEFAULT_ANTHROPIC_MAX_TOKENS),
+            system,
+            prompt,
+            toolbox,
+            max_iterations,
+        )
+        .await
+    }
+}
+
 #[async_trait]
 impl LLMClient for AnthropicClient {
     fn from_env() -> Result<Self> {

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -561,6 +561,50 @@ impl GeminiClient {
     }
 }
 
+#[cfg(feature = "tools")]
+impl GeminiClient {
+    /// Begin a tool-calling request: `client.with_tools(&toolbox).run("...").await?`.
+    ///
+    /// Requires the `tools` feature.
+    pub fn with_tools<'a>(
+        &'a self,
+        toolbox: &'a crate::backend::tools::Toolbox,
+    ) -> crate::backend::tools::ToolRequest<'a, Self> {
+        crate::backend::tools::ToolRequest::new(self, toolbox)
+    }
+}
+
+#[cfg(feature = "tools")]
+#[async_trait]
+impl crate::backend::tools::ToolRunner for GeminiClient {
+    async fn run_tool_loop(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        toolbox: &crate::backend::tools::Toolbox,
+        max_iterations: usize,
+    ) -> Result<String> {
+        let base_url = self
+            .config
+            .base_url
+            .as_deref()
+            .unwrap_or("https://generativelanguage.googleapis.com/v1beta");
+        crate::backend::tools::run_gemini_tools(
+            &self.client,
+            base_url,
+            &self.config.api_key,
+            self.config.model.as_str(),
+            self.config.temperature,
+            self.config.max_tokens,
+            system,
+            prompt,
+            toolbox,
+            max_iterations,
+        )
+        .await
+    }
+}
+
 #[async_trait]
 impl LLMClient for GeminiClient {
     fn from_env() -> Result<Self> {

--- a/src/backend/grok.rs
+++ b/src/backend/grok.rs
@@ -323,6 +323,41 @@ impl GrokClient {
     }
 }
 
+#[cfg(feature = "tools")]
+impl GrokClient {
+    /// Run the agentic tool-calling loop: the model may call the [`Toolbox`]'s
+    /// tools (whose results are fed back) until it produces a final text answer.
+    ///
+    /// Requires the `tools` feature.
+    pub async fn run_with_tools(
+        &self,
+        prompt: &str,
+        toolbox: &crate::backend::tools::Toolbox,
+    ) -> Result<String> {
+        let base_url = self
+            .config
+            .base_url
+            .as_deref()
+            .unwrap_or("https://api.x.ai/v1");
+        let url = format!("{}/chat/completions", base_url);
+
+        crate::backend::tools::run_openai_compatible_tools(
+            &self.client,
+            &url,
+            &self.config.api_key,
+            "Grok",
+            self.config.model.as_str(),
+            self.config.temperature,
+            self.config.max_tokens,
+            None,
+            prompt,
+            toolbox,
+            crate::backend::tools::DEFAULT_MAX_TOOL_ITERATIONS,
+        )
+        .await
+    }
+}
+
 #[async_trait]
 impl LLMClient for GrokClient {
     fn from_env() -> Result<Self> {

--- a/src/backend/grok.rs
+++ b/src/backend/grok.rs
@@ -325,14 +325,26 @@ impl GrokClient {
 
 #[cfg(feature = "tools")]
 impl GrokClient {
-    /// Run the agentic tool-calling loop: the model may call the [`Toolbox`]'s
-    /// tools (whose results are fed back) until it produces a final text answer.
+    /// Begin a tool-calling request: `client.with_tools(&toolbox).run("...").await?`.
     ///
     /// Requires the `tools` feature.
-    pub async fn run_with_tools(
+    pub fn with_tools<'a>(
+        &'a self,
+        toolbox: &'a crate::backend::tools::Toolbox,
+    ) -> crate::backend::tools::ToolRequest<'a, Self> {
+        crate::backend::tools::ToolRequest::new(self, toolbox)
+    }
+}
+
+#[cfg(feature = "tools")]
+#[async_trait]
+impl crate::backend::tools::ToolRunner for GrokClient {
+    async fn run_tool_loop(
         &self,
+        system: Option<&str>,
         prompt: &str,
         toolbox: &crate::backend::tools::Toolbox,
+        max_iterations: usize,
     ) -> Result<String> {
         let base_url = self
             .config
@@ -350,9 +362,10 @@ impl GrokClient {
             self.config.temperature,
             self.config.max_tokens,
             None,
+            system,
             prompt,
             toolbox,
-            crate::backend::tools::DEFAULT_MAX_TOOL_ITERATIONS,
+            max_iterations,
         )
         .await
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -30,7 +30,7 @@ pub use messages::{ChatMessage, ChatRole};
 #[cfg(feature = "_client")]
 pub use messages::{MaterializeInternalOutput, ValidationFailureContext};
 #[cfg(feature = "tools")]
-pub use tools::{DynTool, FnTool, Tool, Toolbox};
+pub use tools::{DynTool, FnTool, Tool, ToolRequest, ToolRunner, Toolbox};
 pub use usage::{GenerateResult, MaterializeResult, TokenUsage};
 
 /// Information about an available model from an LLM provider.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -8,6 +8,8 @@ mod messages;
 mod model_macro;
 #[cfg(feature = "_client")]
 mod openai_compatible;
+#[cfg(feature = "tools")]
+pub mod tools;
 pub mod usage;
 #[cfg(feature = "_client")]
 mod utils;
@@ -27,6 +29,8 @@ pub use client::{LLMClient, MediaFile};
 pub use messages::{ChatMessage, ChatRole};
 #[cfg(feature = "_client")]
 pub use messages::{MaterializeInternalOutput, ValidationFailureContext};
+#[cfg(feature = "tools")]
+pub use tools::{DynTool, FnTool, Tool, Toolbox};
 pub use usage::{GenerateResult, MaterializeResult, TokenUsage};
 
 /// Information about an available model from an LLM provider.

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -453,7 +453,7 @@ impl OpenAIClient {
 
 #[cfg(feature = "tools")]
 impl OpenAIClient {
-    /// Run the agentic tool-calling loop: the model may call the [`Toolbox`]'s
+    /// Begin a tool-calling request. The model may call the [`Toolbox`](crate::Toolbox)'s
     /// tools (whose results are fed back) until it produces a final text answer.
     ///
     /// Requires the `tools` feature.
@@ -473,15 +473,28 @@ impl OpenAIClient {
     /// ));
     ///
     /// let client = OpenAIClient::from_env()?;
-    /// let answer = client.run_with_tools("What's the weather in Paris?", &toolbox).await?;
+    /// let answer = client.with_tools(&toolbox).run("What's the weather in Paris?").await?;
     /// println!("{answer}");
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn run_with_tools(
+    pub fn with_tools<'a>(
+        &'a self,
+        toolbox: &'a crate::backend::tools::Toolbox,
+    ) -> crate::backend::tools::ToolRequest<'a, Self> {
+        crate::backend::tools::ToolRequest::new(self, toolbox)
+    }
+}
+
+#[cfg(feature = "tools")]
+#[async_trait]
+impl crate::backend::tools::ToolRunner for OpenAIClient {
+    async fn run_tool_loop(
         &self,
+        system: Option<&str>,
         prompt: &str,
         toolbox: &crate::backend::tools::Toolbox,
+        max_iterations: usize,
     ) -> Result<String> {
         let base_url = self
             .config
@@ -514,9 +527,10 @@ impl OpenAIClient {
             effective_temp,
             self.config.max_tokens,
             reasoning_effort,
+            system,
             prompt,
             toolbox,
-            crate::backend::tools::DEFAULT_MAX_TOOL_ITERATIONS,
+            max_iterations,
         )
         .await
     }

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -451,6 +451,77 @@ impl OpenAIClient {
     }
 }
 
+#[cfg(feature = "tools")]
+impl OpenAIClient {
+    /// Run the agentic tool-calling loop: the model may call the [`Toolbox`]'s
+    /// tools (whose results are fed back) until it produces a final text answer.
+    ///
+    /// Requires the `tools` feature.
+    ///
+    /// ```no_run
+    /// # use rstructor::{OpenAIClient, Toolbox, FnTool, Instructor};
+    /// # use serde::{Serialize, Deserialize};
+    /// # use serde_json::json;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// #[derive(Instructor, Serialize, Deserialize)]
+    /// struct WeatherArgs { city: String }
+    ///
+    /// let toolbox = Toolbox::new().with(FnTool::new(
+    ///     "get_weather",
+    ///     "Get the current weather for a city",
+    ///     |args: WeatherArgs| async move { Ok(json!({ "city": args.city, "temp_f": 72 })) },
+    /// ));
+    ///
+    /// let client = OpenAIClient::from_env()?;
+    /// let answer = client.run_with_tools("What's the weather in Paris?", &toolbox).await?;
+    /// println!("{answer}");
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn run_with_tools(
+        &self,
+        prompt: &str,
+        toolbox: &crate::backend::tools::Toolbox,
+    ) -> Result<String> {
+        let base_url = self
+            .config
+            .base_url
+            .as_deref()
+            .unwrap_or("https://api.openai.com/v1");
+        let url = format!("{}/chat/completions", base_url);
+
+        // GPT-5.x reasoning models require temperature=1.0 and accept reasoning_effort.
+        let is_gpt5 = self.config.model.as_str().starts_with("gpt-5");
+        let reasoning_effort = if is_gpt5 {
+            self.config
+                .thinking_level
+                .and_then(|level| level.openai_reasoning_effort().map(|s| s.to_string()))
+        } else {
+            None
+        };
+        let effective_temp = if reasoning_effort.is_some() {
+            1.0
+        } else {
+            self.config.temperature
+        };
+
+        crate::backend::tools::run_openai_compatible_tools(
+            &self.client,
+            &url,
+            &self.config.api_key,
+            "OpenAI",
+            self.config.model.as_str(),
+            effective_temp,
+            self.config.max_tokens,
+            reasoning_effort,
+            prompt,
+            toolbox,
+            crate::backend::tools::DEFAULT_MAX_TOOL_ITERATIONS,
+        )
+        .await
+    }
+}
+
 #[async_trait]
 impl LLMClient for OpenAIClient {
     fn from_env() -> Result<Self> {

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -503,16 +503,11 @@ impl crate::backend::tools::ToolRunner for OpenAIClient {
             .unwrap_or("https://api.openai.com/v1");
         let url = format!("{}/chat/completions", base_url);
 
-        // GPT-5.x reasoning models require temperature=1.0 and accept reasoning_effort.
+        // GPT-5.x models require temperature=1.0. `reasoning_effort` combined with
+        // function tools is rejected on /v1/chat/completions, so it is omitted for
+        // the tool loop.
         let is_gpt5 = self.config.model.as_str().starts_with("gpt-5");
-        let reasoning_effort = if is_gpt5 {
-            self.config
-                .thinking_level
-                .and_then(|level| level.openai_reasoning_effort().map(|s| s.to_string()))
-        } else {
-            None
-        };
-        let effective_temp = if reasoning_effort.is_some() {
+        let effective_temp = if is_gpt5 {
             1.0
         } else {
             self.config.temperature
@@ -526,7 +521,7 @@ impl crate::backend::tools::ToolRunner for OpenAIClient {
             self.config.model.as_str(),
             effective_temp,
             self.config.max_tokens,
-            reasoning_effort,
+            None,
             system,
             prompt,
             toolbox,

--- a/src/backend/tools.rs
+++ b/src/backend/tools.rs
@@ -1,0 +1,324 @@
+//! Tool (function) calling: let the model invoke typed Rust functions and feed
+//! the results back, looping until it produces a final answer.
+//!
+//! Define tools whose argument types derive [`Instructor`](crate::Instructor) (so
+//! their JSON Schema is generated for you), collect them in a [`Toolbox`], and run
+//! the agentic loop with a client's `run_with_tools`.
+//!
+//! This module is only compiled with the `tools` feature.
+
+use std::future::Future;
+use std::marker::PhantomData;
+
+use async_trait::async_trait;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::error::{RStructorError, Result};
+use crate::model::Instructor;
+use crate::schema::SchemaType;
+
+/// A typed tool the model can call.
+///
+/// Implement this directly, or use [`FnTool`] to wrap a closure. The argument
+/// type `Args` must derive [`Instructor`](crate::Instructor); its JSON Schema is
+/// sent to the model so it knows how to call the tool.
+#[async_trait]
+pub trait Tool: Send + Sync {
+    /// The tool's argument type. Its schema is derived via `Instructor`.
+    type Args: Instructor + DeserializeOwned + Send;
+
+    /// The tool name the model uses to call it (must be unique within a toolbox).
+    fn name(&self) -> String;
+
+    /// A description telling the model what the tool does and when to use it.
+    fn description(&self) -> String;
+
+    /// Execute the tool with deserialized arguments, returning a JSON result that
+    /// is fed back to the model.
+    async fn invoke(&self, args: Self::Args) -> Result<Value>;
+}
+
+/// Object-safe, type-erased view of a [`Tool`], used to store heterogeneous tools
+/// in a [`Toolbox`]. Implemented automatically for every `Tool`.
+#[async_trait]
+pub trait DynTool: Send + Sync {
+    /// The tool name.
+    fn name(&self) -> String;
+    /// The tool description.
+    fn description(&self) -> String;
+    /// The JSON Schema for the tool's arguments.
+    fn parameters_schema(&self) -> Value;
+    /// Invoke the tool with raw JSON arguments (deserialized into `Args`).
+    async fn invoke_json(&self, args: Value) -> Result<Value>;
+}
+
+#[async_trait]
+impl<T: Tool> DynTool for T {
+    fn name(&self) -> String {
+        Tool::name(self)
+    }
+
+    fn description(&self) -> String {
+        Tool::description(self)
+    }
+
+    fn parameters_schema(&self) -> Value {
+        crate::backend::utils::prepare_strict_schema(&<T::Args as SchemaType>::schema())
+    }
+
+    async fn invoke_json(&self, args: Value) -> Result<Value> {
+        let typed: T::Args = serde_json::from_value(args)
+            .map_err(|e| RStructorError::SerializationError(e.to_string()))?;
+        self.invoke(typed).await
+    }
+}
+
+/// A [`Tool`] built from a closure.
+///
+/// ```no_run
+/// # use rstructor::{FnTool, Instructor, Toolbox};
+/// # use serde::{Serialize, Deserialize};
+/// # use serde_json::json;
+/// #[derive(Instructor, Serialize, Deserialize)]
+/// struct WeatherArgs {
+///     #[llm(description = "City name")]
+///     city: String,
+/// }
+///
+/// let tool = FnTool::new("get_weather", "Get the current weather for a city", |args: WeatherArgs| async move {
+///     Ok(json!({ "city": args.city, "temp_f": 72 }))
+/// });
+/// let toolbox = Toolbox::new().with(tool);
+/// ```
+pub struct FnTool<A, F> {
+    name: String,
+    description: String,
+    func: F,
+    _marker: PhantomData<fn() -> A>,
+}
+
+impl<A, F> FnTool<A, F> {
+    /// Create a tool from a name, description, and an async closure over the
+    /// (derived-schema) argument type.
+    pub fn new(name: impl Into<String>, description: impl Into<String>, func: F) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            func,
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[async_trait]
+impl<A, F, Fut> Tool for FnTool<A, F>
+where
+    A: Instructor + DeserializeOwned + Send + 'static,
+    F: Fn(A) -> Fut + Send + Sync,
+    Fut: Future<Output = Result<Value>> + Send,
+{
+    type Args = A;
+
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn description(&self) -> String {
+        self.description.clone()
+    }
+
+    async fn invoke(&self, args: A) -> Result<Value> {
+        (self.func)(args).await
+    }
+}
+
+/// A collection of tools made available to the model.
+#[derive(Default)]
+pub struct Toolbox {
+    tools: Vec<Box<dyn DynTool>>,
+}
+
+impl Toolbox {
+    /// Create an empty toolbox.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a tool, returning the toolbox (builder style).
+    #[must_use]
+    pub fn with(mut self, tool: impl DynTool + 'static) -> Self {
+        self.tools.push(Box::new(tool));
+        self
+    }
+
+    /// Add a tool in place.
+    pub fn add(&mut self, tool: impl DynTool + 'static) -> &mut Self {
+        self.tools.push(Box::new(tool));
+        self
+    }
+
+    /// Whether the toolbox has no tools.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.tools.is_empty()
+    }
+
+    /// Number of tools.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.tools.len()
+    }
+
+    /// Find a tool by name.
+    fn get(&self, name: &str) -> Option<&dyn DynTool> {
+        self.tools
+            .iter()
+            .find(|t| t.name() == name)
+            .map(AsRef::as_ref)
+    }
+
+    /// Render the tools as OpenAI-compatible `tools` JSON.
+    #[cfg(any(feature = "openai", feature = "grok"))]
+    fn openai_tools_json(&self) -> Vec<Value> {
+        self.tools
+            .iter()
+            .map(|t| {
+                serde_json::json!({
+                    "type": "function",
+                    "function": {
+                        "name": t.name(),
+                        "description": t.description(),
+                        "parameters": t.parameters_schema(),
+                    }
+                })
+            })
+            .collect()
+    }
+}
+
+/// The default maximum number of model round-trips before the tool loop gives up.
+pub(crate) const DEFAULT_MAX_TOOL_ITERATIONS: usize = 10;
+
+/// Run the agentic tool-calling loop against an OpenAI-compatible chat endpoint
+/// (OpenAI and Grok). Returns the model's final text answer.
+#[cfg(any(feature = "openai", feature = "grok"))]
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_openai_compatible_tools(
+    client: &reqwest::Client,
+    url: &str,
+    api_key: &str,
+    provider: &str,
+    model: &str,
+    temperature: f32,
+    max_tokens: Option<u32>,
+    reasoning_effort: Option<String>,
+    prompt: &str,
+    toolbox: &Toolbox,
+    max_iterations: usize,
+) -> Result<String> {
+    use crate::backend::{check_response_status, handle_http_error};
+    use serde_json::json;
+    use tracing::{debug, warn};
+
+    let tools_json = toolbox.openai_tools_json();
+    let mut messages: Vec<Value> = vec![json!({ "role": "user", "content": prompt })];
+
+    for iteration in 0..max_iterations {
+        let mut body = json!({
+            "model": model,
+            "messages": messages,
+            "temperature": temperature,
+        });
+        if !tools_json.is_empty() {
+            body["tools"] = json!(tools_json);
+            body["tool_choice"] = json!("auto");
+        }
+        if let Some(mt) = max_tokens {
+            body["max_tokens"] = json!(mt);
+        }
+        if let Some(ref effort) = reasoning_effort {
+            body["reasoning_effort"] = json!(effort);
+        }
+
+        let response = client
+            .post(url)
+            .header("Authorization", format!("Bearer {api_key}"))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| handle_http_error(e, provider))?;
+        let response = check_response_status(response, provider).await?;
+        let payload: Value = response.json().await.map_err(RStructorError::from)?;
+
+        let message = payload
+            .get("choices")
+            .and_then(|c| c.get(0))
+            .and_then(|c| c.get("message"))
+            .ok_or_else(|| {
+                RStructorError::api_error(
+                    provider,
+                    crate::ApiErrorKind::UnexpectedResponse {
+                        details: "No message in tool-calling response".to_string(),
+                    },
+                )
+            })?
+            .clone();
+
+        let tool_calls = message
+            .get("tool_calls")
+            .and_then(Value::as_array)
+            .filter(|calls| !calls.is_empty());
+
+        let Some(tool_calls) = tool_calls else {
+            // No tool calls: the model produced its final answer.
+            let content = message
+                .get("content")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            debug!(iteration, "Tool loop finished with final answer");
+            return Ok(content);
+        };
+
+        // Record the assistant's tool-call message, then execute each call.
+        messages.push(message.clone());
+        for call in tool_calls {
+            let call_id = call.get("id").and_then(Value::as_str).unwrap_or_default();
+            let function = call.get("function");
+            let name = function
+                .and_then(|f| f.get("name"))
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let args_str = function
+                .and_then(|f| f.get("arguments"))
+                .and_then(Value::as_str)
+                .unwrap_or("{}");
+            let args: Value = serde_json::from_str(args_str).unwrap_or_else(|_| json!({}));
+
+            debug!(tool = name, "Model requested tool call");
+            let result = match toolbox.get(name) {
+                Some(tool) => tool.invoke_json(args).await.unwrap_or_else(|e| {
+                    warn!(tool = name, error = %e, "Tool returned an error");
+                    json!({ "error": e.to_string() })
+                }),
+                None => {
+                    warn!(tool = name, "Model called an unknown tool");
+                    json!({ "error": format!("unknown tool: {name}") })
+                }
+            };
+
+            messages.push(json!({
+                "role": "tool",
+                "tool_call_id": call_id,
+                "content": serde_json::to_string(&result).unwrap_or_default(),
+            }));
+        }
+    }
+
+    Err(RStructorError::ValidationError(format!(
+        "tool-calling loop did not converge within {max_iterations} iterations"
+    )))
+}

--- a/src/backend/tools.rs
+++ b/src/backend/tools.rs
@@ -3,7 +3,7 @@
 //!
 //! Define tools whose argument types derive [`Instructor`](crate::Instructor) (so
 //! their JSON Schema is generated for you), collect them in a [`Toolbox`], and run
-//! the agentic loop with a client's `run_with_tools`.
+//! the agentic loop with a client's `with_tools(...).run(prompt)`.
 //!
 //! This module is only compiled with the `tools` feature.
 
@@ -47,8 +47,11 @@ pub trait DynTool: Send + Sync {
     fn name(&self) -> String;
     /// The tool description.
     fn description(&self) -> String;
-    /// The JSON Schema for the tool's arguments.
+    /// The JSON Schema for the tool's arguments (strict form: `additionalProperties:
+    /// false`), as used by OpenAI/Grok/Anthropic.
     fn parameters_schema(&self) -> Value;
+    /// The argument schema with Gemini-unsupported keywords stripped.
+    fn parameters_schema_gemini(&self) -> Value;
     /// Invoke the tool with raw JSON arguments (deserialized into `Args`).
     async fn invoke_json(&self, args: Value) -> Result<Value>;
 }
@@ -65,6 +68,10 @@ impl<T: Tool> DynTool for T {
 
     fn parameters_schema(&self) -> Value {
         crate::backend::utils::prepare_strict_schema(&<T::Args as SchemaType>::schema())
+    }
+
+    fn parameters_schema_gemini(&self) -> Value {
+        crate::backend::utils::prepare_gemini_schema(&<T::Args as SchemaType>::schema())
     }
 
     async fn invoke_json(&self, args: Value) -> Result<Value> {
@@ -196,6 +203,41 @@ impl Toolbox {
             })
             .collect()
     }
+
+    /// Render the tools as Anthropic `tools` JSON.
+    #[cfg(feature = "anthropic")]
+    fn anthropic_tools_json(&self) -> Vec<Value> {
+        self.tools
+            .iter()
+            .map(|t| {
+                serde_json::json!({
+                    "name": t.name(),
+                    "description": t.description(),
+                    "input_schema": t.parameters_schema(),
+                })
+            })
+            .collect()
+    }
+
+    /// Render the tools as Gemini `tools` JSON (a single `functionDeclarations`).
+    #[cfg(feature = "gemini")]
+    fn gemini_tools_json(&self) -> Vec<Value> {
+        if self.tools.is_empty() {
+            return Vec::new();
+        }
+        let declarations: Vec<Value> = self
+            .tools
+            .iter()
+            .map(|t| {
+                serde_json::json!({
+                    "name": t.name(),
+                    "description": t.description(),
+                    "parameters": t.parameters_schema_gemini(),
+                })
+            })
+            .collect();
+        vec![serde_json::json!({ "functionDeclarations": declarations })]
+    }
 }
 
 /// The default maximum number of model round-trips before the tool loop gives up.
@@ -214,6 +256,7 @@ pub(crate) async fn run_openai_compatible_tools(
     temperature: f32,
     max_tokens: Option<u32>,
     reasoning_effort: Option<String>,
+    system: Option<&str>,
     prompt: &str,
     toolbox: &Toolbox,
     max_iterations: usize,
@@ -223,7 +266,11 @@ pub(crate) async fn run_openai_compatible_tools(
     use tracing::{debug, warn};
 
     let tools_json = toolbox.openai_tools_json();
-    let mut messages: Vec<Value> = vec![json!({ "role": "user", "content": prompt })];
+    let mut messages: Vec<Value> = Vec::new();
+    if let Some(system) = system {
+        messages.push(json!({ "role": "system", "content": system }));
+    }
+    messages.push(json!({ "role": "user", "content": prompt }));
 
     for iteration in 0..max_iterations {
         let mut body = json!({
@@ -321,4 +368,285 @@ pub(crate) async fn run_openai_compatible_tools(
     Err(RStructorError::ValidationError(format!(
         "tool-calling loop did not converge within {max_iterations} iterations"
     )))
+}
+
+/// Error returned when a tool loop exhausts its iteration budget.
+#[cfg(any(feature = "anthropic", feature = "gemini"))]
+fn loop_exhausted(max_iterations: usize) -> RStructorError {
+    RStructorError::ValidationError(format!(
+        "tool-calling loop did not converge within {max_iterations} iterations"
+    ))
+}
+
+/// Run the agentic tool-calling loop against Anthropic's Messages API.
+#[cfg(feature = "anthropic")]
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_anthropic_tools(
+    client: &reqwest::Client,
+    base_url: &str,
+    api_key: &str,
+    model: &str,
+    temperature: f32,
+    max_tokens: u32,
+    system: Option<&str>,
+    prompt: &str,
+    toolbox: &Toolbox,
+    max_iterations: usize,
+) -> Result<String> {
+    use crate::backend::{check_response_status, handle_http_error};
+    use serde_json::json;
+    use tracing::debug;
+
+    let tools_json = toolbox.anthropic_tools_json();
+    let url = format!("{base_url}/messages");
+    let mut messages: Vec<Value> = vec![json!({ "role": "user", "content": prompt })];
+
+    for _ in 0..max_iterations {
+        let mut body = json!({
+            "model": model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        });
+        if let Some(system) = system {
+            body["system"] = json!(system);
+        }
+        if !tools_json.is_empty() {
+            body["tools"] = json!(tools_json);
+        }
+
+        let response = client
+            .post(&url)
+            .header("x-api-key", api_key)
+            .header("anthropic-version", "2023-06-01")
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| handle_http_error(e, "Anthropic"))?;
+        let response = check_response_status(response, "Anthropic").await?;
+        let payload: Value = response.json().await.map_err(RStructorError::from)?;
+
+        let content = payload
+            .get("content")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let stop_reason = payload.get("stop_reason").and_then(Value::as_str);
+
+        let tool_uses: Vec<&Value> = content
+            .iter()
+            .filter(|b| b.get("type").and_then(Value::as_str) == Some("tool_use"))
+            .collect();
+
+        if stop_reason != Some("tool_use") || tool_uses.is_empty() {
+            let text: String = content
+                .iter()
+                .filter(|b| b.get("type").and_then(Value::as_str) == Some("text"))
+                .filter_map(|b| b.get("text").and_then(Value::as_str))
+                .collect();
+            return Ok(text);
+        }
+
+        // Echo the assistant's content (incl. tool_use blocks), then return results.
+        let mut results = Vec::with_capacity(tool_uses.len());
+        for tu in &tool_uses {
+            let id = tu.get("id").and_then(Value::as_str).unwrap_or_default();
+            let name = tu.get("name").and_then(Value::as_str).unwrap_or_default();
+            let input = tu.get("input").cloned().unwrap_or_else(|| json!({}));
+
+            debug!(tool = name, "Model requested tool call");
+            let result = match toolbox.get(name) {
+                Some(tool) => tool
+                    .invoke_json(input)
+                    .await
+                    .unwrap_or_else(|e| json!({ "error": e.to_string() })),
+                None => json!({ "error": format!("unknown tool: {name}") }),
+            };
+            results.push(json!({
+                "type": "tool_result",
+                "tool_use_id": id,
+                "content": serde_json::to_string(&result).unwrap_or_default(),
+            }));
+        }
+
+        messages.push(json!({ "role": "assistant", "content": content }));
+        messages.push(json!({ "role": "user", "content": results }));
+    }
+
+    Err(loop_exhausted(max_iterations))
+}
+
+/// Run the agentic tool-calling loop against Gemini's `generateContent` API.
+#[cfg(feature = "gemini")]
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_gemini_tools(
+    client: &reqwest::Client,
+    base_url: &str,
+    api_key: &str,
+    model: &str,
+    temperature: f32,
+    max_tokens: Option<u32>,
+    system: Option<&str>,
+    prompt: &str,
+    toolbox: &Toolbox,
+    max_iterations: usize,
+) -> Result<String> {
+    use crate::backend::{check_response_status, handle_http_error};
+    use serde_json::json;
+    use tracing::debug;
+
+    let tools_json = toolbox.gemini_tools_json();
+    let url = format!("{base_url}/models/{model}:generateContent");
+    let mut contents: Vec<Value> = vec![json!({ "role": "user", "parts": [{ "text": prompt }] })];
+
+    for _ in 0..max_iterations {
+        let mut generation_config = json!({ "temperature": temperature });
+        if let Some(mt) = max_tokens {
+            generation_config["maxOutputTokens"] = json!(mt);
+        }
+        let mut body = json!({ "contents": contents, "generationConfig": generation_config });
+        if let Some(system) = system {
+            body["systemInstruction"] = json!({ "parts": [{ "text": system }] });
+        }
+        if !tools_json.is_empty() {
+            body["tools"] = json!(tools_json);
+        }
+
+        let response = client
+            .post(&url)
+            .query(&[("key", api_key)])
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| handle_http_error(e, "Gemini"))?;
+        let response = check_response_status(response, "Gemini").await?;
+        let payload: Value = response.json().await.map_err(RStructorError::from)?;
+
+        let parts = payload
+            .pointer("/candidates/0/content/parts")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+
+        let function_calls: Vec<&Value> = parts
+            .iter()
+            .filter(|p| p.get("functionCall").is_some())
+            .collect();
+
+        if function_calls.is_empty() {
+            let text: String = parts
+                .iter()
+                .filter_map(|p| p.get("text").and_then(Value::as_str))
+                .collect();
+            return Ok(text);
+        }
+
+        let mut response_parts = Vec::with_capacity(function_calls.len());
+        for fc in &function_calls {
+            let call = fc.get("functionCall").unwrap();
+            let name = call.get("name").and_then(Value::as_str).unwrap_or_default();
+            let args = call.get("args").cloned().unwrap_or_else(|| json!({}));
+
+            debug!(tool = name, "Model requested tool call");
+            let result = match toolbox.get(name) {
+                Some(tool) => tool
+                    .invoke_json(args)
+                    .await
+                    .unwrap_or_else(|e| json!({ "error": e.to_string() })),
+                None => json!({ "error": format!("unknown tool: {name}") }),
+            };
+            // Gemini requires `functionResponse.response` to be a JSON object.
+            let response_obj = if result.is_object() {
+                result
+            } else {
+                json!({ "result": result })
+            };
+            response_parts.push(json!({
+                "functionResponse": { "name": name, "response": response_obj }
+            }));
+        }
+
+        contents.push(json!({ "role": "model", "parts": parts }));
+        contents.push(json!({ "role": "user", "parts": response_parts }));
+    }
+
+    Err(loop_exhausted(max_iterations))
+}
+
+/// A client capable of running the tool-calling loop.
+///
+/// Implemented for each provider client; you don't call this directly — use the
+/// client's `with_tools` to get a [`ToolRequest`].
+#[doc(hidden)]
+#[async_trait]
+pub trait ToolRunner {
+    async fn run_tool_loop(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        toolbox: &Toolbox,
+        max_iterations: usize,
+    ) -> Result<String>;
+}
+
+/// A fluent tool-calling request, created by a client's `with_tools`.
+///
+/// ```no_run
+/// # use rstructor::{OpenAIClient, Toolbox};
+/// # async fn example(toolbox: Toolbox) -> Result<(), Box<dyn std::error::Error>> {
+/// let client = OpenAIClient::from_env()?;
+/// let answer = client
+///     .with_tools(&toolbox)
+///     .system("You are a concise assistant.")
+///     .run("What's the weather in Paris?")
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct ToolRequest<'a, C: ToolRunner + ?Sized> {
+    client: &'a C,
+    toolbox: &'a Toolbox,
+    system: Option<String>,
+    max_iterations: usize,
+}
+
+impl<'a, C: ToolRunner + ?Sized> ToolRequest<'a, C> {
+    /// Create a tool request (used by clients' `with_tools`).
+    pub(crate) fn new(client: &'a C, toolbox: &'a Toolbox) -> Self {
+        Self {
+            client,
+            toolbox,
+            system: None,
+            max_iterations: DEFAULT_MAX_TOOL_ITERATIONS,
+        }
+    }
+
+    /// Attach a system prompt.
+    #[must_use]
+    pub fn system(mut self, system: impl Into<String>) -> Self {
+        self.system = Some(system.into());
+        self
+    }
+
+    /// Set the maximum number of model round-trips before giving up (default 10).
+    #[must_use]
+    pub fn max_iterations(mut self, max_iterations: usize) -> Self {
+        self.max_iterations = max_iterations;
+        self
+    }
+
+    /// Run the agentic loop with `prompt` as the user message, returning the
+    /// model's final text answer once it stops calling tools.
+    pub async fn run(self, prompt: &str) -> Result<String> {
+        self.client
+            .run_tool_loop(
+                self.system.as_deref(),
+                prompt,
+                self.toolbox,
+                self.max_iterations,
+            )
+            .await
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,4 +77,4 @@ pub use backend::{
     ChatMessage, ChatRole, GenerateResult, MaterializeResult, MediaFile, TokenUsage,
 };
 #[cfg(feature = "tools")]
-pub use backend::{DynTool, FnTool, Tool, Toolbox};
+pub use backend::{DynTool, FnTool, Tool, ToolRequest, ToolRunner, Toolbox};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,3 +76,5 @@ pub use backend::{AnyClient, Provider};
 pub use backend::{
     ChatMessage, ChatRole, GenerateResult, MaterializeResult, MediaFile, TokenUsage,
 };
+#[cfg(feature = "tools")]
+pub use backend::{DynTool, FnTool, Tool, Toolbox};

--- a/tests/tool_calling_tests.rs
+++ b/tests/tool_calling_tests.rs
@@ -1,7 +1,7 @@
 //! Tool-calling tests. Only compiled with `--features tools`.
 //!
-//! The unit-style tests (schema, invocation) run offline; the loop test hits the
-//! live OpenAI API and is gated on the `openai` feature.
+//! The unit-style tests (schema, invocation) run offline; the loop tests hit the
+//! live provider APIs and are gated on each provider's feature.
 #![cfg(feature = "tools")]
 
 use rstructor::{DynTool, FnTool, Instructor, Toolbox};
@@ -48,90 +48,148 @@ async fn unknown_args_error_is_surfaced() {
     assert!(err.is_err());
 }
 
+// ---- Live agentic-loop tests (one per provider) ----
+
 #[derive(Instructor, Serialize, Deserialize)]
 struct WeatherArgs {
     #[llm(description = "City name")]
     city: String,
 }
 
-#[cfg(feature = "openai")]
-#[tokio::test]
-async fn openai_tool_loop_calls_tool_and_answers() {
-    use rstructor::OpenAIClient;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(any(
+    feature = "openai",
+    feature = "grok",
+    feature = "anthropic",
+    feature = "gemini"
+))]
+use std::sync::Arc;
+#[cfg(any(
+    feature = "openai",
+    feature = "grok",
+    feature = "anthropic",
+    feature = "gemini"
+))]
+use std::sync::atomic::{AtomicBool, Ordering};
 
-    let called = Arc::new(AtomicBool::new(false));
-    let flag = called.clone();
-
-    let toolbox = Toolbox::new().with(FnTool::new(
+/// A toolbox with a single `get_weather` tool that records whether it was called.
+#[cfg(any(
+    feature = "openai",
+    feature = "grok",
+    feature = "anthropic",
+    feature = "gemini"
+))]
+fn weather_toolbox(called: Arc<AtomicBool>) -> Toolbox {
+    Toolbox::new().with(FnTool::new(
         "get_weather",
         "Get the current temperature in Fahrenheit for a city",
         move |args: WeatherArgs| {
-            let flag = flag.clone();
+            let called = called.clone();
             async move {
-                flag.store(true, Ordering::SeqCst);
+                called.store(true, Ordering::SeqCst);
                 Ok(json!({ "city": args.city, "temp_f": 71 }))
             }
         },
-    ));
+    ))
+}
 
+const TOOL_PROMPT: &str =
+    "Use the get_weather tool to find the temperature in Paris, then state it.";
+
+#[cfg(feature = "openai")]
+#[tokio::test]
+async fn openai_tool_loop() {
+    use rstructor::OpenAIClient;
+    let called = Arc::new(AtomicBool::new(false));
+    let toolbox = weather_toolbox(called.clone());
     let client = OpenAIClient::from_env().unwrap().model("gpt-4.1-mini");
     let answer = client
-        .run_with_tools(
-            "Use the get_weather tool to find the temperature in Paris, then state it.",
-            &toolbox,
-        )
+        .with_tools(&toolbox)
+        .run(TOOL_PROMPT)
         .await
         .expect("tool loop should succeed");
-
     assert!(
         called.load(Ordering::SeqCst),
-        "the get_weather tool should have been invoked"
+        "tool should have been called"
     );
-    assert!(
-        answer.contains("71"),
-        "final answer should cite 71: {answer}"
-    );
+    assert!(answer.contains("71"), "answer should cite 71: {answer}");
 }
 
 #[cfg(feature = "grok")]
 #[tokio::test]
-async fn grok_tool_loop_calls_tool_and_answers() {
+async fn grok_tool_loop() {
     use rstructor::GrokClient;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
-
     let called = Arc::new(AtomicBool::new(false));
-    let flag = called.clone();
-
-    let toolbox = Toolbox::new().with(FnTool::new(
-        "get_weather",
-        "Get the current temperature in Fahrenheit for a city",
-        move |args: WeatherArgs| {
-            let flag = flag.clone();
-            async move {
-                flag.store(true, Ordering::SeqCst);
-                Ok(json!({ "city": args.city, "temp_f": 71 }))
-            }
-        },
-    ));
-
+    let toolbox = weather_toolbox(called.clone());
     let client = GrokClient::from_env().unwrap();
     let answer = client
-        .run_with_tools(
-            "Use the get_weather tool to find the temperature in Paris, then state it.",
-            &toolbox,
-        )
+        .with_tools(&toolbox)
+        .run(TOOL_PROMPT)
         .await
         .expect("tool loop should succeed");
-
     assert!(
         called.load(Ordering::SeqCst),
-        "the get_weather tool should have been invoked"
+        "tool should have been called"
     );
+    assert!(answer.contains("71"), "answer should cite 71: {answer}");
+}
+
+#[cfg(feature = "anthropic")]
+#[tokio::test]
+async fn anthropic_tool_loop() {
+    use rstructor::AnthropicClient;
+    let called = Arc::new(AtomicBool::new(false));
+    let toolbox = weather_toolbox(called.clone());
+    let client = AnthropicClient::from_env()
+        .unwrap()
+        .model("claude-haiku-4-5-20251001")
+        .max_tokens(1024);
+    let answer = client
+        .with_tools(&toolbox)
+        .run(TOOL_PROMPT)
+        .await
+        .expect("tool loop should succeed");
     assert!(
-        answer.contains("71"),
-        "final answer should cite 71: {answer}"
+        called.load(Ordering::SeqCst),
+        "tool should have been called"
     );
+    assert!(answer.contains("71"), "answer should cite 71: {answer}");
+}
+
+#[cfg(feature = "gemini")]
+#[tokio::test]
+async fn gemini_tool_loop() {
+    use rstructor::GeminiClient;
+    let called = Arc::new(AtomicBool::new(false));
+    let toolbox = weather_toolbox(called.clone());
+    let client = GeminiClient::from_env().unwrap().model("gemini-2.5-flash");
+    let answer = client
+        .with_tools(&toolbox)
+        .run(TOOL_PROMPT)
+        .await
+        .expect("tool loop should succeed");
+    assert!(
+        called.load(Ordering::SeqCst),
+        "tool should have been called"
+    );
+    assert!(answer.contains("71"), "answer should cite 71: {answer}");
+}
+
+#[cfg(feature = "openai")]
+#[tokio::test]
+async fn tool_request_supports_system_prompt() {
+    use rstructor::OpenAIClient;
+    let called = Arc::new(AtomicBool::new(false));
+    let toolbox = weather_toolbox(called.clone());
+    let client = OpenAIClient::from_env().unwrap().model("gpt-4.1-mini");
+    let answer = client
+        .with_tools(&toolbox)
+        .system("Always answer in French.")
+        .run(TOOL_PROMPT)
+        .await
+        .expect("tool loop with system prompt should succeed");
+    assert!(
+        called.load(Ordering::SeqCst),
+        "tool should have been called"
+    );
+    assert!(answer.contains("71"), "answer should cite 71: {answer}");
 }

--- a/tests/tool_calling_tests.rs
+++ b/tests/tool_calling_tests.rs
@@ -1,0 +1,137 @@
+//! Tool-calling tests. Only compiled with `--features tools`.
+//!
+//! The unit-style tests (schema, invocation) run offline; the loop test hits the
+//! live OpenAI API and is gated on the `openai` feature.
+#![cfg(feature = "tools")]
+
+use rstructor::{DynTool, FnTool, Instructor, Toolbox};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(Instructor, Serialize, Deserialize)]
+struct AddArgs {
+    #[llm(description = "First addend")]
+    a: i64,
+    #[llm(description = "Second addend")]
+    b: i64,
+}
+
+#[test]
+fn fn_tool_exposes_schema_and_metadata() {
+    let tool = FnTool::new("add", "Add two integers", |args: AddArgs| async move {
+        Ok(json!({ "sum": args.a + args.b }))
+    });
+    assert_eq!(tool.name(), "add");
+    assert_eq!(tool.description(), "Add two integers");
+    let schema = tool.parameters_schema();
+    assert_eq!(schema["type"], "object");
+    assert!(schema["properties"].get("a").is_some());
+    assert!(schema["properties"].get("b").is_some());
+}
+
+#[tokio::test]
+async fn fn_tool_invokes_with_deserialized_args() {
+    let tool = FnTool::new("add", "Add two integers", |args: AddArgs| async move {
+        Ok(json!({ "sum": args.a + args.b }))
+    });
+    let result = tool.invoke_json(json!({ "a": 2, "b": 3 })).await.unwrap();
+    assert_eq!(result, json!({ "sum": 5 }));
+}
+
+#[tokio::test]
+async fn unknown_args_error_is_surfaced() {
+    let tool = FnTool::new("add", "Add", |args: AddArgs| async move {
+        Ok(json!(args.a + args.b))
+    });
+    // Missing required field `b`.
+    let err = tool.invoke_json(json!({ "a": 1 })).await;
+    assert!(err.is_err());
+}
+
+#[derive(Instructor, Serialize, Deserialize)]
+struct WeatherArgs {
+    #[llm(description = "City name")]
+    city: String,
+}
+
+#[cfg(feature = "openai")]
+#[tokio::test]
+async fn openai_tool_loop_calls_tool_and_answers() {
+    use rstructor::OpenAIClient;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let called = Arc::new(AtomicBool::new(false));
+    let flag = called.clone();
+
+    let toolbox = Toolbox::new().with(FnTool::new(
+        "get_weather",
+        "Get the current temperature in Fahrenheit for a city",
+        move |args: WeatherArgs| {
+            let flag = flag.clone();
+            async move {
+                flag.store(true, Ordering::SeqCst);
+                Ok(json!({ "city": args.city, "temp_f": 71 }))
+            }
+        },
+    ));
+
+    let client = OpenAIClient::from_env().unwrap().model("gpt-4.1-mini");
+    let answer = client
+        .run_with_tools(
+            "Use the get_weather tool to find the temperature in Paris, then state it.",
+            &toolbox,
+        )
+        .await
+        .expect("tool loop should succeed");
+
+    assert!(
+        called.load(Ordering::SeqCst),
+        "the get_weather tool should have been invoked"
+    );
+    assert!(
+        answer.contains("71"),
+        "final answer should cite 71: {answer}"
+    );
+}
+
+#[cfg(feature = "grok")]
+#[tokio::test]
+async fn grok_tool_loop_calls_tool_and_answers() {
+    use rstructor::GrokClient;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let called = Arc::new(AtomicBool::new(false));
+    let flag = called.clone();
+
+    let toolbox = Toolbox::new().with(FnTool::new(
+        "get_weather",
+        "Get the current temperature in Fahrenheit for a city",
+        move |args: WeatherArgs| {
+            let flag = flag.clone();
+            async move {
+                flag.store(true, Ordering::SeqCst);
+                Ok(json!({ "city": args.city, "temp_f": 71 }))
+            }
+        },
+    ));
+
+    let client = GrokClient::from_env().unwrap();
+    let answer = client
+        .run_with_tools(
+            "Use the get_weather tool to find the temperature in Paris, then state it.",
+            &toolbox,
+        )
+        .await
+        .expect("tool loop should succeed");
+
+    assert!(
+        called.load(Ordering::SeqCst),
+        "the get_weather tool should have been invoked"
+    );
+    assert!(
+        answer.contains("71"),
+        "final answer should cite 71: {answer}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds tool/function calling behind an opt-in **`tools`** feature (off by default). The model can call typed Rust functions whose results are fed back, looping until it produces a final answer — implemented for **all four providers**.

```rust
#[derive(Instructor, Serialize, Deserialize)]
struct WeatherArgs { #[llm(description = "City name")] city: String }

let toolbox = Toolbox::new().with(FnTool::new(
    "get_weather", "Get the current weather for a city",
    |args: WeatherArgs| async move { Ok(json!({ "city": args.city, "temp_f": 72 })) },
));

let answer = client
    .with_tools(&toolbox)
    .system("Use tools when relevant.")   // optional
    .run("What's the weather in Paris?")
    .await?;
```

## API

- **`Tool`** — a typed tool whose `Args` derive `Instructor` (JSON Schema generated for you).
- **`FnTool`** — wrap an async closure as a tool.
- **`Toolbox`** — collects heterogeneous tools (object-safe `DynTool`, auto-implemented for every `Tool`).
- **Fluent builder**: `client.with_tools(&toolbox).system(..).max_iterations(..).run(prompt)` — replaces the earlier `run_with_tools(prompt, &toolbox)`. Provider-agnostic via an internal `ToolRunner` trait.

## Providers

The agentic loop is implemented for **all four providers**, each in its native protocol:
- **OpenAI / Grok** — `tools` + `tool_calls` / `{role:"tool"}` results.
- **Anthropic** — `tools` + `tool_use` / `tool_result` content blocks.
- **Gemini** — `functionDeclarations` + `functionCall` / `functionResponse` parts (with Gemini-stripped parameter schemas).

System prompts are wired per-provider (OpenAI system message, Anthropic top-level `system`, Gemini `systemInstruction`).

## Verification

- **Live end-to-end tests against all four providers** (`tests/tool_calling_tests.rs`, `--features tools`): each model invokes the tool, the result is fed back, and the final answer reflects it. Plus a system-prompt test.
- Offline tests: schema generation, typed invocation, arg-deserialization errors.
- `clippy --all-targets` clean with and without the feature; default `--lib`/`--doc` unchanged. Adds `examples/tool_calling_example.rs` + README docs.
- CI: the examples workflow now runs examples with `--all-features` so feature-gated examples build and run.

## Follow-ups
Parallel tool-call execution; an optional typed final answer (`...run_as::<T>()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)