### PR TITLE
fix: omit temperature and use max_completion_tokens for o-series models

### DIFF
--- a/src/backend/grok.rs
+++ b/src/backend/grok.rs
@@ -211,8 +211,10 @@ impl GrokClient {
             model: self.config.model.as_str().to_string(),
             messages: api_messages,
             response_format: Some(response_format),
-            temperature: self.config.temperature,
+            // Grok has no o-series models: always send temperature/max_tokens.
+            temperature: Some(self.config.temperature),
             max_tokens: self.config.max_tokens,
+            max_completion_tokens: None,
             reasoning_effort: None,
         };
 
@@ -339,8 +341,10 @@ impl GrokClient {
                 content: OpenAICompatibleMessageContent::Text(prompt.to_string()),
             }],
             response_format,
-            temperature: self.config.temperature,
+            // Grok has no o-series models: always send temperature/max_tokens.
+            temperature: Some(self.config.temperature),
             max_tokens: self.config.max_tokens,
+            max_completion_tokens: None,
             reasoning_effort: None,
         };
         let mut body = serde_json::to_value(&request).unwrap_or_else(|_| serde_json::json!({}));
@@ -525,8 +529,10 @@ impl LLMClient for GrokClient {
                 content: OpenAICompatibleMessageContent::Text(prompt.to_string()),
             }],
             response_format: None,
-            temperature: self.config.temperature,
+            // Grok has no o-series models: always send temperature/max_tokens.
+            temperature: Some(self.config.temperature),
             max_tokens: self.config.max_tokens,
+            max_completion_tokens: None,
             reasoning_effort: None,
         };
 

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -104,6 +104,40 @@ define_model_enum! {
     }
 }
 
+impl Model {
+    /// Returns `true` if this is an o-series reasoning model
+    /// (`o1`, `o1-pro`, `o3`, `o3-mini`, `o4-mini`, ...).
+    ///
+    /// o-series models accept different request parameters than other chat
+    /// models on `/v1/chat/completions`: they reject `temperature` with a 400
+    /// error and require `max_completion_tokens` instead of `max_tokens`.
+    /// [`OpenAIClient`] consults this predicate to shape requests
+    /// automatically, so all models work without extra configuration.
+    ///
+    /// Custom model identifiers are matched by prefix, so o-series models
+    /// without a named variant (e.g. `o3-pro`) are detected too.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rstructor::OpenAIModel;
+    ///
+    /// assert!(OpenAIModel::O3.is_reasoning_model());
+    /// assert!(OpenAIModel::O1Pro.is_reasoning_model());
+    /// assert!(OpenAIModel::from_string("o3-pro").is_reasoning_model());
+    ///
+    /// assert!(!OpenAIModel::Gpt4O.is_reasoning_model());
+    /// assert!(!OpenAIModel::Gpt5.is_reasoning_model());
+    /// ```
+    pub fn is_reasoning_model(&self) -> bool {
+        let id = self.as_str();
+        matches!(id, "o1" | "o3" | "o4")
+            || id.starts_with("o1-")
+            || id.starts_with("o3-")
+            || id.starts_with("o4-")
+    }
+}
+
 /// Configuration for the OpenAI client
 #[derive(Debug, Clone)]
 pub struct OpenAIConfig {
@@ -126,6 +160,17 @@ pub struct OpenAIConfig {
 pub struct OpenAIClient {
     config: OpenAIConfig,
     client: reqwest::Client,
+}
+
+/// Per-request parameters derived from the configured model's capabilities.
+///
+/// See [`OpenAIClient::request_tuning`] for the per-model rules.
+#[derive(Debug)]
+struct RequestTuning {
+    temperature: Option<f32>,
+    max_tokens: Option<u32>,
+    max_completion_tokens: Option<u32>,
+    reasoning_effort: Option<String>,
 }
 
 // ResponseFormat and JsonSchemaFormat are imported from utils and shared
@@ -298,6 +343,56 @@ impl OpenAIClient {
         self
     }
 
+    /// Derive the sampling, token-limit, and reasoning parameters for the
+    /// configured model's capabilities.
+    ///
+    /// - o-series reasoning models (`o1`, `o3`, `o4-mini`, ...): `temperature`
+    ///   is omitted entirely (the API rejects it with a 400 error) and the
+    ///   configured token limit is sent as `max_completion_tokens` instead of
+    ///   `max_tokens`. `reasoning_effort` is sent for the configured thinking
+    ///   level, except `Off` ("none"), which o-series models don't accept.
+    /// - GPT-5.x models: `reasoning_effort` is sent for the configured
+    ///   thinking level, and `temperature` is forced to 1.0 while reasoning is
+    ///   enabled (required by the API).
+    /// - All other models: `temperature` and `max_tokens` are sent exactly as
+    ///   configured.
+    fn request_tuning(&self) -> RequestTuning {
+        if self.config.model.is_reasoning_model() {
+            let reasoning_effort = self
+                .config
+                .thinking_level
+                .and_then(|level| level.openai_reasoning_effort().map(|s| s.to_string()))
+                .filter(|effort| effort != "none");
+            return RequestTuning {
+                temperature: None,
+                max_tokens: None,
+                max_completion_tokens: self.config.max_tokens,
+                reasoning_effort,
+            };
+        }
+
+        let is_gpt5 = self.config.model.as_str().starts_with("gpt-5");
+        let reasoning_effort = if is_gpt5 {
+            self.config
+                .thinking_level
+                .and_then(|level| level.openai_reasoning_effort().map(|s| s.to_string()))
+        } else {
+            None
+        };
+        // GPT-5.x with reasoning requires temperature=1.0
+        let temperature = if reasoning_effort.is_some() {
+            1.0
+        } else {
+            self.config.temperature
+        };
+        RequestTuning {
+            temperature: Some(temperature),
+            max_tokens: self.config.max_tokens,
+            max_completion_tokens: None,
+            reasoning_effort,
+        }
+    }
+
     /// Internal implementation of materialize (without retry logic)
     /// Accepts conversation history for multi-turn interactions.
     /// Returns the data, raw response, and optional usage info.
@@ -335,22 +430,9 @@ impl OpenAIClient {
             Some("Output in the specified format. Include ALL required fields and follow the schema exactly.".to_string()),
         );
 
-        // Build reasoning_effort for GPT-5.x models
-        let is_gpt5 = self.config.model.as_str().starts_with("gpt-5");
-        let reasoning_effort = if is_gpt5 {
-            self.config
-                .thinking_level
-                .and_then(|level| level.openai_reasoning_effort().map(|s| s.to_string()))
-        } else {
-            None
-        };
-
-        // GPT-5.x with reasoning requires temperature=1.0
-        let effective_temp = if reasoning_effort.is_some() {
-            1.0
-        } else {
-            self.config.temperature
-        };
+        // Derive per-model request parameters (temperature, token limits,
+        // reasoning effort) from the configured model's capabilities.
+        let tuning = self.request_tuning();
 
         // Convert ChatMessage to OpenAI's format
         let api_messages =
@@ -365,9 +447,10 @@ impl OpenAIClient {
             model: self.config.model.as_str().to_string(),
             messages: api_messages,
             response_format: Some(response_format),
-            temperature: effective_temp,
-            max_tokens: self.config.max_tokens,
-            reasoning_effort,
+            temperature: tuning.temperature,
+            max_tokens: tuning.max_tokens,
+            max_completion_tokens: tuning.max_completion_tokens,
+            reasoning_effort: tuning.reasoning_effort,
         };
 
         // Send the request to OpenAI
@@ -460,19 +543,7 @@ impl OpenAIClient {
         prompt: &str,
         response_format: Option<ResponseFormat>,
     ) -> serde_json::Value {
-        let is_gpt5 = self.config.model.as_str().starts_with("gpt-5");
-        let reasoning_effort = if is_gpt5 {
-            self.config
-                .thinking_level
-                .and_then(|level| level.openai_reasoning_effort().map(|s| s.to_string()))
-        } else {
-            None
-        };
-        let effective_temp = if reasoning_effort.is_some() {
-            1.0
-        } else {
-            self.config.temperature
-        };
+        let tuning = self.request_tuning();
         let request = OpenAICompatibleChatCompletionRequest {
             model: self.config.model.as_str().to_string(),
             messages: vec![OpenAICompatibleChatMessage {
@@ -480,9 +551,10 @@ impl OpenAIClient {
                 content: OpenAICompatibleMessageContent::Text(prompt.to_string()),
             }],
             response_format,
-            temperature: effective_temp,
-            max_tokens: self.config.max_tokens,
-            reasoning_effort,
+            temperature: tuning.temperature,
+            max_tokens: tuning.max_tokens,
+            max_completion_tokens: tuning.max_completion_tokens,
+            reasoning_effort: tuning.reasoning_effort,
         };
         let mut body = serde_json::to_value(&request).unwrap_or_else(|_| serde_json::json!({}));
         body["stream"] = serde_json::Value::Bool(true);
@@ -667,22 +739,9 @@ impl LLMClient for OpenAIClient {
     async fn generate_with_metadata(&self, prompt: &str) -> Result<GenerateResult> {
         info!("Generating raw text response with OpenAI");
 
-        // Build reasoning_effort for GPT-5.x models
-        let is_gpt5 = self.config.model.as_str().starts_with("gpt-5");
-        let reasoning_effort = if is_gpt5 {
-            self.config
-                .thinking_level
-                .and_then(|level| level.openai_reasoning_effort().map(|s| s.to_string()))
-        } else {
-            None
-        };
-
-        // GPT-5.x with reasoning requires temperature=1.0
-        let effective_temp = if reasoning_effort.is_some() {
-            1.0
-        } else {
-            self.config.temperature
-        };
+        // Derive per-model request parameters (temperature, token limits,
+        // reasoning effort) from the configured model's capabilities.
+        let tuning = self.request_tuning();
 
         // Build the request for text generation (no structured output)
         debug!("Building OpenAI API request for text generation");
@@ -693,9 +752,10 @@ impl LLMClient for OpenAIClient {
                 content: OpenAICompatibleMessageContent::Text(prompt.to_string()),
             }],
             response_format: None,
-            temperature: effective_temp,
-            max_tokens: self.config.max_tokens,
-            reasoning_effort,
+            temperature: tuning.temperature,
+            max_tokens: tuning.max_tokens,
+            max_completion_tokens: tuning.max_completion_tokens,
+            reasoning_effort: tuning.reasoning_effort,
         };
 
         // Send the request to OpenAI

--- a/src/backend/openai_compatible.rs
+++ b/src/backend/openai_compatible.rs
@@ -33,11 +33,19 @@ pub(crate) struct OpenAICompatibleChatCompletionRequest {
     pub messages: Vec<OpenAICompatibleChatMessage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_format: Option<ResponseFormat>,
-    pub temperature: f32,
+    /// Sampling temperature. `None` omits the key entirely, which is required
+    /// for OpenAI o-series reasoning models (they reject `temperature` with a
+    /// 400 error).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<u32>,
-    /// Reasoning effort for GPT-5.x models (OpenAI only).
-    /// Omitted for providers that don't support it.
+    /// Completion-token limit for OpenAI o-series reasoning models, which
+    /// reject `max_tokens` and require `max_completion_tokens` instead.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_completion_tokens: Option<u32>,
+    /// Reasoning effort for OpenAI reasoning-capable models (GPT-5.x and the
+    /// o-series). Omitted for providers that don't support it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<String>,
 }
@@ -114,10 +122,63 @@ mod tests {
                 content: OpenAICompatibleMessageContent::Text("hi".to_string()),
             }],
             response_format: None,
-            temperature: 0.0,
+            temperature: None,
             max_tokens: None,
+            max_completion_tokens: None,
             reasoning_effort: None,
         }
+    }
+
+    /// When `temperature` is `None`, the `temperature` key must be absent from
+    /// the serialized request body. o-series reasoning models reject the
+    /// parameter with a 400 error, so omitting it must be possible.
+    #[test]
+    fn test_request_omits_temperature_when_none() {
+        let req = request_with_none_options();
+        let json = serde_json::to_value(&req).expect("serialization should succeed");
+
+        let obj = json.as_object().expect("request serializes to an object");
+        assert!(
+            !obj.contains_key("temperature"),
+            "temperature key must be omitted when None, got: {json}"
+        );
+    }
+
+    /// When `temperature` is `Some(..)`, the serialized request body must carry
+    /// the numeric value under the `temperature` key.
+    #[test]
+    fn test_request_includes_temperature_when_some() {
+        let mut req = request_with_none_options();
+        req.temperature = Some(0.5);
+        let json = serde_json::to_value(&req).expect("serialization should succeed");
+
+        assert_eq!(json["temperature"], serde_json::json!(0.5));
+    }
+
+    /// When `max_completion_tokens` is `None`, the key must be absent from the
+    /// serialized request body.
+    #[test]
+    fn test_request_omits_max_completion_tokens_when_none() {
+        let req = request_with_none_options();
+        let json = serde_json::to_value(&req).expect("serialization should succeed");
+
+        let obj = json.as_object().expect("request serializes to an object");
+        assert!(
+            !obj.contains_key("max_completion_tokens"),
+            "max_completion_tokens key must be omitted when None, got: {json}"
+        );
+    }
+
+    /// When `max_completion_tokens` is `Some(..)`, the serialized request body
+    /// must carry the numeric value under the `max_completion_tokens` key
+    /// (the limit parameter o-series reasoning models require).
+    #[test]
+    fn test_request_includes_max_completion_tokens_when_some() {
+        let mut req = request_with_none_options();
+        req.max_completion_tokens = Some(1024);
+        let json = serde_json::to_value(&req).expect("serialization should succeed");
+
+        assert_eq!(json["max_completion_tokens"], serde_json::json!(1024));
     }
 
     /// When `max_tokens` is `None`, the `max_tokens` key must be absent from the
@@ -199,8 +260,10 @@ mod tests {
         assert_eq!(json["response_format"]["type"], "json_schema");
     }
 
-    /// Sanity check: the always-serialized fields (`model`, `messages`,
-    /// `temperature`) remain present even when every `Option` field is `None`.
+    /// Sanity check: the always-serialized fields (`model`, `messages`) remain
+    /// present even when every `Option` field is `None`. `temperature` is no
+    /// longer unconditional: it is omitted for o-series reasoning models,
+    /// which reject the parameter.
     #[test]
     fn test_request_required_fields_present_with_all_none() {
         let req = request_with_none_options();
@@ -211,10 +274,6 @@ mod tests {
         assert!(
             obj.contains_key("messages"),
             "messages must always be present"
-        );
-        assert!(
-            obj.contains_key("temperature"),
-            "temperature must always be present"
         );
     }
 

--- a/tests/http_mock_tests.rs
+++ b/tests/http_mock_tests.rs
@@ -7,7 +7,7 @@
 //! shaping and the retry loop it drives are shared by the OpenAI-compatible path.
 #![cfg(feature = "openai")]
 
-use rstructor::{ApiErrorKind, Instructor, LLMClient, OpenAIClient, RStructorError};
+use rstructor::{ApiErrorKind, Instructor, LLMClient, OpenAIClient, RStructorError, ThinkingLevel};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
@@ -355,6 +355,200 @@ async fn non_gpt5_omits_reasoning_effort_and_passes_temperature_through() {
         body["temperature"],
         json!(0.2),
         "configured temperature must pass through unchanged"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// o-series request parameters (offline_mockito)
+// ---------------------------------------------------------------------------
+
+/// Mount a catch-all `/chat/completions` mock that records every request body
+/// into the returned buffer and responds with `chat_completion(content)`.
+async fn capture_chat_request(
+    server: &mut mockito::Server,
+    content: &str,
+) -> (mockito::Mock, std::sync::Arc<std::sync::Mutex<Vec<Value>>>) {
+    let captured: std::sync::Arc<std::sync::Mutex<Vec<Value>>> =
+        std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let sink = captured.clone();
+    let mock = server
+        .mock("POST", "/chat/completions")
+        .match_request(move |req| {
+            if let Ok(body) = req.utf8_lossy_body()
+                && let Ok(v) = serde_json::from_str::<Value>(&body)
+            {
+                sink.lock().unwrap().push(v);
+            }
+            true
+        })
+        .with_status(200)
+        .with_body(chat_completion(content))
+        .expect(1)
+        .create_async()
+        .await;
+    (mock, captured)
+}
+
+/// o-series reasoning models (here `o3`) reject `temperature` (400) and require
+/// `max_completion_tokens` instead of `max_tokens`. The structured-output
+/// request must omit `temperature` and `max_tokens` entirely, carry the
+/// configured limit as `max_completion_tokens`, and still send
+/// `reasoning_effort` (the default thinking level is Medium).
+#[tokio::test]
+async fn o_series_omits_temperature_and_maps_max_tokens() {
+    let mut server = mockito::Server::new_async().await;
+    let (m, captured) =
+        capture_chat_request(&mut server, r#"{"title":"Inception","year":2010}"#).await;
+
+    let movie: Movie = OpenAIClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("o3")
+        .temperature(0.7)
+        .max_tokens(1234)
+        .materialize("Describe Inception")
+        .await
+        .unwrap();
+    assert_eq!(movie.title, "Inception");
+    m.assert_async().await;
+
+    let bodies = captured.lock().unwrap();
+    assert_eq!(bodies.len(), 1, "expected exactly one request");
+    let body = &bodies[0];
+    assert!(
+        body.get("temperature").is_none(),
+        "temperature must be omitted for o-series models, got {body}"
+    );
+    assert!(
+        body.get("max_tokens").is_none(),
+        "max_tokens must be omitted for o-series models, got {body}"
+    );
+    assert_eq!(
+        body["max_completion_tokens"],
+        json!(1234),
+        "configured max_tokens must be sent as max_completion_tokens"
+    );
+    assert_eq!(
+        body["reasoning_effort"],
+        json!("medium"),
+        "default thinking level (Medium) must map to reasoning_effort"
+    );
+}
+
+/// An o-series model with `ThinkingLevel::Off` must omit `reasoning_effort`
+/// (o-series models don't accept `"none"`), and with no `max_tokens` configured
+/// no token-limit key may appear at all.
+#[tokio::test]
+async fn o_series_thinking_off_omits_reasoning_effort() {
+    let mut server = mockito::Server::new_async().await;
+    let (m, captured) = capture_chat_request(&mut server, "ok").await;
+
+    let text = OpenAIClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("o4-mini")
+        .thinking_level(ThinkingLevel::Off)
+        .generate("hi")
+        .await
+        .unwrap();
+    assert_eq!(text, "ok");
+    m.assert_async().await;
+
+    let bodies = captured.lock().unwrap();
+    assert_eq!(bodies.len(), 1, "expected exactly one request");
+    let body = &bodies[0];
+    assert!(
+        body.get("reasoning_effort").is_none(),
+        "reasoning_effort 'none' must not be sent to o-series models, got {body}"
+    );
+    assert!(
+        body.get("temperature").is_none(),
+        "temperature must be omitted for o-series models, got {body}"
+    );
+    assert!(
+        body.get("max_tokens").is_none(),
+        "max_tokens must be omitted for o-series models, got {body}"
+    );
+    assert!(
+        body.get("max_completion_tokens").is_none(),
+        "max_completion_tokens must be absent when no max_tokens is configured, got {body}"
+    );
+}
+
+/// Non-reasoning models keep the existing contract: `temperature` and
+/// `max_tokens` are sent as configured and `max_completion_tokens` never
+/// appears.
+#[tokio::test]
+async fn non_reasoning_model_keeps_temperature_and_max_tokens() {
+    let mut server = mockito::Server::new_async().await;
+    let (m, captured) = capture_chat_request(&mut server, "ok").await;
+
+    let text = OpenAIClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("gpt-4o")
+        .temperature(0.5)
+        .max_tokens(64)
+        .generate("hi")
+        .await
+        .unwrap();
+    assert_eq!(text, "ok");
+    m.assert_async().await;
+
+    let bodies = captured.lock().unwrap();
+    assert_eq!(bodies.len(), 1, "expected exactly one request");
+    let body = &bodies[0];
+    assert_eq!(body["temperature"], json!(0.5));
+    assert_eq!(body["max_tokens"], json!(64));
+    assert!(
+        body.get("max_completion_tokens").is_none(),
+        "max_completion_tokens must never be sent for non-o-series models, got {body}"
+    );
+}
+
+/// Grok shares the OpenAI-compatible request struct but has no o-series
+/// models: its requests must still always carry `temperature` and `max_tokens`
+/// and never `max_completion_tokens` or `reasoning_effort`.
+#[cfg(feature = "grok")]
+#[tokio::test]
+async fn grok_request_still_sends_temperature_and_max_tokens() {
+    use rstructor::GrokClient;
+
+    let mut server = mockito::Server::new_async().await;
+    let (m, captured) = capture_chat_request(&mut server, "ok").await;
+
+    let text = GrokClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("grok-3")
+        .temperature(0.5)
+        .max_tokens(64)
+        .generate("hi")
+        .await
+        .unwrap();
+    assert_eq!(text, "ok");
+    m.assert_async().await;
+
+    let bodies = captured.lock().unwrap();
+    assert_eq!(bodies.len(), 1, "expected exactly one request");
+    let body = &bodies[0];
+    assert_eq!(
+        body["temperature"],
+        json!(0.5),
+        "Grok must always send temperature"
+    );
+    assert_eq!(
+        body["max_tokens"],
+        json!(64),
+        "Grok must always send max_tokens"
+    );
+    assert!(
+        body.get("max_completion_tokens").is_none(),
+        "Grok must never send max_completion_tokens, got {body}"
+    );
+    assert!(
+        body.get("reasoning_effort").is_none(),
+        "Grok must never send reasoning_effort, got {body}"
     );
 }
 


### PR DESCRIPTION
## Problem

The OpenAI o-series reasoning models (`O4Mini`, `O3`, `O3Mini`, `O1`, `O1Pro`) could not actually be called. Every request through the shared OpenAI-compatible request struct unconditionally serialized `temperature` and only ever used `max_tokens` — but on `/v1/chat/completions` the o-series models return **400** for `temperature` and require `max_completion_tokens` instead of `max_tokens`. There was even a unit test asserting "temperature must always be present", locking in the broken contract.

## Fix

- **`OpenAIModel::is_reasoning_model()`** — new capability predicate matching all o-series variants. Custom identifiers are matched by prefix (`o1-`/`o3-`/`o4-`), so models like `o3-pro` without a named variant are detected too.
- **Shared request struct** (`src/backend/openai_compatible.rs`): `temperature` is now `Option<f32>` with `skip_serializing_if`, and a new optional `max_completion_tokens: Option<u32>` field was added.
- **`OpenAIClient::request_tuning()`** — centralizes per-model parameter shaping, used by all three OpenAI request builders (materialize, generate, streaming):
  - **o-series**: `temperature` omitted entirely; the configured `max_tokens` is sent as `max_completion_tokens`; `reasoning_effort` is sent from the configured thinking level (`Off` is omitted rather than sent as `"none"`, which o-series models reject).
  - **GPT-5.x**: unchanged — `reasoning_effort` from the thinking level, `temperature` forced to 1.0 while reasoning is enabled, `max_tokens` as before.
  - **All other models**: unchanged — `temperature` and `max_tokens` sent exactly as configured.
- **Grok** shares the request struct but has no o-series models: its requests still always send `temperature` and `max_tokens`, and never `max_completion_tokens`.
- The tool-calling loop (`tools` feature) builds its own JSON body in `tools.rs` and is untouched (out of scope).

## Tests (all offline — no live API calls)

- Updated the "temperature must always be present" serialization test to the new contract; added unit tests for omit/include of `temperature` and `max_completion_tokens`.
- New mockito request-body tests in `tests/http_mock_tests.rs`:
  - `o3` (materialize): no `temperature`, no `max_tokens`, `max_completion_tokens: 1234`, `reasoning_effort: "medium"` (default thinking level).
  - `o4-mini` with `ThinkingLevel::Off`: no `reasoning_effort`/`temperature`/`max_tokens`/`max_completion_tokens`.
  - `gpt-4o`: `temperature` and `max_tokens` unchanged, no `max_completion_tokens`.
  - Grok: request body unchanged (`temperature` + `max_tokens` always present).

## Verification

- `cargo fmt` — clean
- `cargo clippy --all-targets` (default features, matching CI) — clean; also clean with `--all-features`
- `cargo test` — full suite passes (146 lib unit tests, all integration tests, 63 doctests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)