### PR TITLE
fix: add default HTTP timeout and retry transient connection errors

### DIFF
--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -7,11 +7,11 @@ use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::backend::model_macro::define_model_enum;
 use crate::backend::{
-    AnthropicMessageContent, ChatMessage, GenerateResult, LLMClient, MaterializeInternalOutput,
-    MaterializeResult, ModelInfo, ThinkingLevel, TokenUsage, ValidationFailureContext,
-    build_anthropic_message_content, check_response_status, generate_with_retry_with_history,
-    handle_http_error, materialize_with_media_with_retry, parse_validate_and_create_output,
-    prepare_strict_schema,
+    AnthropicMessageContent, ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient,
+    MaterializeInternalOutput, MaterializeResult, ModelInfo, ThinkingLevel, TokenUsage,
+    ValidationFailureContext, build_anthropic_message_content, build_http_client,
+    check_response_status, generate_with_retry_with_history, handle_http_error,
+    materialize_with_media_with_retry, parse_validate_and_create_output, prepare_strict_schema,
 };
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
@@ -70,6 +70,8 @@ pub struct AnthropicConfig {
     pub model: AnthropicModel,
     pub temperature: f32,
     pub max_tokens: Option<u32>,
+    /// Total timeout for each HTTP request.
+    /// Defaults to [`DEFAULT_REQUEST_TIMEOUT`](crate::DEFAULT_REQUEST_TIMEOUT) (5 minutes).
     pub timeout: Option<Duration>,
     pub max_retries: Option<usize>,
     /// Custom base URL for Anthropic-compatible APIs
@@ -198,16 +200,16 @@ impl AnthropicClient {
             model: AnthropicModel::ClaudeSonnet46, // Default to Claude Sonnet 4.6 (latest balanced model)
             temperature: 0.0,
             max_tokens: None,
-            timeout: None,        // Default: no timeout (uses reqwest's default)
-            max_retries: Some(3), // Default: 3 retries with error feedback
-            base_url: None,       // Default: use official Anthropic API
+            timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
+            max_retries: Some(3),                   // Default: 3 retries with error feedback
+            base_url: None,                         // Default: use official Anthropic API
             thinking_level: None, // Default: no extended thinking (faster responses)
         };
 
         debug!("Anthropic client created with default configuration");
         Ok(Self {
             config,
-            client: reqwest::Client::new(),
+            client: build_http_client(DEFAULT_REQUEST_TIMEOUT),
         })
     }
 
@@ -240,16 +242,16 @@ impl AnthropicClient {
             model: AnthropicModel::ClaudeSonnet46, // Default to Claude Sonnet 4.6 (latest balanced model)
             temperature: 0.0,
             max_tokens: None,
-            timeout: None,        // Default: no timeout (uses reqwest's default)
-            max_retries: Some(3), // Default: 3 retries with error feedback
-            base_url: None,       // Default: use official Anthropic API
+            timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
+            max_retries: Some(3),                   // Default: 3 retries with error feedback
+            base_url: None,                         // Default: use official Anthropic API
             thinking_level: None, // Default: no extended thinking (faster responses)
         };
 
         debug!("Anthropic client created with default configuration");
         Ok(Self {
             config,
-            client: reqwest::Client::new(),
+            client: build_http_client(DEFAULT_REQUEST_TIMEOUT),
         })
     }
 
@@ -1005,5 +1007,25 @@ mod tests {
         let thinking = thinking_config_with_budget(u32::MAX);
         let result = effective_max_tokens(None, Some(&thinking));
         assert_eq!(result, u32::MAX);
+    }
+
+    #[test]
+    fn default_config_has_default_timeout() {
+        let client = super::AnthropicClient::new("test-key").unwrap();
+        assert_eq!(
+            client.config.timeout,
+            Some(crate::backend::DEFAULT_REQUEST_TIMEOUT)
+        );
+    }
+
+    #[test]
+    fn explicit_timeout_overrides_default() {
+        let client = super::AnthropicClient::new("test-key")
+            .unwrap()
+            .timeout(std::time::Duration::from_secs(10));
+        assert_eq!(
+            client.config.timeout,
+            Some(std::time::Duration::from_secs(10))
+        );
     }
 }

--- a/src/backend/client.rs
+++ b/src/backend/client.rs
@@ -126,6 +126,9 @@ impl MediaFile {
 ///   - Gemini: `GEMINI_API_KEY`
 /// - Builder methods: `model()`, `temperature()`, `max_tokens()`, `timeout()`
 /// - All clients validate `max_tokens >= 1` to avoid API errors
+/// - Requests default to a 5-minute total timeout (`DEFAULT_REQUEST_TIMEOUT`) with a
+///   30-second connect timeout (`DEFAULT_CONNECT_TIMEOUT`), so a hung connection can
+///   never block forever
 /// - Timeout is applied immediately when `timeout()` is called - no need to call `build()`
 ///
 /// # Examples

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -7,10 +7,10 @@ use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::backend::model_macro::define_model_enum;
 use crate::backend::{
-    ChatMessage, GenerateResult, LLMClient, MaterializeInternalOutput, MaterializeResult,
-    ModelInfo, ThinkingLevel, TokenUsage, ValidationFailureContext, check_response_status,
-    generate_with_retry_with_history, handle_http_error, materialize_with_media_with_retry,
-    parse_validate_and_create_output,
+    ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient, MaterializeInternalOutput,
+    MaterializeResult, ModelInfo, ThinkingLevel, TokenUsage, ValidationFailureContext,
+    build_http_client, check_response_status, generate_with_retry_with_history, handle_http_error,
+    materialize_with_media_with_retry, parse_validate_and_create_output,
 };
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
@@ -87,6 +87,8 @@ pub struct GeminiConfig {
     pub model: Model,
     pub temperature: f32,
     pub max_tokens: Option<u32>,
+    /// Total timeout for each HTTP request.
+    /// Defaults to [`DEFAULT_REQUEST_TIMEOUT`](crate::DEFAULT_REQUEST_TIMEOUT) (5 minutes).
     pub timeout: Option<Duration>,
     pub max_retries: Option<usize>,
     /// Custom base URL for Gemini-compatible APIs
@@ -276,13 +278,13 @@ impl GeminiClient {
             model: Model::Gemini35Flash, // Default to Gemini 3.5 Flash (latest Flash, best price/performance)
             temperature: 0.0,
             max_tokens: None,
-            timeout: None,        // Default: no timeout (uses reqwest's default)
-            max_retries: Some(3), // Default: 3 retries with error feedback
-            base_url: None,       // Default: use official Gemini API
+            timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
+            max_retries: Some(3),                   // Default: 3 retries with error feedback
+            base_url: None,                         // Default: use official Gemini API
             thinking_level: Some(ThinkingLevel::Low), // Default to Low thinking for Gemini 3.x
         };
 
-        let client = reqwest::Client::new();
+        let client = build_http_client(DEFAULT_REQUEST_TIMEOUT);
 
         info!(
             model = %config.model.as_str(),
@@ -318,13 +320,13 @@ impl GeminiClient {
             model: Model::Gemini35Flash, // Default to Gemini 3.5 Flash (latest Flash, best price/performance)
             temperature: 0.0,
             max_tokens: None,
-            timeout: None,        // Default: no timeout (uses reqwest's default)
-            max_retries: Some(3), // Default: 3 retries with error feedback
-            base_url: None,       // Default: use official Gemini API
+            timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
+            max_retries: Some(3),                   // Default: 3 retries with error feedback
+            base_url: None,                         // Default: use official Gemini API
             thinking_level: Some(ThinkingLevel::Low), // Default to Low thinking for Gemini 3.x
         };
 
-        let client = reqwest::Client::new();
+        let client = build_http_client(DEFAULT_REQUEST_TIMEOUT);
 
         info!(
             model = %config.model.as_str(),
@@ -1134,6 +1136,26 @@ mod tests {
         assert_eq!(
             list_url,
             "http://localhost:8080/v1beta//models?key=test-key"
+        );
+    }
+
+    #[test]
+    fn default_config_has_default_timeout() {
+        let client = super::GeminiClient::new("test-key").unwrap();
+        assert_eq!(
+            client.config.timeout,
+            Some(crate::backend::DEFAULT_REQUEST_TIMEOUT)
+        );
+    }
+
+    #[test]
+    fn explicit_timeout_overrides_default() {
+        let client = super::GeminiClient::new("test-key")
+            .unwrap()
+            .timeout(std::time::Duration::from_secs(10));
+        assert_eq!(
+            client.config.timeout,
+            Some(std::time::Duration::from_secs(10))
         );
     }
 }

--- a/src/backend/grok.rs
+++ b/src/backend/grok.rs
@@ -5,11 +5,12 @@ use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::backend::model_macro::define_model_enum;
 use crate::backend::{
-    ChatMessage, GenerateResult, LLMClient, MaterializeInternalOutput, MaterializeResult,
-    ModelInfo, OpenAICompatibleChatCompletionRequest, OpenAICompatibleChatCompletionResponse,
-    ResponseFormat, TokenUsage, ValidationFailureContext, check_response_status,
-    convert_openai_compatible_chat_messages, generate_with_retry_with_history, handle_http_error,
-    materialize_with_media_with_retry, parse_validate_and_create_output, prepare_strict_schema,
+    ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient, MaterializeInternalOutput,
+    MaterializeResult, ModelInfo, OpenAICompatibleChatCompletionRequest,
+    OpenAICompatibleChatCompletionResponse, ResponseFormat, TokenUsage, ValidationFailureContext,
+    build_http_client, check_response_status, convert_openai_compatible_chat_messages,
+    generate_with_retry_with_history, handle_http_error, materialize_with_media_with_retry,
+    parse_validate_and_create_output, prepare_strict_schema,
 };
 #[cfg(feature = "streaming")]
 use crate::backend::{OpenAICompatibleChatMessage, OpenAICompatibleMessageContent};
@@ -61,6 +62,8 @@ pub struct GrokConfig {
     pub model: Model,
     pub temperature: f32,
     pub max_tokens: Option<u32>,
+    /// Total timeout for each HTTP request.
+    /// Defaults to [`DEFAULT_REQUEST_TIMEOUT`](crate::DEFAULT_REQUEST_TIMEOUT) (5 minutes).
     pub timeout: Option<Duration>,
     pub max_retries: Option<usize>,
     /// Custom base URL for Grok-compatible APIs (e.g., local LLMs, proxy endpoints)
@@ -111,15 +114,15 @@ impl GrokClient {
             model: Model::Grok43, // Default to Grok 4.3 (latest recommended chat model)
             temperature: 0.0,
             max_tokens: None,
-            timeout: None,        // Default: no timeout (uses reqwest's default)
-            max_retries: Some(3), // Default: 3 retries with error feedback
-            base_url: None,       // Default: use official Grok API
+            timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
+            max_retries: Some(3),                   // Default: 3 retries with error feedback
+            base_url: None,                         // Default: use official Grok API
         };
 
         debug!("Grok client created with default configuration");
         Ok(Self {
             config,
-            client: reqwest::Client::new(),
+            client: build_http_client(DEFAULT_REQUEST_TIMEOUT),
         })
     }
 
@@ -151,15 +154,15 @@ impl GrokClient {
             model: Model::Grok43, // Default to Grok 4.3 (latest recommended chat model)
             temperature: 0.0,
             max_tokens: None,
-            timeout: None,        // Default: no timeout (uses reqwest's default)
-            max_retries: Some(3), // Default: 3 retries with error feedback
-            base_url: None,       // Default: use official Grok API
+            timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
+            max_retries: Some(3),                   // Default: 3 retries with error feedback
+            base_url: None,                         // Default: use official Grok API
         };
 
         debug!("Grok client created with default configuration");
         Ok(Self {
             config,
-            client: reqwest::Client::new(),
+            client: build_http_client(DEFAULT_REQUEST_TIMEOUT),
         })
     }
 
@@ -734,5 +737,25 @@ impl LLMClient for GrokClient {
 
         debug!(count = models.len(), "Fetched Grok models");
         Ok(models)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::DEFAULT_REQUEST_TIMEOUT;
+
+    #[test]
+    fn default_config_has_default_timeout() {
+        let client = GrokClient::new("test-key").unwrap();
+        assert_eq!(client.config.timeout, Some(DEFAULT_REQUEST_TIMEOUT));
+    }
+
+    #[test]
+    fn explicit_timeout_overrides_default() {
+        let client = GrokClient::new("test-key")
+            .unwrap()
+            .timeout(Duration::from_secs(10));
+        assert_eq!(client.config.timeout, Some(Duration::from_secs(10)));
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -86,9 +86,12 @@ pub(crate) use openai_compatible::{
     convert_openai_compatible_chat_messages,
 };
 #[cfg(feature = "_client")]
+pub use utils::{DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT};
+#[cfg(feature = "_client")]
 pub(crate) use utils::{
-    ResponseFormat, check_response_status, generate_with_retry_with_history, handle_http_error,
-    materialize_with_media_with_retry, parse_validate_and_create_output, prepare_strict_schema,
+    ResponseFormat, build_http_client, check_response_status, generate_with_retry_with_history,
+    handle_http_error, materialize_with_media_with_retry, parse_validate_and_create_output,
+    prepare_strict_schema,
 };
 
 /// Thinking level configuration for models that support extended reasoning.

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -5,9 +5,10 @@ use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::backend::model_macro::define_model_enum;
 use crate::backend::{
-    ChatMessage, GenerateResult, LLMClient, MaterializeInternalOutput, MaterializeResult,
-    ModelInfo, OpenAICompatibleChatCompletionRequest, OpenAICompatibleChatCompletionResponse,
-    ResponseFormat, ThinkingLevel, TokenUsage, ValidationFailureContext, check_response_status,
+    ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient, MaterializeInternalOutput,
+    MaterializeResult, ModelInfo, OpenAICompatibleChatCompletionRequest,
+    OpenAICompatibleChatCompletionResponse, ResponseFormat, ThinkingLevel, TokenUsage,
+    ValidationFailureContext, build_http_client, check_response_status,
     convert_openai_compatible_chat_messages, generate_with_retry_with_history, handle_http_error,
     materialize_with_media_with_retry, parse_validate_and_create_output, prepare_strict_schema,
 };
@@ -112,6 +113,8 @@ pub struct OpenAIConfig {
     pub model: Model,
     pub temperature: f32,
     pub max_tokens: Option<u32>,
+    /// Total timeout for each HTTP request.
+    /// Defaults to [`DEFAULT_REQUEST_TIMEOUT`](crate::DEFAULT_REQUEST_TIMEOUT) (5 minutes).
     pub timeout: Option<Duration>,
     pub max_retries: Option<usize>,
     /// Custom base URL for OpenAI-compatible APIs (e.g., local LLMs, proxy endpoints)
@@ -165,16 +168,16 @@ impl OpenAIClient {
             model: Model::Gpt55, // Default to GPT-5.5 (latest frontier model)
             temperature: 0.0,
             max_tokens: None,
-            timeout: None,        // Default: no timeout (uses reqwest's default)
-            max_retries: Some(3), // Default: 3 retries with error feedback
-            base_url: None,       // Default: use official OpenAI API
+            timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
+            max_retries: Some(3),                   // Default: 3 retries with error feedback
+            base_url: None,                         // Default: use official OpenAI API
             thinking_level: Some(ThinkingLevel::Medium), // GPT-5.5 defaults to medium reasoning
         };
 
         debug!("OpenAI client created with default configuration");
         Ok(Self {
             config,
-            client: reqwest::Client::new(),
+            client: build_http_client(DEFAULT_REQUEST_TIMEOUT),
         })
     }
 
@@ -206,16 +209,16 @@ impl OpenAIClient {
             model: Model::Gpt55, // Default to GPT-5.5 (latest frontier model)
             temperature: 0.0,
             max_tokens: None,
-            timeout: None,        // Default: no timeout (uses reqwest's default)
-            max_retries: Some(3), // Default: 3 retries with error feedback
-            base_url: None,       // Default: use official OpenAI API
+            timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
+            max_retries: Some(3),                   // Default: 3 retries with error feedback
+            base_url: None,                         // Default: use official OpenAI API
             thinking_level: Some(ThinkingLevel::Medium), // GPT-5.5 defaults to medium reasoning
         };
 
         debug!("OpenAI client created with default configuration");
         Ok(Self {
             config,
-            client: reqwest::Client::new(),
+            client: build_http_client(DEFAULT_REQUEST_TIMEOUT),
         })
     }
 
@@ -914,5 +917,25 @@ impl LLMClient for OpenAIClient {
 
         debug!(count = models.len(), "Fetched OpenAI models");
         Ok(models)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::DEFAULT_REQUEST_TIMEOUT;
+
+    #[test]
+    fn default_config_has_default_timeout() {
+        let client = OpenAIClient::new("test-key").unwrap();
+        assert_eq!(client.config.timeout, Some(DEFAULT_REQUEST_TIMEOUT));
+    }
+
+    #[test]
+    fn explicit_timeout_overrides_default() {
+        let client = OpenAIClient::new("test-key")
+            .unwrap()
+            .timeout(Duration::from_secs(10));
+        assert_eq!(client.config.timeout, Some(Duration::from_secs(10)));
     }
 }

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -11,6 +11,60 @@ use std::time::Duration;
 use tokio::time::sleep;
 use tracing::{debug, error, info, trace, warn};
 
+/// Default timeout for an entire HTTP request to an LLM provider (5 minutes).
+///
+/// LLM calls — especially with reasoning models — can legitimately run for
+/// several minutes, but a request should never hang forever (reqwest applies
+/// no timeout by default). All provider clients use this value unless an
+/// explicit timeout is set with the `timeout()` builder method.
+///
+/// # Example
+///
+/// ```
+/// use rstructor::DEFAULT_REQUEST_TIMEOUT;
+/// use std::time::Duration;
+///
+/// assert_eq!(DEFAULT_REQUEST_TIMEOUT, Duration::from_secs(300));
+/// ```
+pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Default timeout for establishing a TCP connection to an LLM provider (30 seconds).
+///
+/// This bounds only the connect phase of a request; the overall request is
+/// bounded by [`DEFAULT_REQUEST_TIMEOUT`] (or the timeout set via the client's
+/// `timeout()` builder method). A healthy provider endpoint accepts connections
+/// well within 30 seconds, so a slower connect almost always indicates a
+/// network problem worth surfacing quickly.
+///
+/// # Example
+///
+/// ```
+/// use rstructor::DEFAULT_CONNECT_TIMEOUT;
+/// use std::time::Duration;
+///
+/// assert_eq!(DEFAULT_CONNECT_TIMEOUT, Duration::from_secs(30));
+/// ```
+pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Build the reqwest client used by all provider clients.
+///
+/// Applies the given total request timeout plus the default connect timeout
+/// ([`DEFAULT_CONNECT_TIMEOUT`]). Falls back to `reqwest::Client::new()` if the
+/// builder fails (which should never happen with these options).
+pub fn build_http_client(timeout: Duration) -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(timeout)
+        .connect_timeout(DEFAULT_CONNECT_TIMEOUT)
+        .build()
+        .unwrap_or_else(|e| {
+            warn!(
+                error = %e,
+                "Failed to build reqwest client with timeout, using default client"
+            );
+            reqwest::Client::new()
+        })
+}
+
 /// Prepare a JSON schema for strict mode by recursively adding required fields
 /// to all object types in the schema.
 ///
@@ -1055,6 +1109,11 @@ where
 }
 
 /// Convert a reqwest error to a RStructorError, handling timeout errors specially.
+///
+/// Request timeouts become [`RStructorError::Timeout`]. Other transport errors
+/// become [`RStructorError::HttpError`]; transient connection failures
+/// (connection refused/reset, DNS errors) are classified as retryable by
+/// [`RStructorError::is_retryable`], while body/decode errors are not.
 pub fn handle_http_error(e: reqwest::Error, provider_name: &str) -> RStructorError {
     error!(error = %e, "HTTP request to {} failed", provider_name);
     if e.is_timeout() {
@@ -1497,8 +1556,13 @@ macro_rules! impl_client_builder_methods {
 
             /// Set the timeout for HTTP requests.
             ///
-            /// This sets the timeout for both the connection and the entire request.
-            /// The timeout applies to each HTTP request made by the client.
+            /// This sets the total timeout for each HTTP request made by the
+            /// client (connection + response). The connect phase additionally
+            /// keeps the default connect timeout of 30 seconds
+            /// ([`DEFAULT_CONNECT_TIMEOUT`](crate::DEFAULT_CONNECT_TIMEOUT)).
+            ///
+            /// If not called, requests use the default timeout of 5 minutes
+            /// ([`DEFAULT_REQUEST_TIMEOUT`](crate::DEFAULT_REQUEST_TIMEOUT)).
             ///
             /// # Arguments
             ///
@@ -1512,17 +1576,8 @@ macro_rules! impl_client_builder_methods {
                 );
                 self.config.timeout = Some(timeout);
 
-                // Rebuild reqwest client with timeout immediately
-                self.client = reqwest::Client::builder()
-                    .timeout(timeout)
-                    .build()
-                    .unwrap_or_else(|e| {
-                        tracing::warn!(
-                            error = %e,
-                            "Failed to build reqwest client with timeout, using default"
-                        );
-                        reqwest::Client::new()
-                    });
+                // Rebuild reqwest client with the new timeout immediately
+                self.client = $crate::backend::utils::build_http_client(timeout);
 
                 self
             }
@@ -3053,6 +3108,80 @@ mod tests {
             RStructorError::Unsupported("nope".into()).retry_delay(),
             None
         );
+    }
+
+    // ===================================================================
+    // HTTP client defaults & transient connection error classification
+    // ===================================================================
+
+    #[tokio::test]
+    async fn connection_refused_error_is_retryable() {
+        // Bind to an ephemeral port, then drop the listener so a connection
+        // to that port is deterministically refused. No external network.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().expect("local_addr");
+        drop(listener);
+
+        let client = build_http_client(Duration::from_secs(5));
+        let err = client
+            .get(format!("http://{addr}/"))
+            .send()
+            .await
+            .expect_err("request to a closed port must fail");
+        assert!(
+            err.is_connect(),
+            "expected a connection error, got: {err:?}"
+        );
+
+        let converted = handle_http_error(err, "Test");
+        assert!(
+            matches!(converted, RStructorError::HttpError(_)),
+            "connection errors should remain HttpError, got: {converted:?}"
+        );
+        assert!(
+            converted.is_retryable(),
+            "connection-refused errors must be retryable"
+        );
+        assert_eq!(converted.retry_delay(), Some(Duration::from_secs(1)));
+    }
+
+    #[tokio::test]
+    async fn request_timeout_applies_and_maps_to_timeout_error() {
+        // A listener that accepts connections (kernel backlog) but never
+        // responds: the TCP handshake completes, no HTTP response arrives,
+        // so the total request timeout configured on the client must fire.
+        // This verifies build_http_client actually applies the timeout.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().expect("local_addr");
+
+        let client = build_http_client(Duration::from_millis(200));
+        let err = client
+            .get(format!("http://{addr}/"))
+            .send()
+            .await
+            .expect_err("request to an unresponsive server must time out");
+        assert!(err.is_timeout(), "expected a timeout error, got: {err:?}");
+
+        let converted = handle_http_error(err, "Test");
+        assert_eq!(converted, RStructorError::Timeout);
+        assert!(converted.is_retryable());
+        drop(listener);
+    }
+
+    #[test]
+    fn non_transient_http_error_is_not_retryable() {
+        // A reqwest error that is neither a timeout nor a connection failure
+        // (here: an invalid URL at build time) must remain non-retryable.
+        let err = reqwest::Client::new()
+            .get("not a valid url")
+            .build()
+            .expect_err("invalid URL must fail to build");
+        assert!(!err.is_connect() && !err.is_timeout());
+
+        let converted = handle_http_error(err, "Test");
+        assert!(matches!(converted, RStructorError::HttpError(_)));
+        assert!(!converted.is_retryable());
+        assert_eq!(converted.retry_delay(), None);
     }
 
     // ===================================================================

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -366,6 +366,11 @@ impl RStructorError {
     /// - Gateway errors (520-524)
     /// - Server errors (500, 502)
     /// - Timeout errors
+    /// - Transient connection failures (connection refused/reset, DNS errors,
+    ///   connect timeouts) — these are just as transient as the 5xx errors above
+    ///
+    /// HTTP errors that occur after a response is received (e.g. body or decode
+    /// errors) remain non-retryable.
     ///
     /// # Example
     ///
@@ -386,6 +391,8 @@ impl RStructorError {
         match self {
             RStructorError::ApiError { kind, .. } => kind.is_retryable(),
             RStructorError::Timeout => true,
+            #[cfg(feature = "_client")]
+            RStructorError::HttpError(e) => e.is_connect() || e.is_timeout(),
             _ => false,
         }
     }
@@ -397,6 +404,10 @@ impl RStructorError {
         match self {
             RStructorError::ApiError { kind, .. } => kind.retry_delay(),
             RStructorError::Timeout => Some(Duration::from_secs(1)),
+            #[cfg(feature = "_client")]
+            RStructorError::HttpError(e) if e.is_connect() || e.is_timeout() => {
+                Some(Duration::from_secs(1))
+            }
             _ => None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,8 @@ pub use backend::{AnyClient, Provider, Request, RequestExt};
 pub use backend::{
     ChatMessage, ChatRole, GenerateResult, MaterializeResult, MediaFile, TokenUsage,
 };
+#[cfg(feature = "_client")]
+pub use backend::{DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT};
 #[cfg(feature = "tools")]
 pub use backend::{DynTool, FnTool, Tool, ToolRunner, Toolbox};
 #[cfg(feature = "streaming")]


### PR DESCRIPTION
## Summary

Fixes two related reliability hazards in all four provider clients (OpenAI, Anthropic, Gemini, Grok):

### 1. No default HTTP timeout — a hung connection blocked `materialize()` forever

Every client defaulted to `timeout: None`, and reqwest's default is **no timeout at all**, so a stalled connection (half-open TCP, unresponsive proxy, blackholed route) would hang a `materialize()`/`generate()` call indefinitely. Worse, the configured timeout only reached the reqwest client when `.timeout()` was explicitly called — the constructors built a bare `reqwest::Client::new()`.

**Now:**
- All clients default to a **5-minute total request timeout** (`DEFAULT_REQUEST_TIMEOUT = 300s` — generous enough for reasoning models) plus a **30-second connect timeout** (`DEFAULT_CONNECT_TIMEOUT = 30s`).
- Both constants are defined once in a shared `build_http_client()` helper (and re-exported as `rstructor::DEFAULT_REQUEST_TIMEOUT` / `rstructor::DEFAULT_CONNECT_TIMEOUT`), used by every constructor so the default actually reaches the reqwest client.
- The `.timeout()` builder still overrides the request timeout, and now also preserves the connect timeout when it rebuilds the client.
- Custom `base_url` paths use the same client and inherit the timeouts; `MockClient` is offline and unaffected.

### 2. Transient connection errors were fatal while 502s retried

`RStructorError::is_retryable()` returned `true` for retryable `ApiError` kinds and `Timeout`, but `false` for everything else. reqwest connection-reset/refused/DNS failures map to `RStructorError::HttpError` and were therefore **never retried** — even though they are exactly as transient as the 5xx errors that DO retry.

**Now:** `is_retryable()` (and `retry_delay()`) return `true` / `Some(1s)` for `HttpError(e)` where `e.is_connect() || e.is_timeout()`. Body/decode errors remain non-retryable. The existing retry loop in `generate_with_retry_with_initial_messages` consults `is_retryable()` and picks these up automatically.

## ⚠️ Behavior change

Requests that previously could run (or hang) indefinitely now **fail with `RStructorError::Timeout` after 5 minutes** (30s if the connection can't even be established). Restore the old behavior with an explicit long `.timeout(...)` if needed. Additionally, transient connection failures are now retried by the built-in retry loop instead of failing fast.

## Tests

- `connection_refused_error_is_retryable` — local bind-then-drop ephemeral port; asserts the converted error stays `HttpError`, classifies retryable, and carries a retry delay (no external network).
- `request_timeout_applies_and_maps_to_timeout_error` — local listener that accepts but never responds; proves the default-built client's timeout actually fires and maps to `RStructorError::Timeout`.
- `non_transient_http_error_is_not_retryable` — a non-connect/non-timeout reqwest error remains non-retryable.
- `default_config_has_default_timeout` / `explicit_timeout_overrides_default` on all four provider clients.
- Full suite: 605 tests pass with `--all-features`; `cargo clippy --all-targets` (default features) and `--all-features` are clean; doctests pass. No new tests hit live APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)