### PR TITLE
Add unified fluent Request builder over LLMClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+## Request Builder
+
+`materialize`, `generate`, and (with the `tools` feature) tool `run` are also
+available through a fluent builder that attaches context, images, and tools to a
+single request. Bring `RequestExt` into scope and chain the pieces you need:
+
+```rust
+use rstructor::{Instructor, OpenAIClient, RequestExt};
+
+let client = OpenAIClient::from_env()?;
+
+// Add context that is prepended to the prompt, then materialize a struct.
+let movie: Movie = client
+    .with_system("Assume USD; format dates as ISO-8601.")
+    .materialize("Describe Inception")
+    .await?;
+
+// Or start from `.request()` and combine builders before a terminal.
+let summary = client
+    .request()
+    .system("Be concise.")
+    .generate("Summarize the plot of Inception")
+    .await?;
+```
+
+The terminals are `materialize::<T>(prompt)` (structured), `generate(prompt)`
+(text), and — with the `tools` feature — `run(prompt)` (text, calling any
+attached tools in a loop). Builders compose: `with_system`, `with_media`, and
+`with_tools` can be chained in any order before the terminal.
+
 ## Providers
 
 ```rust
@@ -241,10 +271,11 @@ impl SchemaType for SecurityId {
 
 ## Multimodal (Image Input)
 
-Analyze images with structured extraction across all major providers using `materialize_with_media`:
+Analyze images with structured extraction across all major providers by
+attaching media to a request with `with_media`:
 
 ```rust
-use rstructor::{Instructor, LLMClient, OpenAIClient, MediaFile};
+use rstructor::{Instructor, OpenAIClient, MediaFile, RequestExt};
 
 #[derive(Instructor, Serialize, Deserialize, Debug)]
 struct ImageAnalysis {
@@ -259,12 +290,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?.bytes().await?;
 
     // Inline media is base64-encoded automatically
-    let media = MediaFile::from_bytes(&image_bytes, "image/png");
+    let media = [MediaFile::from_bytes(&image_bytes, "image/png")];
 
     // Works with OpenAI, Anthropic, Grok, and Gemini clients
     let client = OpenAIClient::from_env()?;
     let analysis: ImageAnalysis = client
-        .materialize_with_media("Describe this image", &[media])
+        .with_media(&media)
+        .materialize("Describe this image")
         .await?;
     println!("{:?}", analysis);
     Ok(())
@@ -272,6 +304,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 `MediaFile::new(uri, mime_type)` is also available for URL/URI-based media input.
+The lower-level `LLMClient::materialize_with_media(prompt, &media)` method does
+the same thing in one call when you do not need the builder.
 
 Provider examples:
 - `cargo run --example openai_multimodal_example --features openai`

--- a/examples/tool_calling_example.rs
+++ b/examples/tool_calling_example.rs
@@ -7,7 +7,7 @@
 //! schema-validated arguments); rstructor runs them and feeds the results back
 //! until the model produces a final answer.
 
-use rstructor::{FnTool, Instructor, OpenAIClient, Toolbox};
+use rstructor::{FnTool, Instructor, OpenAIClient, RequestExt, Toolbox};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -559,19 +559,6 @@ impl AnthropicClient {
 }
 
 #[cfg(feature = "tools")]
-impl AnthropicClient {
-    /// Begin a tool-calling request: `client.with_tools(&toolbox).run("...").await?`.
-    ///
-    /// Requires the `tools` feature.
-    pub fn with_tools<'a>(
-        &'a self,
-        toolbox: &'a crate::backend::tools::Toolbox,
-    ) -> crate::backend::tools::ToolRequest<'a, Self> {
-        crate::backend::tools::ToolRequest::new(self, toolbox)
-    }
-}
-
-#[cfg(feature = "tools")]
 #[async_trait]
 impl crate::backend::tools::ToolRunner for AnthropicClient {
     async fn run_tool_loop(

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -626,19 +626,6 @@ impl GeminiClient {
 }
 
 #[cfg(feature = "tools")]
-impl GeminiClient {
-    /// Begin a tool-calling request: `client.with_tools(&toolbox).run("...").await?`.
-    ///
-    /// Requires the `tools` feature.
-    pub fn with_tools<'a>(
-        &'a self,
-        toolbox: &'a crate::backend::tools::Toolbox,
-    ) -> crate::backend::tools::ToolRequest<'a, Self> {
-        crate::backend::tools::ToolRequest::new(self, toolbox)
-    }
-}
-
-#[cfg(feature = "tools")]
 #[async_trait]
 impl crate::backend::tools::ToolRunner for GeminiClient {
     async fn run_tool_loop(

--- a/src/backend/grok.rs
+++ b/src/backend/grok.rs
@@ -376,19 +376,6 @@ impl GrokClient {
 }
 
 #[cfg(feature = "tools")]
-impl GrokClient {
-    /// Begin a tool-calling request: `client.with_tools(&toolbox).run("...").await?`.
-    ///
-    /// Requires the `tools` feature.
-    pub fn with_tools<'a>(
-        &'a self,
-        toolbox: &'a crate::backend::tools::Toolbox,
-    ) -> crate::backend::tools::ToolRequest<'a, Self> {
-        crate::backend::tools::ToolRequest::new(self, toolbox)
-    }
-}
-
-#[cfg(feature = "tools")]
 #[async_trait]
 impl crate::backend::tools::ToolRunner for GrokClient {
     async fn run_tool_loop(

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -8,6 +8,8 @@ mod messages;
 mod model_macro;
 #[cfg(feature = "_client")]
 mod openai_compatible;
+#[cfg(feature = "_client")]
+mod request;
 #[cfg(feature = "streaming")]
 pub mod streaming;
 #[cfg(feature = "tools")]
@@ -31,10 +33,12 @@ pub use client::{LLMClient, MediaFile};
 pub use messages::{ChatMessage, ChatRole};
 #[cfg(feature = "_client")]
 pub use messages::{MaterializeInternalOutput, ValidationFailureContext};
+#[cfg(feature = "_client")]
+pub use request::{Request, RequestExt};
 #[cfg(feature = "streaming")]
 pub use streaming::{ItemStream, ObjectStream, StreamedObject, TextStream};
 #[cfg(feature = "tools")]
-pub use tools::{DynTool, FnTool, Tool, ToolRequest, ToolRunner, Toolbox};
+pub use tools::{DynTool, FnTool, Tool, ToolRunner, Toolbox};
 pub use usage::{GenerateResult, MaterializeResult, TokenUsage};
 
 /// Information about an available model from an LLM provider.

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -517,41 +517,6 @@ impl OpenAIClient {
 }
 
 #[cfg(feature = "tools")]
-impl OpenAIClient {
-    /// Begin a tool-calling request. The model may call the [`Toolbox`](crate::Toolbox)'s
-    /// tools (whose results are fed back) until it produces a final text answer.
-    ///
-    /// Requires the `tools` feature.
-    ///
-    /// ```no_run
-    /// # use rstructor::{OpenAIClient, Toolbox, FnTool, Instructor};
-    /// # use serde::{Serialize, Deserialize};
-    /// # use serde_json::json;
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// #[derive(Instructor, Serialize, Deserialize)]
-    /// struct WeatherArgs { city: String }
-    ///
-    /// let toolbox = Toolbox::new().with(FnTool::new(
-    ///     "get_weather",
-    ///     "Get the current weather for a city",
-    ///     |args: WeatherArgs| async move { Ok(json!({ "city": args.city, "temp_f": 72 })) },
-    /// ));
-    ///
-    /// let client = OpenAIClient::from_env()?;
-    /// let answer = client.with_tools(&toolbox).run("What's the weather in Paris?").await?;
-    /// println!("{answer}");
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn with_tools<'a>(
-        &'a self,
-        toolbox: &'a crate::backend::tools::Toolbox,
-    ) -> crate::backend::tools::ToolRequest<'a, Self> {
-        crate::backend::tools::ToolRequest::new(self, toolbox)
-    }
-}
-
-#[cfg(feature = "tools")]
 #[async_trait]
 impl crate::backend::tools::ToolRunner for OpenAIClient {
     async fn run_tool_loop(

--- a/src/backend/request.rs
+++ b/src/backend/request.rs
@@ -1,0 +1,215 @@
+//! A fluent request builder over any [`LLMClient`].
+//!
+//! Attach context with `with_system`, images with `with_media`, and tools with
+//! `with_tools`, then choose a terminal: `materialize` (structured), `generate`
+//! (text), `run` (text, using tools if attached), or — with the `streaming`
+//! feature — `materialize_iter` / `materialize_stream` / `generate_stream`.
+//!
+//! ```no_run
+//! # use rstructor::{OpenAIClient, RequestExt, Instructor};
+//! # use serde::{Serialize, Deserialize};
+//! # #[derive(Instructor, Serialize, Deserialize)] struct Movie { title: String }
+//! # async fn ex() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = OpenAIClient::from_env()?;
+//! let movie: Movie = client
+//!     .with_system("Assume USD; dates as ISO-8601.")
+//!     .materialize("Describe Inception")
+//!     .await?;
+//! # Ok(()) }
+//! ```
+
+use serde::de::DeserializeOwned;
+
+use crate::backend::{LLMClient, MediaFile};
+use crate::error::Result;
+use crate::model::Instructor;
+
+/// A fluent request being built against a client. Created via [`RequestExt`].
+pub struct Request<'a, C: ?Sized> {
+    client: &'a C,
+    system: Option<String>,
+    media: Vec<MediaFile>,
+    #[cfg(feature = "tools")]
+    tools: Option<&'a crate::backend::tools::Toolbox>,
+    #[cfg(feature = "tools")]
+    max_iterations: usize,
+}
+
+impl<'a, C: ?Sized> Request<'a, C> {
+    fn new(client: &'a C) -> Self {
+        Self {
+            client,
+            system: None,
+            media: Vec::new(),
+            #[cfg(feature = "tools")]
+            tools: None,
+            #[cfg(feature = "tools")]
+            max_iterations: crate::backend::tools::DEFAULT_MAX_TOOL_ITERATIONS,
+        }
+    }
+
+    /// Attach system/context instructions, prepended to the prompt (for
+    /// `materialize`/`generate`) or sent as the provider's system prompt (for
+    /// tool `run`).
+    #[must_use]
+    pub fn system(mut self, system: impl Into<String>) -> Self {
+        self.system = Some(system.into());
+        self
+    }
+
+    /// Attach media (images) to the request (used by `materialize`).
+    #[must_use]
+    pub fn media(mut self, media: impl Into<Vec<MediaFile>>) -> Self {
+        self.media = media.into();
+        self
+    }
+
+    /// Attach a [`Toolbox`](crate::Toolbox); `run` will let the model call its
+    /// tools. Requires the `tools` feature.
+    #[cfg(feature = "tools")]
+    #[must_use]
+    pub fn tools(mut self, toolbox: &'a crate::backend::tools::Toolbox) -> Self {
+        self.tools = Some(toolbox);
+        self
+    }
+
+    /// Maximum number of tool round-trips for `run` (default 10).
+    #[cfg(feature = "tools")]
+    #[must_use]
+    pub fn max_iterations(mut self, max_iterations: usize) -> Self {
+        self.max_iterations = max_iterations;
+        self
+    }
+
+    /// Prompt with the system context prepended, if any.
+    fn combined(&self, prompt: &str) -> String {
+        match &self.system {
+            Some(system) => format!("{system}\n\n{prompt}"),
+            None => prompt.to_string(),
+        }
+    }
+}
+
+impl<C: LLMClient + Sync + ?Sized> Request<'_, C> {
+    /// Materialize a structured `T`, applying any attached system context and media.
+    pub async fn materialize<T>(self, prompt: &str) -> Result<T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        let prompt = self.combined(prompt);
+        if self.media.is_empty() {
+            self.client.materialize(&prompt).await
+        } else {
+            self.client
+                .materialize_with_media(&prompt, &self.media)
+                .await
+        }
+    }
+
+    /// Generate raw text, applying any attached system context.
+    pub async fn generate(self, prompt: &str) -> Result<String> {
+        self.client.generate(&self.combined(prompt)).await
+    }
+}
+
+#[cfg(feature = "streaming")]
+impl<'a, C: LLMClient + Sync + ?Sized> Request<'a, C> {
+    /// Stream a **list** of structured `T`, yielding each item as soon as it is
+    /// fully generated and validated, with any attached system context prepended.
+    ///
+    /// Attached media is ignored — the streaming APIs are text-only.
+    pub fn materialize_iter<T>(self, prompt: &str) -> crate::backend::streaming::ItemStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        use futures_util::StreamExt;
+        let combined = self.combined(prompt);
+        let client = self.client;
+        Box::pin(async_stream::try_stream! {
+            let mut inner = client.materialize_iter::<T>(&combined);
+            while let Some(item) = inner.next().await {
+                yield item?;
+            }
+        })
+    }
+
+    /// Stream raw text deltas, with any attached system context prepended.
+    pub fn generate_stream(self, prompt: &str) -> crate::backend::streaming::TextStream<'a> {
+        use futures_util::StreamExt;
+        let combined = self.combined(prompt);
+        let client = self.client;
+        Box::pin(async_stream::try_stream! {
+            let mut inner = client.generate_stream(&combined);
+            while let Some(chunk) = inner.next().await {
+                yield chunk?;
+            }
+        })
+    }
+
+    /// Stream a single structured object as its JSON fills in, with any attached
+    /// system context prepended. Attached media is ignored.
+    pub fn materialize_stream<T>(
+        self,
+        prompt: &str,
+    ) -> crate::backend::streaming::ObjectStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        use futures_util::StreamExt;
+        let combined = self.combined(prompt);
+        let client = self.client;
+        Box::pin(async_stream::try_stream! {
+            let mut inner = client.materialize_stream::<T>(&combined);
+            while let Some(obj) = inner.next().await {
+                yield obj?;
+            }
+        })
+    }
+}
+
+#[cfg(feature = "tools")]
+impl<C: crate::backend::tools::ToolRunner + LLMClient + Sync + ?Sized> Request<'_, C> {
+    /// Get a text answer, letting the model call attached tools (if any) in a loop
+    /// until it produces a final response. With no tools attached this is
+    /// equivalent to [`generate`](Self::generate).
+    pub async fn run(self, prompt: &str) -> Result<String> {
+        match self.tools {
+            Some(toolbox) => {
+                self.client
+                    .run_tool_loop(self.system.as_deref(), prompt, toolbox, self.max_iterations)
+                    .await
+            }
+            None => self.client.generate(&self.combined(prompt)).await,
+        }
+    }
+}
+
+/// Fluent request entry points, available on every [`LLMClient`].
+///
+/// `use rstructor::RequestExt;` to call `client.with_system(..)`,
+/// `client.with_media(..)`, `client.with_tools(..)`, or `client.request()`.
+pub trait RequestExt: LLMClient {
+    /// Start an empty request.
+    fn request(&self) -> Request<'_, Self> {
+        Request::new(self)
+    }
+
+    /// Start a request with system/context instructions.
+    fn with_system(&self, system: impl Into<String>) -> Request<'_, Self> {
+        Request::new(self).system(system)
+    }
+
+    /// Start a request with attached media (images).
+    fn with_media<'a>(&'a self, media: &'a [MediaFile]) -> Request<'a, Self> {
+        Request::new(self).media(media.to_vec())
+    }
+
+    /// Start a request with a [`Toolbox`](crate::Toolbox); call `.run(prompt)` to
+    /// run the agentic loop. Requires the `tools` feature.
+    #[cfg(feature = "tools")]
+    fn with_tools<'a>(&'a self, toolbox: &'a crate::backend::tools::Toolbox) -> Request<'a, Self> {
+        Request::new(self).tools(toolbox)
+    }
+}
+
+impl<C: LLMClient + ?Sized> RequestExt for C {}

--- a/src/backend/tools.rs
+++ b/src/backend/tools.rs
@@ -577,8 +577,9 @@ pub(crate) async fn run_gemini_tools(
 
 /// A client capable of running the tool-calling loop.
 ///
-/// Implemented for each provider client; you don't call this directly — use the
-/// client's `with_tools` to get a [`ToolRequest`].
+/// Implemented for each provider client and driven by the fluent
+/// [`Request`](crate::Request) builder (`client.with_tools(..).run(..)`); not
+/// called directly.
 #[doc(hidden)]
 #[async_trait]
 pub trait ToolRunner {
@@ -589,64 +590,4 @@ pub trait ToolRunner {
         toolbox: &Toolbox,
         max_iterations: usize,
     ) -> Result<String>;
-}
-
-/// A fluent tool-calling request, created by a client's `with_tools`.
-///
-/// ```no_run
-/// # use rstructor::{OpenAIClient, Toolbox};
-/// # async fn example(toolbox: Toolbox) -> Result<(), Box<dyn std::error::Error>> {
-/// let client = OpenAIClient::from_env()?;
-/// let answer = client
-///     .with_tools(&toolbox)
-///     .system("You are a concise assistant.")
-///     .run("What's the weather in Paris?")
-///     .await?;
-/// # Ok(())
-/// # }
-/// ```
-pub struct ToolRequest<'a, C: ToolRunner + ?Sized> {
-    client: &'a C,
-    toolbox: &'a Toolbox,
-    system: Option<String>,
-    max_iterations: usize,
-}
-
-impl<'a, C: ToolRunner + ?Sized> ToolRequest<'a, C> {
-    /// Create a tool request (used by clients' `with_tools`).
-    pub(crate) fn new(client: &'a C, toolbox: &'a Toolbox) -> Self {
-        Self {
-            client,
-            toolbox,
-            system: None,
-            max_iterations: DEFAULT_MAX_TOOL_ITERATIONS,
-        }
-    }
-
-    /// Attach a system prompt.
-    #[must_use]
-    pub fn system(mut self, system: impl Into<String>) -> Self {
-        self.system = Some(system.into());
-        self
-    }
-
-    /// Set the maximum number of model round-trips before giving up (default 10).
-    #[must_use]
-    pub fn max_iterations(mut self, max_iterations: usize) -> Self {
-        self.max_iterations = max_iterations;
-        self
-    }
-
-    /// Run the agentic loop with `prompt` as the user message, returning the
-    /// model's final text answer once it stops calling tools.
-    pub async fn run(self, prompt: &str) -> Result<String> {
-        self.client
-            .run_tool_loop(
-                self.system.as_deref(),
-                prompt,
-                self.toolbox,
-                self.max_iterations,
-            )
-            .await
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,11 +72,11 @@ pub use backend::LLMClient;
 pub use backend::ModelInfo;
 pub use backend::ThinkingLevel;
 #[cfg(feature = "_client")]
-pub use backend::{AnyClient, Provider};
+pub use backend::{AnyClient, Provider, Request, RequestExt};
 pub use backend::{
     ChatMessage, ChatRole, GenerateResult, MaterializeResult, MediaFile, TokenUsage,
 };
 #[cfg(feature = "tools")]
-pub use backend::{DynTool, FnTool, Tool, ToolRequest, ToolRunner, Toolbox};
+pub use backend::{DynTool, FnTool, Tool, ToolRunner, Toolbox};
 #[cfg(feature = "streaming")]
 pub use backend::{ItemStream, ObjectStream, StreamedObject, TextStream};

--- a/tests/core_ergonomics_test.rs
+++ b/tests/core_ergonomics_test.rs
@@ -1,11 +1,11 @@
 //! Tests for the core ergonomics improvements: the media-drop default,
-//! and the runtime-selectable `AnyClient`.
+//! the runtime-selectable `AnyClient`, and the fluent `Request` builder.
 #![cfg(feature = "_client")]
 
 use async_trait::async_trait;
 use rstructor::{
     GenerateResult, Instructor, LLMClient, MaterializeResult, MediaFile, ModelInfo, RStructorError,
-    Result,
+    RequestExt, Result,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -79,6 +79,121 @@ async fn media_default_errors_instead_of_silently_dropping() {
     assert!(
         matches!(result, Err(RStructorError::Unsupported(_))),
         "non-empty media on an unsupported client should return Unsupported, got {result:?}"
+    );
+}
+
+/// A client that echoes the prompt back, so tests can observe exactly what the
+/// `Request` builder sends to the underlying client (e.g. system prepending).
+struct EchoClient;
+
+#[async_trait]
+impl LLMClient for EchoClient {
+    async fn materialize<T>(&self, prompt: &str) -> Result<T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        // Surface the received prompt through the error so the test can inspect it.
+        Err(RStructorError::ValidationError(prompt.to_string()))
+    }
+
+    async fn materialize_with_metadata<T>(&self, prompt: &str) -> Result<MaterializeResult<T>>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        Err(RStructorError::ValidationError(prompt.to_string()))
+    }
+
+    async fn generate(&self, prompt: &str) -> Result<String> {
+        Ok(prompt.to_string())
+    }
+
+    async fn generate_with_metadata(&self, prompt: &str) -> Result<GenerateResult> {
+        Ok(GenerateResult {
+            text: prompt.to_string(),
+            usage: None,
+        })
+    }
+
+    fn from_env() -> Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(EchoClient)
+    }
+
+    async fn list_models(&self) -> Result<Vec<ModelInfo>> {
+        Ok(vec![])
+    }
+}
+
+#[tokio::test]
+async fn builder_generate_has_no_system_by_default() {
+    let client = EchoClient;
+    let out = client.request().generate("hello").await.unwrap();
+    assert_eq!(
+        out, "hello",
+        "no system context should pass the prompt as-is"
+    );
+}
+
+#[tokio::test]
+async fn builder_prepends_system_context() {
+    let client = EchoClient;
+    let out = client.with_system("CTX").generate("hello").await.unwrap();
+    assert_eq!(
+        out, "CTX\n\nhello",
+        "system context should be prepended to the prompt"
+    );
+}
+
+#[tokio::test]
+async fn builder_materialize_routes_through_materialize() {
+    let client = EchoClient;
+    // With no media, `materialize` is used and receives the combined prompt.
+    let result = client
+        .with_system("CTX")
+        .materialize::<Dummy>("hello")
+        .await;
+    assert!(
+        matches!(&result, Err(RStructorError::ValidationError(m)) if m == "CTX\n\nhello"),
+        "builder materialize should route through materialize with the combined prompt, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn builder_with_media_routes_through_materialize_with_media() {
+    // `EchoClient` has no media support, so non-empty media must error loudly
+    // rather than silently dropping the attachment.
+    let client = EchoClient;
+    let media = [MediaFile::new("https://example.com/cat.png", "image/png")];
+    let result = client
+        .with_media(&media)
+        .materialize::<Dummy>("describe")
+        .await;
+    assert!(
+        matches!(result, Err(RStructorError::Unsupported(_))),
+        "builder media should route through materialize_with_media, got {result:?}"
+    );
+}
+
+#[cfg(feature = "streaming")]
+#[tokio::test]
+async fn builder_generate_stream_prepends_system() {
+    use futures_util::StreamExt;
+    // `EchoClient` uses the default `generate_stream`, which falls back to a single
+    // chunk from `generate` — enough to confirm the builder's stream terminal works
+    // and prepends the system context.
+    let client = EchoClient;
+    let chunks: Vec<String> = client
+        .with_system("CTX")
+        .generate_stream("hi")
+        .map(|c| c.unwrap())
+        .collect()
+        .await;
+    assert_eq!(
+        chunks.concat(),
+        "CTX\n\nhi",
+        "streaming terminal should prepend system context"
     );
 }
 

--- a/tests/tool_calling_tests.rs
+++ b/tests/tool_calling_tests.rs
@@ -4,7 +4,7 @@
 //! live provider APIs and are gated on each provider's feature.
 #![cfg(feature = "tools")]
 
-use rstructor::{DynTool, FnTool, Instructor, Toolbox};
+use rstructor::{DynTool, FnTool, Instructor, RequestExt, Toolbox};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 


### PR DESCRIPTION
## Summary

Introduces a single fluent **`Request` builder** over `LLMClient`, reachable on every client via the blanket `RequestExt` trait. This unifies the previously scattered entry points (`materialize`, `materialize_with_media`, the per-client `with_tools().run()`, streaming methods) into one composable surface, directly following the `run_with_X` → `with_X` direction:

```rust
use rstructor::{OpenAIClient, RequestExt};

let client = OpenAIClient::from_env()?;

// context prepended to the prompt
let movie: Movie = client.with_system("Assume USD; ISO-8601 dates").materialize("Describe Inception").await?;

// images
let analysis: ImageAnalysis = client.with_media(&imgs).materialize("Describe this image").await?;

// tools (agentic loop)
let answer = client.with_tools(&toolbox).system("Be concise").run("Weather in Paris?").await?;

// start empty and compose
let text = client.request().system("Be concise").generate("Summarize Inception").await?;
```

### Terminals
- `materialize::<T>(prompt)` — structured output
- `generate(prompt)` — raw text
- `run(prompt)` — text via the tool loop (`tools` feature; falls back to `generate` with no tools attached)
- `materialize_iter::<T>` / `materialize_stream::<T>` / `generate_stream` — under the `streaming` feature

### Design notes
- **System context**: prepended to the prompt for `materialize`/`generate`/streaming (every provider already enforces the JSON Schema, so a separate system message isn't needed there); sent as the provider's real system prompt for tool `run`.
- **Media**: `with_media` routes through `materialize_with_media`, preserving the loud-error-on-unsupported-media default. The lower-level `LLMClient::materialize_with_media` remains for one-shot use.
- **Streaming lifetimes**: the streaming terminals own the combined prompt inside an `async_stream` generator so it outlives the returned stream.

### Cleanup
- Removed the redundant inherent `with_tools` methods on each provider client and the `ToolRequest` type — both fully superseded by `Request`/`RequestExt`.

## Tests
- New offline tests in `core_ergonomics_test.rs`: system prepending, media routing, and the streaming terminal (via an echo client).
- `cargo clippy --all-targets -- -D warnings` (default features) and `--all-features --all-targets`: clean.
- Doctests: 63 pass, 0 ignored.
- `cargo build --all-features --examples`: builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
