### PR TITLE
fix: remove fabrication-inducing array guidance from validation retry prompt

### DIFF
--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -1115,6 +1115,22 @@ pub async fn check_response_status(response: Response, provider_name: &str) -> R
     Ok(response)
 }
 
+/// Builds the user-role feedback message sent back to the LLM when a response
+/// fails schema or custom validation (the re-ask prompt).
+///
+/// The array guidance deliberately avoids any minimum-count instruction.
+/// Telling the model to include "at least N" items induces fabrication: a
+/// model that correctly extracted one item (or zero) from the source material
+/// would be instructed to invent more. Instead, the prompt requires arrays to
+/// contain only entries actually supported by the input — a single-item or
+/// empty array is valid when that is all the data supports.
+fn validation_retry_feedback(error_message: &str) -> String {
+    format!(
+        "Your previous response contained validation errors. Please provide a complete, valid JSON response that includes ALL required fields and follows the schema exactly.\n\nError details:\n{}\n\nPlease fix the issues in your response. Make sure to:\n1. Include ALL required fields exactly as specified in the schema\n2. For enum fields, use EXACTLY one of the allowed values from the description\n3. CRITICAL: For arrays where items.type = 'object':\n   - You MUST provide an array of OBJECTS, not strings or primitive values\n   - Each object must be a complete JSON object with all its required fields\n4. Arrays must contain ONLY items actually supported by the input: an array may have a single item or be empty if that is what the data supports — NEVER invent entries to pad an array\n5. Verify all nested objects have their complete structure\n6. Follow ALL type specifications (string, number, boolean, array, object)",
+        error_message
+    )
+}
+
 /// Helper function to execute generation with retry logic using conversation history.
 ///
 /// This function maintains a conversation history across retry attempts, which enables:
@@ -1237,10 +1253,7 @@ where
                         messages.push(ChatMessage::assistant(&ctx.raw_response));
 
                         // Add user message with error feedback
-                        let error_feedback = format!(
-                            "Your previous response contained validation errors. Please provide a complete, valid JSON response that includes ALL required fields and follows the schema exactly.\n\nError details:\n{}\n\nPlease fix the issues in your response. Make sure to:\n1. Include ALL required fields exactly as specified in the schema\n2. For enum fields, use EXACTLY one of the allowed values from the description\n3. CRITICAL: For arrays where items.type = 'object':\n   - You MUST provide an array of OBJECTS, not strings or primitive values\n   - Each object must be a complete JSON object with all its required fields\n   - Include multiple items (at least 2-3) in arrays of objects\n4. Verify all nested objects have their complete structure\n5. Follow ALL type specifications (string, number, boolean, array, object)",
-                            ctx.error_message
-                        );
+                        let error_feedback = validation_retry_feedback(&ctx.error_message);
                         messages.push(ChatMessage::user(error_feedback));
 
                         debug!(
@@ -2232,6 +2245,33 @@ mod tests {
 
         assert_eq!(attempts, 2);
         assert_eq!(output.data, "ok");
+    }
+
+    #[test]
+    fn test_validation_retry_feedback_does_not_induce_array_fabrication() {
+        let feedback = validation_retry_feedback("missing required field: summary");
+
+        // The actual validation error is embedded for the model to act on.
+        assert!(feedback.contains("missing required field: summary"));
+
+        // The prompt previously instructed "Include multiple items (at least
+        // 2-3) in arrays of objects", which told a model that correctly
+        // extracted one item (or zero) to fabricate more. No minimum-count
+        // language may appear.
+        assert!(!feedback.contains("at least 2"));
+        assert!(!feedback.contains("2-3"));
+        assert!(!feedback.contains("multiple items"));
+
+        // Instead, arrays must stay faithful to the source material.
+        assert!(feedback.contains("ONLY items actually supported by the input"));
+        assert!(feedback.contains("may have a single item or be empty"));
+        assert!(feedback.contains("NEVER invent entries to pad an array"));
+
+        // The rest of the prompt's intent is preserved.
+        assert!(feedback.contains("ALL required fields"));
+        assert!(feedback.contains("EXACTLY one of the allowed values"));
+        assert!(feedback.contains("array of OBJECTS, not strings or primitive values"));
+        assert!(feedback.contains("type specifications (string, number, boolean, array, object)"));
     }
 
     // ===================================================================


### PR DESCRIPTION
## Problem

The hardcoded validation-retry ("re-ask") prompt in `src/backend/utils.rs` told the model:

> Include multiple items (at least 2-3) in arrays of objects

This corrupts extraction results. When a response fails validation for an unrelated reason (a missing field, a wrong enum value), the retry prompt instructs the model to populate every object array with 2-3 entries — even when the source material only supports one item, or none. A model that correctly extracted a single item is explicitly told to invent more, so the retried response can be *less* faithful to the input than the one that failed validation.

## Fix

- Replaced the minimum-count instruction with faithfulness guidance: arrays must contain only items actually supported by the input; a single-item or empty array is valid when that is all the data supports; never invent entries to pad an array.
- Preserved the rest of the prompt's intent unchanged: complete JSON, all required fields, exact enum values, objects (not strings) in object arrays, and correct type specifications.
- Extracted the prompt into a `validation_retry_feedback(error_message)` helper so the wording is unit-testable.
- Added `test_validation_retry_feedback_does_not_induce_array_fabrication`, which asserts the fabrication language ("at least 2", "2-3", "multiple items") is gone and the don't-invent guidance is present, alongside the preserved instructions.

A repo-wide grep for "2-3" / "at least 2" confirmed this was the only copy of the fabrication wording (the other hits are unrelated: multimodal test assertion messages about image counts and an example field description about summary length). No existing tests asserted the old prompt text.

## Verification

- `cargo fmt` — clean
- `cargo clippy --all-targets` (default features, matching CI) — no warnings
- `cargo test` — all 43 suites pass (143 lib unit tests plus integration/doc tests), including the new prompt test

🤖 Generated with [Claude Code](https://claude.com/claude-code)