### PR TITLE
Sharpen copy for discoverability (Persona B) + fix crate-level docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rstructor"
 version = "0.3.1"
 edition = "2024"
-description = "The Rust equivalent of Python's Instructor + Pydantic. Extract structured, validated data from LLMs (OpenAI, Anthropic Claude, Grok, Gemini) into type-safe structs and enums, with automatic JSON Schema generation, parsing, and validation-with-retry."
+description = "Get structured, validated data out of LLMs as native Rust structs and enums. Derive a type and rstructor generates the JSON Schema, prompts the model, parses the reply, and retries on validation errors — across OpenAI, Anthropic Claude, Google Gemini, and xAI Grok. The Rust answer to Python's Pydantic + Instructor."
 license = "MIT"
 repository = "https://github.com/clifton/rstructor"
 authors = ["Clifton King <cliftonk@gmail.com>"]
@@ -28,10 +28,10 @@ exclude = [
   "*.orig",
   "*.bak",
 ]
-keywords = ["llm", "openai", "anthropic", "structured-output", "instructor"]
+keywords = ["llm", "structured-output", "json-schema", "openai", "anthropic"]
 categories = [
   "api-bindings",
-  "web-programming",
+  "science",
   "parsing",
   "text-processing",
   "asynchronous",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT"/>
 </p>
 
-Turn unstructured prose into strongly-typed, validated Rust data — define your schema as plain structs and enums, and rstructor handles JSON Schema generation, prompting, parsing, and validation with automatic retries.
+Get structured, validated data out of any LLM as native Rust structs and enums. Define the shape you want as plain Rust types — rstructor generates the JSON Schema, prompts the model, parses the response, and retries on validation errors until the data fits.
 
 ## Features
 
@@ -16,7 +16,7 @@ Turn unstructured prose into strongly-typed, validated Rust data — define your
 - **Multi-provider, one API** — OpenAI, Anthropic, Grok (xAI), and Gemini behind a single `materialize()` call with swappable clients
 - **Validation with automatic re-ask** — Built-in type checking plus custom business rules; validation failures are fed back to the model and retried until the data is correct
 - **Rich, nested data** — Nested objects, arrays, optionals, maps, and enums with associated data, with validation that recurses through the whole tree
-- **The Instructor / Pydantic experience for Rust** — The familiar structured-output workflow of [Instructor](https://github.com/jxnl/instructor) + [Pydantic](https://github.com/pydantic/pydantic), now with compile-time guarantees and reasoning-model support (GPT-5.5, Claude 4.6, Gemini 3.1)
+- **Familiar if you know Pydantic + Instructor** — The same structured-output workflow as Python's [Instructor](https://github.com/jxnl/instructor) + [Pydantic](https://github.com/pydantic/pydantic), with Rust's compile-time type safety
 
 ## Installation
 
@@ -29,7 +29,7 @@ tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 
 ## Quick Start
 
-Describe the shape you want as plain Rust types, then turn a sentence of prose into a fully-typed, validated value:
+Describe the shape you want as plain Rust types, then turn a line of free-form text into a fully-typed, validated value:
 
 ```rust
 use rstructor::{Instructor, LLMClient, OpenAIClient};
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-Every field is *inferred*, not transcribed: the urgency is read from the tone and deadline, the email is plucked out of mid-sentence prose, and the tags are synthesized — all parsed into the exact types you declared.
+Every field is *inferred*, not transcribed: the urgency is read from the tone and deadline, the email is plucked out of mid-sentence text, and the tags are synthesized — all parsed into the exact types you declared.
 
 ## Request Builder
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,46 +1,46 @@
-/// rstructor: A Rust library for structured outputs from LLMs
-///
-/// # Overview
-///
-/// rstructor simplifies getting validated, strongly-typed outputs from Large Language Models
-/// (LLMs) like GPT-5.5 and Claude. It automatically generates JSON Schema from your Rust types,
-/// sends the schema to LLMs, parses responses, and validates against the schema.
-///
-/// Key features:
-/// - Derive macro for automatic JSON Schema generation
-/// - Built-in OpenAI and Anthropic API clients
-/// - Validation of responses against schemas
-/// - Type-safe conversion from LLM outputs to Rust structs and enums
-/// - Customizable client configurations
-///
-/// # Quick Start
-///
-/// ```no_run
-/// use rstructor::{LLMClient, OpenAIClient, Instructor};
-/// use serde::{Serialize, Deserialize};
-///
-/// #[derive(Instructor, Serialize, Deserialize, Debug)]
-/// struct Person {
-///     name: String,
-///     age: u8,
-///     bio: String,
-/// }
-///
-/// #[tokio::main]
-/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     // Create a client
-///     let client = OpenAIClient::new("your-openai-api-key")?;
-///
-///     // Generate a structured response
-///     let person: Person = client.materialize("Describe a fictional person").await?;
-///
-///     println!("Name: {}", person.name);
-///     println!("Age: {}", person.age);
-///     println!("Bio: {}", person.bio);
-///
-///     Ok(())
-/// }
-/// ```
+//! rstructor: get structured, validated data out of LLMs as native Rust structs and enums
+//!
+//! # Overview
+//!
+//! rstructor gets structured, validated data out of large language models (LLMs) as native
+//! Rust structs and enums. It generates JSON Schema from your types, prompts the model, parses
+//! the response, and validates the result — retrying automatically when validation fails.
+//!
+//! Key features:
+//! - Derive macro for automatic JSON Schema generation
+//! - Built-in clients for OpenAI, Anthropic, Google Gemini, and xAI Grok
+//! - Validation of responses against schemas
+//! - Type-safe conversion from LLM outputs to Rust structs and enums
+//! - Customizable client configurations
+//!
+//! # Quick Start
+//!
+//! ```no_run
+//! use rstructor::{LLMClient, OpenAIClient, Instructor};
+//! use serde::{Serialize, Deserialize};
+//!
+//! #[derive(Instructor, Serialize, Deserialize, Debug)]
+//! struct Person {
+//!     name: String,
+//!     age: u8,
+//!     bio: String,
+//! }
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     // Create a client
+//!     let client = OpenAIClient::new("your-openai-api-key")?;
+//!
+//!     // Generate a structured response
+//!     let person: Person = client.materialize("Describe a fictional person").await?;
+//!
+//!     println!("Name: {}", person.name);
+//!     println!("Age: {}", person.age);
+//!     println!("Bio: {}", person.bio);
+//!
+//!     Ok(())
+//! }
+//! ```
 mod backend;
 pub mod error;
 #[cfg(feature = "logging")]


### PR DESCRIPTION
## Why

Optimizes the crates.io / docs.rs / README copy for the developer who wants to **get structured data out of an LLM but has never used Instructor or Pydantic**. That person searches the *problem* in plain words — `structured output`, `json schema llm`, `typed data from llm`, `extract structured data` — not the solution-by-analogy.

Today the crate ranks well only for queries that already assume the Instructor/Pydantic mental model, and is invisible on the high-volume generic phrasings. The biggest controllable levers on crates.io are the **description** and **keywords** (its search indexes `name > keywords > description > readme`; downloads don't affect ranking), so this PR points those at the plain-language vocabulary.

## Changes

**`Cargo.toml` (the crates.io surface)**
- Description now **leads with the capability** — *"Get structured, validated data out of LLMs as native Rust structs and enums"* — and demotes the Pydantic/Instructor analogy to the final sentence (still there for those who know it).
- Keywords: dropped `instructor` (the crate name already matches it; ~zero search traffic) and added **`json-schema`** — a high-intent query where the crate was previously not in the top 20.
- Category `web-programming` → **`science`** (crates.io's home for ML/AI crates; there's no AI-specific slug).

**`README.md`**
- Rewrote the lede in plain Persona-B vocabulary.
- Replaced every "unstructured **prose**" with plain "text".
- Cut the dated *"reasoning-model support (GPT-5.5, Claude 4.6, Gemini 3.1)"* line — every model reasons now, and version name-drops age fast.

**`src/lib.rs` (docs.rs front page) — also a real bug fix**
- The crate overview used `///` (outer doc), which attached it to the private `mod backend` that follows it, so **it never rendered as the docs.rs front page** (the live page only shows the Cargo.toml description). Converted the block to `//!` (inner doc) so it actually becomes the front page.
- Refreshed the prose to match and fixed the stale *"Built-in OpenAI and Anthropic API clients"* → all four providers (OpenAI, Anthropic, Gemini, Grok).

`cargo check` passes. No code or behavior changes — copy, metadata, and doc-comment style only.

## Not in this PR (suggested follow-ups)
- GitHub repo **About** + topics still lead with the Instructor/Pydantic brand; reordering to capability-first would mirror these changes.
- A README **comparison table** (vs the `llm` crate, `instructor-rs`, `aisdk`, BAML) and a short *"structured outputs from LLMs in Rust"* walkthrough post are the highest-ceiling discoverability moves — happy to draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)