### PR TITLE
fix(derive): nested Vec items, Date name-sniffing, Box recursion guard, generic structs

### DIFF
--- a/rstructor_derive/src/generators/enum_schema.rs
+++ b/rstructor_derive/src/generators/enum_schema.rs
@@ -17,6 +17,7 @@ pub fn generate_enum_schema(
     name: &Ident,
     data_enum: &DataEnum,
     container_attrs: &ContainerAttributes,
+    generics: &syn::Generics,
 ) -> TokenStream {
     // Check if it's a simple enum (no data)
     let all_simple = data_enum.variants.iter().all(|v| v.fields.is_empty());
@@ -24,11 +25,22 @@ pub fn generate_enum_schema(
 
     if all_simple && !has_tag {
         // Generate implementation for simple enum as before
-        generate_simple_enum_schema(name, data_enum, container_attrs)
+        generate_simple_enum_schema(name, data_enum, container_attrs, generics)
     } else {
         // Generate implementation for enum with associated data
-        generate_complex_enum_schema(name, data_enum, container_attrs)
+        generate_complex_enum_schema(name, data_enum, container_attrs, generics)
     }
+}
+
+/// Clone the enum's generics, additionally binding every type parameter by
+/// `SchemaType` — the generated code calls `<T as SchemaType>::schema()` for
+/// type-parameter fields inside variants. Use with `split_for_impl()` to emit
+/// the `impl ... SchemaType for ...` header.
+fn schema_bounded_generics(generics: &syn::Generics) -> syn::Generics {
+    crate::type_utils::generics_with_bounds(
+        generics,
+        &[syn::parse_quote!(::rstructor::schema::SchemaType)],
+    )
 }
 
 /// Generate schema for a simple enum (no associated data)
@@ -36,6 +48,7 @@ fn generate_simple_enum_schema(
     name: &Ident,
     data_enum: &DataEnum,
     container_attrs: &ContainerAttributes,
+    generics: &syn::Generics,
 ) -> TokenStream {
     // Generate implementation for simple enum with serde rename support
     let variant_values: Vec<_> = data_enum
@@ -92,8 +105,11 @@ fn generate_simple_enum_schema(
         quote! {}
     };
 
+    let schema_generics = schema_bounded_generics(generics);
+    let (impl_generics, ty_generics, where_clause) = schema_generics.split_for_impl();
+
     quote! {
-        impl ::rstructor::schema::SchemaType for #name {
+        impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
             fn schema() -> ::rstructor::schema::Schema {
                 // Create array of enum values
                 let enum_values = vec![
@@ -124,10 +140,11 @@ fn generate_complex_enum_schema(
     name: &Ident,
     data_enum: &DataEnum,
     container_attrs: &ContainerAttributes,
+    generics: &syn::Generics,
 ) -> TokenStream {
     // Dispatch to appropriate generator based on serde tagging mode
     if container_attrs.serde_untagged {
-        return generate_untagged_enum_schema(name, data_enum, container_attrs);
+        return generate_untagged_enum_schema(name, data_enum, container_attrs, generics);
     } else if let Some(tag) = &container_attrs.serde_tag {
         if let Some(content) = &container_attrs.serde_content {
             // Adjacent tagging: #[serde(tag = "...", content = "...")]
@@ -135,17 +152,24 @@ fn generate_complex_enum_schema(
                 name,
                 data_enum,
                 container_attrs,
+                generics,
                 tag,
                 content,
             );
         } else {
             // Internal tagging: #[serde(tag = "...")]
-            return generate_internally_tagged_enum_schema(name, data_enum, container_attrs, tag);
+            return generate_internally_tagged_enum_schema(
+                name,
+                data_enum,
+                container_attrs,
+                generics,
+                tag,
+            );
         }
     }
 
     // Default: External tagging (current behavior)
-    generate_externally_tagged_enum_schema(name, data_enum, container_attrs)
+    generate_externally_tagged_enum_schema(name, data_enum, container_attrs, generics)
 }
 
 /// Generate schema for externally tagged enums (default serde behavior)
@@ -154,6 +178,7 @@ fn generate_externally_tagged_enum_schema(
     name: &Ident,
     data_enum: &DataEnum,
     container_attrs: &ContainerAttributes,
+    generics: &syn::Generics,
 ) -> TokenStream {
     // Create variants for oneOf schema
     let mut variant_schemas = Vec::new();
@@ -392,8 +417,11 @@ fn generate_externally_tagged_enum_schema(
     };
 
     // Generate the final schema implementation
+    let schema_generics = schema_bounded_generics(generics);
+    let (impl_generics, ty_generics, where_clause) = schema_generics.split_for_impl();
+
     quote! {
-        impl ::rstructor::schema::SchemaType for #name {
+        impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
             fn schema() -> ::rstructor::schema::Schema {
                 // Create oneOf schema for enum variants
                 let variant_schemas = vec![
@@ -698,6 +726,7 @@ fn generate_internally_tagged_enum_schema(
     name: &Ident,
     data_enum: &DataEnum,
     container_attrs: &ContainerAttributes,
+    generics: &syn::Generics,
     tag_name: &str,
 ) -> TokenStream {
     let mut variant_schemas = Vec::new();
@@ -921,8 +950,11 @@ fn generate_internally_tagged_enum_schema(
     // Container attributes
     let container_setter = generate_container_setters(container_attrs);
 
+    let schema_generics = schema_bounded_generics(generics);
+    let (impl_generics, ty_generics, where_clause) = schema_generics.split_for_impl();
+
     quote! {
-        impl ::rstructor::schema::SchemaType for #name {
+        impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
             fn schema() -> ::rstructor::schema::Schema {
                 let variant_schemas = vec![
                     #(#variant_schemas),*
@@ -951,6 +983,7 @@ fn generate_adjacently_tagged_enum_schema(
     name: &Ident,
     data_enum: &DataEnum,
     container_attrs: &ContainerAttributes,
+    generics: &syn::Generics,
     tag_name: &str,
     content_name: &str,
 ) -> TokenStream {
@@ -1212,8 +1245,11 @@ fn generate_adjacently_tagged_enum_schema(
     // Container attributes
     let container_setter = generate_container_setters(container_attrs);
 
+    let schema_generics = schema_bounded_generics(generics);
+    let (impl_generics, ty_generics, where_clause) = schema_generics.split_for_impl();
+
     quote! {
-        impl ::rstructor::schema::SchemaType for #name {
+        impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
             fn schema() -> ::rstructor::schema::Schema {
                 let variant_schemas = vec![
                     #(#variant_schemas),*
@@ -1242,6 +1278,7 @@ fn generate_untagged_enum_schema(
     name: &Ident,
     data_enum: &DataEnum,
     container_attrs: &ContainerAttributes,
+    generics: &syn::Generics,
 ) -> TokenStream {
     let mut variant_schemas = Vec::new();
 
@@ -1369,8 +1406,11 @@ fn generate_untagged_enum_schema(
     // Container attributes
     let container_setter = generate_container_setters(container_attrs);
 
+    let schema_generics = schema_bounded_generics(generics);
+    let (impl_generics, ty_generics, where_clause) = schema_generics.split_for_impl();
+
     quote! {
-        impl ::rstructor::schema::SchemaType for #name {
+        impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
             fn schema() -> ::rstructor::schema::Schema {
                 let variant_schemas = vec![
                     #(#variant_schemas),*

--- a/rstructor_derive/src/generators/struct_schema.rs
+++ b/rstructor_derive/src/generators/struct_schema.rs
@@ -210,7 +210,17 @@ pub fn generate_struct_schema(
                     };
                     if let Some(inner_ty) = get_box_inner_type(actual_type) {
                         let inner_schema_type = get_schema_type_from_rust_type(inner_ty);
-                        if inner_schema_type == "object" {
+                        if is_self_reference(inner_ty, &struct_name_str) {
+                            // Self-referential type (e.g. Option<Box<Self>>): use $ref
+                            // to prevent infinite recursion at schema() time, mirroring
+                            // the guard in the array branch. The root schema places the
+                            // struct's definition under $defs in this case.
+                            quote! {
+                                let mut props = ::serde_json::Map::new();
+                                props.insert("$ref".to_string(),
+                                    ::serde_json::Value::String(format!("#/$defs/{}", #struct_name_str)));
+                            }
+                        } else if inner_schema_type == "object" {
                             // Inner type is a complex type, use its schema
                             quote! {
                                 let nested_schema = <#inner_ty as ::rstructor::schema::SchemaType>::schema();

--- a/rstructor_derive/src/generators/struct_schema.rs
+++ b/rstructor_derive/src/generators/struct_schema.rs
@@ -78,35 +78,35 @@ pub fn generate_struct_schema(
                 // Create field property
                 // IMPORTANT: Default to treating unknown types as structs (objects)
                 // Structs are far more common than enums, and this is the safest default
-                let field_prop = if is_datetime_type {
-                    // For date-time types (DateTime, NaiveDateTime)
+                let field_prop = if is_datetime_type || is_date_only_type || is_uuid_type {
+                    // Well-known library type *names* (chrono's DateTime/NaiveDate/...,
+                    // uuid's Uuid). These names are only a heuristic: a user-defined
+                    // `struct Date` deriving Instructor must keep its real schema. So
+                    // probe at compile time (via autoref specialization): if the field
+                    // type implements SchemaType, its own schema wins; otherwise fall
+                    // back to the sniffed string/format schema.
+                    let actual_type = if is_optional {
+                        get_option_inner_type(&field.ty)
+                    } else {
+                        &field.ty
+                    };
+                    let fallback = sniffed_fallback_schema(is_datetime_type, is_date_only_type);
                     quote! {
-                        // Create property for this date-time field
-                        let mut props = ::serde_json::Map::new();
-                        props.insert("type".to_string(), ::serde_json::Value::String("string".to_string()));
-                        props.insert("format".to_string(), ::serde_json::Value::String("date-time".to_string()));
-                        props.insert("description".to_string(),
-                                    ::serde_json::Value::String("ISO-8601 formatted date and time".to_string()));
-                    }
-                } else if is_date_only_type {
-                    // For date-only types (NaiveDate, Date)
-                    quote! {
-                        // Create property for this date field
-                        let mut props = ::serde_json::Map::new();
-                        props.insert("type".to_string(), ::serde_json::Value::String("string".to_string()));
-                        props.insert("format".to_string(), ::serde_json::Value::String("date".to_string()));
-                        props.insert("description".to_string(),
-                                    ::serde_json::Value::String("ISO-8601 formatted date (YYYY-MM-DD)".to_string()));
-                    }
-                } else if is_uuid_type {
-                    // For UUID types
-                    quote! {
-                        // Create property for this UUID field
-                        let mut props = ::serde_json::Map::new();
-                        props.insert("type".to_string(), ::serde_json::Value::String("string".to_string()));
-                        props.insert("format".to_string(), ::serde_json::Value::String("uuid".to_string()));
-                        props.insert("description".to_string(),
-                                    ::serde_json::Value::String("UUID identifier string".to_string()));
+                        // Create property for this well-known (date/uuid) field,
+                        // preferring the type's own SchemaType impl when present
+                        let probed = {
+                            #[allow(unused_imports)]
+                            use ::rstructor::schema::__private::SchemaProbeFallback as _;
+                            ::rstructor::schema::__private::SchemaProbe::<#actual_type>::new()
+                                .rstructor_schema_or(#fallback)
+                        };
+                        let mut props = if let ::serde_json::Value::Object(m) = probed {
+                            m
+                        } else {
+                            let mut m = ::serde_json::Map::new();
+                            m.insert("type".to_string(), ::serde_json::Value::String("object".to_string()));
+                            m
+                        };
                     }
                 } else if is_array_type(&field.ty)
                     || (is_optional && is_array_type(get_option_inner_type(&field.ty)))
@@ -484,6 +484,37 @@ pub fn generate_struct_schema(
     }
 }
 
+/// Generate an expression evaluating to the sniffed fallback schema for a
+/// well-known library type name: date-time (`DateTime`/`NaiveDateTime`), date
+/// (`NaiveDate`/`Date`), or uuid (`Uuid`).
+fn sniffed_fallback_schema(is_datetime: bool, is_date_only: bool) -> TokenStream {
+    if is_datetime {
+        quote! {
+            ::serde_json::json!({
+                "type": "string",
+                "format": "date-time",
+                "description": "ISO-8601 formatted date and time"
+            })
+        }
+    } else if is_date_only {
+        quote! {
+            ::serde_json::json!({
+                "type": "string",
+                "format": "date",
+                "description": "ISO-8601 formatted date (YYYY-MM-DD)"
+            })
+        }
+    } else {
+        quote! {
+            ::serde_json::json!({
+                "type": "string",
+                "format": "uuid",
+                "description": "UUID identifier string"
+            })
+        }
+    }
+}
+
 /// Generate an expression evaluating to the JSON Schema `items` value for an
 /// array whose element type is `inner_type`.
 ///
@@ -500,31 +531,18 @@ fn generate_array_items_schema(inner_type: &Type, struct_name_str: &str) -> Toke
     let is_date_only = matches!(inner_type_name.as_deref(), Some("NaiveDate") | Some("Date"));
     let is_uuid = matches!(inner_type_name.as_deref(), Some("Uuid"));
 
-    if is_datetime {
+    if is_datetime || is_date_only || is_uuid {
+        // Name match is only a heuristic: prefer the element type's own
+        // SchemaType impl (user-defined `struct Date`), falling back to the
+        // sniffed string/format schema (chrono/uuid types).
+        let fallback = sniffed_fallback_schema(is_datetime, is_date_only);
         return quote! {
-            ::serde_json::json!({
-                "type": "string",
-                "format": "date-time",
-                "description": "ISO-8601 formatted date and time"
-            })
-        };
-    }
-    if is_date_only {
-        return quote! {
-            ::serde_json::json!({
-                "type": "string",
-                "format": "date",
-                "description": "ISO-8601 formatted date (YYYY-MM-DD)"
-            })
-        };
-    }
-    if is_uuid {
-        return quote! {
-            ::serde_json::json!({
-                "type": "string",
-                "format": "uuid",
-                "description": "UUID identifier string"
-            })
+            {
+                #[allow(unused_imports)]
+                use ::rstructor::schema::__private::SchemaProbeFallback as _;
+                ::rstructor::schema::__private::SchemaProbe::<#inner_type>::new()
+                    .rstructor_schema_or(#fallback)
+            }
         };
     }
 

--- a/rstructor_derive/src/generators/struct_schema.rs
+++ b/rstructor_derive/src/generators/struct_schema.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{DataStruct, Fields, Ident};
+use syn::{DataStruct, Fields, Ident, Type};
 
 use crate::container_attrs::ContainerAttributes;
 use crate::parsers::field_parser::parse_field_attributes;
@@ -119,113 +119,16 @@ pub fn generate_struct_schema(
                             &field.ty
                         };
                     if let Some(inner_type) = get_array_inner_type(actual_array_type) {
-                        // Get the inner schema type
-                        let inner_schema_type = get_schema_type_from_rust_type(inner_type);
+                        // Generate the items schema, recursing into nested
+                        // collections so e.g. Vec<Vec<i32>> keeps its inner items
+                        let items_expr = generate_array_items_schema(inner_type, &struct_name_str);
+                        quote! {
+                            // Create property for this array field
+                            let mut props = ::serde_json::Map::new();
+                            props.insert("type".to_string(), ::serde_json::Value::String(#schema_type.to_string()));
 
-                        // Extract inner type name for well-known library types only
-                        let inner_type_name = get_type_name(inner_type);
-
-                        // Check for well-known library types by exact match only
-                        let is_datetime = matches!(
-                            inner_type_name.as_deref(),
-                            Some("DateTime") | Some("NaiveDateTime")
-                        );
-                        let is_date_only =
-                            matches!(inner_type_name.as_deref(), Some("NaiveDate") | Some("Date"));
-                        let is_uuid = matches!(inner_type_name.as_deref(), Some("Uuid"));
-
-                        // Generate items schema
-                        if is_datetime {
-                            // Handle array of date-times
-                            quote! {
-                                // Create property for this array field with date-time items
-                                let mut props = ::serde_json::Map::new();
-                                props.insert("type".to_string(), ::serde_json::Value::String(#schema_type.to_string()));
-
-                                // Add items schema for date-times
-                                let mut items_schema = ::serde_json::Map::new();
-                                items_schema.insert("type".to_string(), ::serde_json::Value::String("string".to_string()));
-                                items_schema.insert("format".to_string(), ::serde_json::Value::String("date-time".to_string()));
-                                items_schema.insert("description".to_string(),
-                                    ::serde_json::Value::String("ISO-8601 formatted date and time".to_string()));
-
-                                props.insert("items".to_string(), ::serde_json::Value::Object(items_schema));
-                            }
-                        } else if is_date_only {
-                            // Handle array of date-only values
-                            quote! {
-                                // Create property for this array field with date items
-                                let mut props = ::serde_json::Map::new();
-                                props.insert("type".to_string(), ::serde_json::Value::String(#schema_type.to_string()));
-
-                                // Add items schema for dates
-                                let mut items_schema = ::serde_json::Map::new();
-                                items_schema.insert("type".to_string(), ::serde_json::Value::String("string".to_string()));
-                                items_schema.insert("format".to_string(), ::serde_json::Value::String("date".to_string()));
-                                items_schema.insert("description".to_string(),
-                                    ::serde_json::Value::String("ISO-8601 formatted date (YYYY-MM-DD)".to_string()));
-
-                                props.insert("items".to_string(), ::serde_json::Value::Object(items_schema));
-                            }
-                        } else if is_uuid {
-                            // Handle array of UUIDs
-                            quote! {
-                                // Create property for this array field with UUID items
-                                let mut props = ::serde_json::Map::new();
-                                props.insert("type".to_string(), ::serde_json::Value::String(#schema_type.to_string()));
-
-                                // Add items schema for UUIDs
-                                let mut items_schema = ::serde_json::Map::new();
-                                items_schema.insert("type".to_string(), ::serde_json::Value::String("string".to_string()));
-                                items_schema.insert("format".to_string(), ::serde_json::Value::String("uuid".to_string()));
-                                items_schema.insert("description".to_string(),
-                                    ::serde_json::Value::String("UUID identifier string".to_string()));
-
-                                props.insert("items".to_string(), ::serde_json::Value::Object(items_schema));
-                            }
-                        } else if inner_schema_type == "object" {
-                            // Check if this is a self-reference (recursive type)
-                            let struct_name_str = name.to_string();
-                            if is_self_reference(inner_type, &struct_name_str) {
-                                // For self-referential types, use $ref to prevent infinite recursion
-                                quote! {
-                                    // Create property for this array field with recursive reference
-                                    let mut props = ::serde_json::Map::new();
-                                    props.insert("type".to_string(), ::serde_json::Value::String(#schema_type.to_string()));
-
-                                    // Use $ref for recursive type
-                                    let mut items_schema = ::serde_json::Map::new();
-                                    items_schema.insert("$ref".to_string(), ::serde_json::Value::String(format!("#/$defs/{}", #struct_name_str)));
-                                    props.insert("items".to_string(), ::serde_json::Value::Object(items_schema));
-                                }
-                            } else {
-                                // For arrays of nested structs, embed the inner type's schema directly
-                                // This requires the inner type to implement SchemaType
-                                quote! {
-                                    // Create property for this array field with nested struct items
-                                    let mut props = ::serde_json::Map::new();
-                                    props.insert("type".to_string(), ::serde_json::Value::String(#schema_type.to_string()));
-
-                                    // Get the inner type's schema directly
-                                    // This embeds the full schema with properties at compile time
-                                    let inner_schema = <#inner_type as ::rstructor::schema::SchemaType>::schema();
-                                    let items_schema = inner_schema.to_json();
-
-                                    props.insert("items".to_string(), items_schema);
-                                }
-                            }
-                        } else {
-                            // Standard handling for primitive types
-                            quote! {
-                                // Create property for this array field
-                                let mut props = ::serde_json::Map::new();
-                                props.insert("type".to_string(), ::serde_json::Value::String(#schema_type.to_string()));
-
-                                // Add items schema
-                                let mut items_schema = ::serde_json::Map::new();
-                                items_schema.insert("type".to_string(), ::serde_json::Value::String(#inner_schema_type.to_string()));
-                                props.insert("items".to_string(), ::serde_json::Value::Object(items_schema));
-                            }
+                            // Add items schema (recursive for nested collections)
+                            props.insert("items".to_string(), #items_expr);
                         }
                     } else {
                         // Fallback for array without detectable item type
@@ -577,6 +480,88 @@ pub fn generate_struct_schema(
                     Some(stringify!(#name).to_string())
                 }
             }
+        }
+    }
+}
+
+/// Generate an expression evaluating to the JSON Schema `items` value for an
+/// array whose element type is `inner_type`.
+///
+/// Recurses into nested collections (`Vec<Vec<i32>>`, `Vec<HashSet<String>>`,
+/// ...) so every nesting level carries its own `items` schema, and emits a
+/// `$ref` for self-referential element types to prevent infinite recursion.
+fn generate_array_items_schema(inner_type: &Type, struct_name_str: &str) -> TokenStream {
+    // Check for well-known library types by exact match only (no heuristics)
+    let inner_type_name = get_type_name(inner_type);
+    let is_datetime = matches!(
+        inner_type_name.as_deref(),
+        Some("DateTime") | Some("NaiveDateTime")
+    );
+    let is_date_only = matches!(inner_type_name.as_deref(), Some("NaiveDate") | Some("Date"));
+    let is_uuid = matches!(inner_type_name.as_deref(), Some("Uuid"));
+
+    if is_datetime {
+        return quote! {
+            ::serde_json::json!({
+                "type": "string",
+                "format": "date-time",
+                "description": "ISO-8601 formatted date and time"
+            })
+        };
+    }
+    if is_date_only {
+        return quote! {
+            ::serde_json::json!({
+                "type": "string",
+                "format": "date",
+                "description": "ISO-8601 formatted date (YYYY-MM-DD)"
+            })
+        };
+    }
+    if is_uuid {
+        return quote! {
+            ::serde_json::json!({
+                "type": "string",
+                "format": "uuid",
+                "description": "UUID identifier string"
+            })
+        };
+    }
+
+    // Nested collections: recurse so the inner `items` schema is preserved
+    if is_array_type(inner_type)
+        && let Some(next_inner) = get_array_inner_type(inner_type)
+    {
+        let nested_items = generate_array_items_schema(next_inner, struct_name_str);
+        return quote! {
+            {
+                let mut items_schema = ::serde_json::Map::new();
+                items_schema.insert("type".to_string(), ::serde_json::Value::String("array".to_string()));
+                items_schema.insert("items".to_string(), #nested_items);
+                ::serde_json::Value::Object(items_schema)
+            }
+        };
+    }
+
+    // Self-referential element types use $ref to prevent infinite recursion
+    if is_self_reference(inner_type, struct_name_str) {
+        return quote! {
+            ::serde_json::json!({ "$ref": format!("#/$defs/{}", #struct_name_str) })
+        };
+    }
+
+    let inner_schema_type = get_schema_type_from_rust_type(inner_type);
+    if inner_schema_type == "object" {
+        // For nested structs (and Box/HashMap wrappers), embed the inner
+        // type's schema directly. This requires the inner type to implement
+        // SchemaType.
+        quote! {
+            <#inner_type as ::rstructor::schema::SchemaType>::schema().to_json()
+        }
+    } else {
+        // Standard handling for primitive types
+        quote! {
+            ::serde_json::json!({ "type": #inner_schema_type })
         }
     }
 }

--- a/rstructor_derive/src/generators/struct_schema.rs
+++ b/rstructor_derive/src/generators/struct_schema.rs
@@ -5,9 +5,10 @@ use syn::{DataStruct, Fields, Ident, Type};
 use crate::container_attrs::ContainerAttributes;
 use crate::parsers::field_parser::parse_field_attributes;
 use crate::type_utils::{
-    get_array_inner_type, get_box_inner_type, get_map_types, get_option_inner_type,
-    get_schema_type_from_rust_type, get_tuple_element_types, get_type_name, is_array_type,
-    is_box_type, is_json_value_type, is_map_type, is_option_type, is_self_reference, is_tuple_type,
+    generics_with_bounds, get_array_inner_type, get_box_inner_type, get_map_types,
+    get_option_inner_type, get_schema_type_from_rust_type, get_tuple_element_types, get_type_name,
+    is_array_type, is_box_type, is_json_value_type, is_map_type, is_option_type, is_self_reference,
+    is_tuple_type,
 };
 
 /// Generate the schema implementation for a struct
@@ -15,6 +16,7 @@ pub fn generate_struct_schema(
     name: &Ident,
     data_struct: &DataStruct,
     container_attrs: &ContainerAttributes,
+    generics: &syn::Generics,
 ) -> TokenStream {
     let mut property_setters = Vec::new();
     let mut required_setters = Vec::new();
@@ -421,10 +423,19 @@ pub fn generate_struct_schema(
         quote! {}
     };
 
+    // Emit a generics-aware impl: every type parameter is additionally bound
+    // by SchemaType, since the generated code calls <T as SchemaType>::schema()
+    // for type-parameter fields.
+    let schema_generics = generics_with_bounds(
+        generics,
+        &[syn::parse_quote!(::rstructor::schema::SchemaType)],
+    );
+    let (impl_generics, ty_generics, where_clause) = schema_generics.split_for_impl();
+
     // Generate implementation with $defs support for recursive types
     if has_self_reference {
         quote! {
-            impl ::rstructor::schema::SchemaType for #name {
+            impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
                 fn schema() -> ::rstructor::schema::Schema {
                     // Create base schema object (properties will be added to $defs)
                     let mut schema_obj = ::serde_json::json!({
@@ -463,7 +474,7 @@ pub fn generate_struct_schema(
         }
     } else {
         quote! {
-            impl ::rstructor::schema::SchemaType for #name {
+            impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
                 fn schema() -> ::rstructor::schema::Schema {
                     // Create base schema object
                     let mut schema_obj = ::serde_json::json!({
@@ -532,6 +543,31 @@ fn sniffed_fallback_schema(is_datetime: bool, is_date_only: bool) -> TokenStream
 /// ...) so every nesting level carries its own `items` schema, and emits a
 /// `$ref` for self-referential element types to prevent infinite recursion.
 fn generate_array_items_schema(inner_type: &Type, struct_name_str: &str) -> TokenStream {
+    // Nested collections: recurse so the inner `items` schema is preserved
+    if is_array_type(inner_type)
+        && let Some(next_inner) = get_array_inner_type(inner_type)
+    {
+        let nested_items = generate_array_items_schema(next_inner, struct_name_str);
+        return quote! {
+            {
+                let mut items_schema = ::serde_json::Map::new();
+                items_schema.insert("type".to_string(), ::serde_json::Value::String("array".to_string()));
+                items_schema.insert("items".to_string(), #nested_items);
+                ::serde_json::Value::Object(items_schema)
+            }
+        };
+    }
+
+    // Self-referential element types use $ref to prevent infinite recursion.
+    // This must run before the well-known-name sniff below: a recursive
+    // struct that happens to be named `Date` must still get a $ref, not a
+    // probe that would call its own schema() and never terminate.
+    if is_self_reference(inner_type, struct_name_str) {
+        return quote! {
+            ::serde_json::json!({ "$ref": format!("#/$defs/{}", #struct_name_str) })
+        };
+    }
+
     // Check for well-known library types by exact match only (no heuristics)
     let inner_type_name = get_type_name(inner_type);
     let is_datetime = matches!(
@@ -553,28 +589,6 @@ fn generate_array_items_schema(inner_type: &Type, struct_name_str: &str) -> Toke
                 ::rstructor::schema::__private::SchemaProbe::<#inner_type>::new()
                     .rstructor_schema_or(#fallback)
             }
-        };
-    }
-
-    // Nested collections: recurse so the inner `items` schema is preserved
-    if is_array_type(inner_type)
-        && let Some(next_inner) = get_array_inner_type(inner_type)
-    {
-        let nested_items = generate_array_items_schema(next_inner, struct_name_str);
-        return quote! {
-            {
-                let mut items_schema = ::serde_json::Map::new();
-                items_schema.insert("type".to_string(), ::serde_json::Value::String("array".to_string()));
-                items_schema.insert("items".to_string(), #nested_items);
-                ::serde_json::Value::Object(items_schema)
-            }
-        };
-    }
-
-    // Self-referential element types use $ref to prevent infinite recursion
-    if is_self_reference(inner_type, struct_name_str) {
-        return quote! {
-            ::serde_json::json!({ "$ref": format!("#/$defs/{}", #struct_name_str) })
         };
     }
 

--- a/rstructor_derive/src/lib.rs
+++ b/rstructor_derive/src/lib.rs
@@ -158,10 +158,10 @@ pub fn derive_instructor(input: TokenStream) -> TokenStream {
     // Generate the schema implementation
     let schema_impl = match &input.data {
         Data::Struct(data_struct) => {
-            generators::generate_struct_schema(name, data_struct, &container_attrs)
+            generators::generate_struct_schema(name, data_struct, &container_attrs, &input.generics)
         }
         Data::Enum(data_enum) => {
-            generators::generate_enum_schema(name, data_enum, &container_attrs)
+            generators::generate_enum_schema(name, data_enum, &container_attrs, &input.generics)
         }
         _ => panic!("Instructor can only be derived for structs and enums"),
     };
@@ -180,8 +180,21 @@ pub fn derive_instructor(input: TokenStream) -> TokenStream {
     } else {
         quote::quote! {}
     };
+    // `Instructor` requires `SchemaType + Serialize + DeserializeOwned` as
+    // supertraits, so for generic types every type parameter must be bound by
+    // those traits for the impl to typecheck (mirroring serde's own derive,
+    // which bounds type parameters by `Serialize`/`Deserialize`).
+    let instructor_generics = type_utils::generics_with_bounds(
+        &input.generics,
+        &[
+            syn::parse_quote!(::rstructor::schema::SchemaType),
+            syn::parse_quote!(::serde::Serialize),
+            syn::parse_quote!(::serde::de::DeserializeOwned),
+        ],
+    );
+    let (impl_generics, ty_generics, where_clause) = instructor_generics.split_for_impl();
     let instructor_impl = quote::quote! {
-        impl ::rstructor::model::Instructor for #name {
+        impl #impl_generics ::rstructor::model::Instructor for #name #ty_generics #where_clause {
             fn validate(&self) -> ::rstructor::error::Result<()> {
                 #[allow(unused_imports)]
                 use ::rstructor::model::__private::ProbeFallback as _;

--- a/rstructor_derive/src/type_utils.rs
+++ b/rstructor_derive/src/type_utils.rs
@@ -376,3 +376,25 @@ pub fn get_core_type_name(ty: &Type) -> Option<String> {
 pub fn is_self_reference(ty: &Type, struct_name: &str) -> bool {
     get_core_type_name(ty).is_some_and(|name| name == struct_name)
 }
+
+/// Clone `generics`, adding the given trait bounds to every type parameter.
+///
+/// Used when emitting `impl` blocks for generic types: the generated schema
+/// code calls `<T as SchemaType>::schema()` for type-parameter fields, so the
+/// `SchemaType` impl needs every type parameter bound by `SchemaType` (and
+/// the `Instructor` impl additionally by serde's traits, which `Instructor`
+/// requires as supertraits).
+pub fn generics_with_bounds(
+    generics: &syn::Generics,
+    bounds: &[syn::TypeParamBound],
+) -> syn::Generics {
+    let mut generics = generics.clone();
+    for param in generics.params.iter_mut() {
+        if let syn::GenericParam::Type(type_param) = param {
+            for bound in bounds {
+                type_param.bounds.push(bound.clone());
+            }
+        }
+    }
+    generics
+}

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -214,5 +214,58 @@ pub trait SchemaType {
     }
 }
 
+/// Internal helpers used by `#[derive(Instructor)]`. Not part of the public API
+/// and exempt from semver guarantees.
+#[doc(hidden)]
+pub mod __private {
+    use super::SchemaType;
+    use serde_json::Value;
+    use std::marker::PhantomData;
+
+    /// Autoref-specialization probe that lets generated code use a field type's
+    /// own [`SchemaType`] schema **iff** the type implements it, and otherwise
+    /// fall back to a name-based well-known schema (e.g. `{"type": "string",
+    /// "format": "date"}` for `chrono::NaiveDate`) — without the derive macro
+    /// having to know which crate a type named `Date` comes from.
+    ///
+    /// `#[derive(Instructor)]` emits
+    /// `SchemaProbe::<FieldType>::new().rstructor_schema_or(fallback)` for
+    /// fields whose type *name* matches a well-known library type (`Date`,
+    /// `DateTime`, `NaiveDate`, `NaiveDateTime`, `Uuid`). When the field's
+    /// type implements `SchemaType` (e.g. a user-defined `struct Date` that
+    /// derives `Instructor`), the inherent method below is selected (inherent
+    /// methods take priority over trait methods) and the type's real schema
+    /// wins; otherwise method resolution falls back to
+    /// [`SchemaProbeFallback`], which returns the sniffed fallback schema.
+    pub struct SchemaProbe<T: ?Sized>(PhantomData<T>);
+
+    impl<T: ?Sized> SchemaProbe<T> {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            SchemaProbe(PhantomData)
+        }
+    }
+
+    /// Fallback for field types that do not implement [`SchemaType`]
+    /// (e.g. `chrono::NaiveDate`, `uuid::Uuid`).
+    pub trait SchemaProbeFallback {
+        fn rstructor_schema_or(&self, fallback: Value) -> Value;
+    }
+
+    impl<T: ?Sized> SchemaProbeFallback for SchemaProbe<T> {
+        fn rstructor_schema_or(&self, fallback: Value) -> Value {
+            fallback
+        }
+    }
+
+    impl<T: SchemaType + ?Sized> SchemaProbe<T> {
+        /// Return the wrapped type's real schema (selected over the trait
+        /// method when `T: SchemaType`).
+        pub fn rstructor_schema_or(&self, _fallback: Value) -> Value {
+            T::schema().to_json()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests;

--- a/tests/derive_schema_offline_tests.rs
+++ b/tests/derive_schema_offline_tests.rs
@@ -1008,3 +1008,67 @@ fn chrono_date_array_items_still_sniffed_to_string_format() {
     assert_eq!(past_times["items"]["type"], "string");
     assert_eq!(past_times["items"]["format"], "date-time");
 }
+
+// ============================================================================
+// Recursive types through Box: Option<Box<Self>>, Vec<Box<Self>>
+// ============================================================================
+
+/// Singly-linked list node: recursion through Option<Box<Self>>.
+/// Before the Box-branch $ref guard, calling schema() overflowed the stack.
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct LinkedNode {
+    #[llm(description = "Value held by this node")]
+    value: i32,
+    #[llm(description = "Next node in the list, if any")]
+    next: Option<Box<LinkedNode>>,
+}
+
+#[test]
+fn option_box_self_recursion_terminates_with_ref() {
+    // Must terminate (no stack overflow) ...
+    let schema = LinkedNode::schema().to_json();
+    // ... and use the $defs/$ref indirection like the array guard does.
+    assert_eq!(schema["$ref"], "#/$defs/LinkedNode");
+    let def = &schema["$defs"]["LinkedNode"];
+    assert!(def.is_object(), "$defs.LinkedNode must exist");
+    assert_eq!(
+        def["properties"]["next"]["$ref"], "#/$defs/LinkedNode",
+        "Box<Self> field must be emitted as a $ref, got: {:?}",
+        def["properties"]["next"]
+    );
+    assert_eq!(def["properties"]["value"]["type"], "integer");
+    // Option<Box<Self>> must not be required.
+    let required: Vec<&str> = def["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(required.contains(&"value"));
+    assert!(!required.contains(&"next"));
+}
+
+#[test]
+fn option_box_self_recursion_schema_name() {
+    assert_eq!(LinkedNode::schema_name(), Some("LinkedNode".to_string()));
+}
+
+/// Tree node: recursion through Vec<Box<Self>> (array guard with boxed items).
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct BoxedTreeNode {
+    #[llm(description = "Node label")]
+    label: String,
+    #[llm(description = "Child nodes")]
+    #[allow(clippy::vec_box)]
+    children: Vec<Box<BoxedTreeNode>>,
+}
+
+#[test]
+fn vec_box_self_recursion_terminates_with_ref() {
+    let schema = BoxedTreeNode::schema().to_json();
+    assert_eq!(schema["$ref"], "#/$defs/BoxedTreeNode");
+    let def = &schema["$defs"]["BoxedTreeNode"];
+    let children = &def["properties"]["children"];
+    assert_eq!(children["type"], "array");
+    assert_eq!(children["items"]["$ref"], "#/$defs/BoxedTreeNode");
+}

--- a/tests/derive_schema_offline_tests.rs
+++ b/tests/derive_schema_offline_tests.rs
@@ -788,3 +788,91 @@ fn serde_json_value_field_is_any_json() {
     // The neighbor field is unaffected.
     assert_eq!(schema["properties"]["name"]["type"], "string");
 }
+
+// ============================================================================
+// Nested collections: Vec<Vec<T>>, Vec<Vec<Vec<T>>>, Vec<HashSet<T>>
+// ============================================================================
+
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct NestedCollections {
+    #[llm(description = "A matrix of integers")]
+    matrix: Vec<Vec<i32>>,
+    #[llm(description = "A cube of strings")]
+    cube: Vec<Vec<Vec<String>>>,
+    #[llm(description = "A list of unique-tag sets")]
+    tag_sets: Vec<std::collections::HashSet<String>>,
+    #[llm(description = "Optional matrix")]
+    opt_matrix: Option<Vec<Vec<f64>>>,
+}
+
+#[test]
+fn nested_vec_field_keeps_inner_items() {
+    let schema = NestedCollections::schema().to_json();
+
+    // Vec<Vec<i32>>: every nesting level carries its own items schema.
+    let matrix = &schema["properties"]["matrix"];
+    assert_eq!(matrix["type"], "array");
+    assert_eq!(matrix["items"]["type"], "array");
+    assert_eq!(
+        matrix["items"]["items"]["type"], "integer",
+        "Vec<Vec<i32>> must recurse: items.items.type == integer, got: {matrix:?}"
+    );
+}
+
+#[test]
+fn triply_nested_vec_field_keeps_all_items() {
+    let schema = NestedCollections::schema().to_json();
+    let cube = &schema["properties"]["cube"];
+    assert_eq!(cube["type"], "array");
+    assert_eq!(cube["items"]["type"], "array");
+    assert_eq!(cube["items"]["items"]["type"], "array");
+    assert_eq!(
+        cube["items"]["items"]["items"]["type"], "string",
+        "Vec<Vec<Vec<String>>> must recurse three levels, got: {cube:?}"
+    );
+}
+
+#[test]
+fn vec_of_hashset_field_keeps_inner_items() {
+    let schema = NestedCollections::schema().to_json();
+    let tag_sets = &schema["properties"]["tag_sets"];
+    assert_eq!(tag_sets["type"], "array");
+    assert_eq!(tag_sets["items"]["type"], "array");
+    assert_eq!(tag_sets["items"]["items"]["type"], "string");
+}
+
+#[test]
+fn optional_nested_vec_field_keeps_inner_items() {
+    let schema = NestedCollections::schema().to_json();
+    let opt_matrix = &schema["properties"]["opt_matrix"];
+    assert_eq!(opt_matrix["type"], "array");
+    assert_eq!(opt_matrix["items"]["type"], "array");
+    assert_eq!(opt_matrix["items"]["items"]["type"], "number");
+    let required: Vec<&str> = schema["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(!required.contains(&"opt_matrix"));
+}
+
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct NestedStructMatrix {
+    #[llm(description = "Grid of addresses")]
+    grid: Vec<Vec<Address>>,
+}
+
+#[test]
+fn nested_vec_of_structs_embeds_inner_schema() {
+    let schema = NestedStructMatrix::schema().to_json();
+    let grid = &schema["properties"]["grid"];
+    assert_eq!(grid["type"], "array");
+    assert_eq!(grid["items"]["type"], "array");
+    // Innermost items embed the struct's full object schema.
+    assert_eq!(grid["items"]["items"]["type"], "object");
+    assert_eq!(
+        grid["items"]["items"]["properties"]["street"]["type"],
+        "string"
+    );
+}

--- a/tests/derive_schema_offline_tests.rs
+++ b/tests/derive_schema_offline_tests.rs
@@ -1072,3 +1072,128 @@ fn vec_box_self_recursion_terminates_with_ref() {
     assert_eq!(children["type"], "array");
     assert_eq!(children["items"]["$ref"], "#/$defs/BoxedTreeNode");
 }
+
+// ============================================================================
+// Generic types deriving Instructor
+// ============================================================================
+
+use serde::de::DeserializeOwned;
+
+/// A generic wrapper: the derive must emit generics-aware impl blocks
+/// (split_for_impl) for both SchemaType and Instructor.
+///
+/// The `#[serde(bound(...))]` attribute is required by *serde's own derive*
+/// whenever `DeserializeOwned` appears as a struct bound (serde otherwise
+/// emits an ambiguous `T: Deserialize<'de>` + `T: DeserializeOwned` impl);
+/// it is unrelated to the Instructor derive.
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+#[serde(bound(deserialize = "T: DeserializeOwned"))]
+struct Wrapper<T: SchemaType + Serialize + DeserializeOwned> {
+    #[llm(description = "The wrapped value")]
+    value: T,
+    #[llm(description = "A label for the value")]
+    label: String,
+}
+
+/// Generics without bounds on the struct itself: the derive adds the
+/// SchemaType / serde bounds to its own impls.
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct Pair<A, B> {
+    first: A,
+    second: B,
+}
+
+/// Generic enum with a default type parameter and data-carrying variants.
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+enum Maybe<T = String> {
+    Nothing,
+    Just(T),
+}
+
+#[test]
+fn generic_struct_compiles_and_produces_schema() {
+    let schema = Wrapper::<i32>::schema().to_json();
+    assert_eq!(schema["type"], "object");
+    assert_eq!(schema["title"], "Wrapper");
+    assert_eq!(schema["properties"]["value"]["type"], "integer");
+    assert_eq!(schema["properties"]["label"]["type"], "string");
+    let required: Vec<&str> = schema["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(required.contains(&"value"));
+    assert!(required.contains(&"label"));
+}
+
+#[test]
+fn generic_struct_with_struct_parameter_embeds_schema() {
+    // Instantiated with a derived struct: T's full object schema is embedded.
+    let schema = Wrapper::<Address>::schema().to_json();
+    let value = &schema["properties"]["value"];
+    assert_eq!(value["type"], "object");
+    assert_eq!(value["properties"]["street"]["type"], "string");
+}
+
+#[test]
+fn generic_struct_instructor_impl_validates() {
+    // `use rstructor::Instructor` at the top of this file imports both the
+    // derive macro and the trait, so `validate` is callable here.
+    let wrapped = Wrapper {
+        value: 42i64,
+        label: "answer".to_string(),
+    };
+    assert!(wrapped.validate().is_ok());
+}
+
+#[test]
+fn unbounded_generic_struct_compiles_and_produces_schema() {
+    let schema = Pair::<String, f64>::schema().to_json();
+    assert_eq!(schema["type"], "object");
+    assert_eq!(schema["properties"]["first"]["type"], "string");
+    assert_eq!(schema["properties"]["second"]["type"], "number");
+}
+
+#[test]
+fn generic_enum_compiles_and_produces_schema() {
+    let schema = Maybe::<i32>::schema().to_json();
+    let any_of = schema["anyOf"].as_array().expect("anyOf for data enum");
+    assert_eq!(any_of.len(), 2);
+    // The Just variant carries the type parameter's schema.
+    let just = any_of
+        .iter()
+        .find(|v| v["properties"].get("Just").is_some())
+        .expect("Just variant present");
+    assert_eq!(just["properties"]["Just"]["type"], "integer");
+}
+
+/// Pathological combination of the sniffing and recursion fixes: a recursive
+/// struct that is itself named `Date`. The self-reference $ref must win over
+/// both the name sniff and the SchemaType probe (which would otherwise call
+/// its own schema() forever).
+mod recursive_date {
+    use super::*;
+
+    #[derive(Instructor, Serialize, Deserialize, Debug)]
+    pub struct Date {
+        #[llm(description = "Node label")]
+        pub label: String,
+        #[llm(description = "Nested child dates")]
+        pub children: Vec<Date>,
+    }
+}
+
+#[test]
+fn recursive_struct_named_date_terminates_with_ref() {
+    use rstructor::SchemaType as _;
+    let schema = recursive_date::Date::schema().to_json();
+    assert_eq!(schema["$ref"], "#/$defs/Date");
+    let def = &schema["$defs"]["Date"];
+    assert_eq!(def["properties"]["children"]["type"], "array");
+    assert_eq!(
+        def["properties"]["children"]["items"]["$ref"],
+        "#/$defs/Date"
+    );
+    assert_eq!(def["properties"]["label"]["type"], "string");
+}

--- a/tests/derive_schema_offline_tests.rs
+++ b/tests/derive_schema_offline_tests.rs
@@ -876,3 +876,135 @@ fn nested_vec_of_structs_embeds_inner_schema() {
         "string"
     );
 }
+
+// ============================================================================
+// Well-known type-name sniffing vs user-defined types named Date/DateTime
+// ============================================================================
+
+/// A user-defined struct that happens to share its name with chrono's `Date`.
+/// It derives Instructor, so its real object schema must win over the
+/// name-sniffed `{type: "string", format: "date"}`.
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct Date {
+    #[llm(description = "Day of month")]
+    day: u8,
+    #[llm(description = "Month number")]
+    month: u8,
+    #[llm(description = "Full year")]
+    year: i32,
+}
+
+/// Same collision for `DateTime` (no generic parameters, unlike chrono's).
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct DateTime {
+    #[llm(description = "Unix timestamp")]
+    epoch_seconds: i64,
+}
+
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct Appointment {
+    title: String,
+    date: Date,
+    starts_at: DateTime,
+    ends_at: Option<Date>,
+    reschedule_options: Vec<Date>,
+}
+
+#[test]
+fn user_defined_date_struct_keeps_its_object_schema() {
+    let schema = Appointment::schema().to_json();
+    let date = &schema["properties"]["date"];
+    assert_eq!(
+        date["type"], "object",
+        "user struct named Date must keep its derived object schema, got: {date:?}"
+    );
+    assert_eq!(date["properties"]["day"]["type"], "integer");
+    assert_eq!(date["properties"]["month"]["type"], "integer");
+    assert_eq!(date["properties"]["year"]["type"], "integer");
+    assert!(
+        date.get("format").is_none(),
+        "user struct named Date must not be sniffed into format: date"
+    );
+}
+
+#[test]
+fn user_defined_datetime_struct_keeps_its_object_schema() {
+    let schema = Appointment::schema().to_json();
+    let starts_at = &schema["properties"]["starts_at"];
+    assert_eq!(starts_at["type"], "object");
+    assert_eq!(starts_at["properties"]["epoch_seconds"]["type"], "integer");
+    assert!(starts_at.get("format").is_none());
+}
+
+#[test]
+fn optional_user_defined_date_struct_keeps_its_object_schema() {
+    let schema = Appointment::schema().to_json();
+    let ends_at = &schema["properties"]["ends_at"];
+    assert_eq!(ends_at["type"], "object");
+    assert_eq!(ends_at["properties"]["day"]["type"], "integer");
+    let required: Vec<&str> = schema["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(!required.contains(&"ends_at"));
+}
+
+#[test]
+fn vec_of_user_defined_date_struct_embeds_object_items() {
+    let schema = Appointment::schema().to_json();
+    let opts = &schema["properties"]["reschedule_options"];
+    assert_eq!(opts["type"], "array");
+    assert_eq!(opts["items"]["type"], "object");
+    assert_eq!(opts["items"]["properties"]["year"]["type"], "integer");
+}
+
+/// chrono's real date/time types must still be sniffed into string/format
+/// schemas (chrono types do not implement SchemaType, so the probe falls back).
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct ChronoEvent {
+    name: String,
+    on_date: chrono::NaiveDate,
+    at: chrono::DateTime<chrono::Utc>,
+    local_ts: chrono::NaiveDateTime,
+    maybe_date: Option<chrono::NaiveDate>,
+    past_dates: Vec<chrono::NaiveDate>,
+    past_times: Vec<chrono::DateTime<chrono::Utc>>,
+}
+
+#[test]
+fn chrono_date_fields_still_sniffed_to_string_format() {
+    let schema = ChronoEvent::schema().to_json();
+
+    let on_date = &schema["properties"]["on_date"];
+    assert_eq!(on_date["type"], "string");
+    assert_eq!(on_date["format"], "date");
+
+    let at = &schema["properties"]["at"];
+    assert_eq!(at["type"], "string");
+    assert_eq!(at["format"], "date-time");
+
+    let local_ts = &schema["properties"]["local_ts"];
+    assert_eq!(local_ts["type"], "string");
+    assert_eq!(local_ts["format"], "date-time");
+
+    let maybe_date = &schema["properties"]["maybe_date"];
+    assert_eq!(maybe_date["type"], "string");
+    assert_eq!(maybe_date["format"], "date");
+}
+
+#[test]
+fn chrono_date_array_items_still_sniffed_to_string_format() {
+    let schema = ChronoEvent::schema().to_json();
+
+    let past_dates = &schema["properties"]["past_dates"];
+    assert_eq!(past_dates["type"], "array");
+    assert_eq!(past_dates["items"]["type"], "string");
+    assert_eq!(past_dates["items"]["format"], "date");
+
+    let past_times = &schema["properties"]["past_times"];
+    assert_eq!(past_times["type"], "array");
+    assert_eq!(past_times["items"]["type"], "string");
+    assert_eq!(past_times["items"]["format"], "date-time");
+}


### PR DESCRIPTION
Fixes four bugs in the `Instructor` derive's schema generation (`rstructor_derive/src/generators/struct_schema.rs` and friends), each reproduced via a probe crate and now covered by offline tests in `tests/derive_schema_offline_tests.rs`.

## 1. Nested `Vec` loses inner `items`

**Symptom:** `Vec<Vec<i32>>` generated `{"type": "array", "items": {"type": "array"}}` — the inner `items` schema was missing entirely, so LLMs had no idea what the inner arrays contain.

**Root cause:** the array branch computed the element schema with a single non-recursive call to `get_schema_type_from_rust_type`, which only yields a flat type word (`"array"`).

**Fix:** items generation is now a recursive helper (`generate_array_items_schema`) that recurses into nested collections (`Vec`, `HashSet`, `BTreeSet`, any depth) while preserving the existing behavior for date/uuid elements, self-references (`$ref`), nested structs, and primitives. `Vec<Vec<i32>>` now produces `items.items.type == "integer"`; tests cover triple nesting, `Vec<HashSet<String>>`, `Option<Vec<Vec<f64>>>`, and `Vec<Vec<Struct>>`.

## 2. Type-name sniffing false positive on user types named `Date`/`DateTime`

**Symptom:** a user-defined `struct Date` (or `DateTime`, etc.) deriving `Instructor` and used as a field type was silently turned into `{"type": "string", "format": "date"}` instead of its real object schema.

**Root cause:** well-known library types are detected by the final path segment *name only* (`Date`, `DateTime`, `NaiveDate`, `NaiveDateTime`, `Uuid`), and that sniff ran before (instead of) the normal nested-struct path that emits `<T as SchemaType>::schema()`.

**Decision / fix:** the sniff cannot simply be dropped — `chrono`/`uuid` are dev-only dependencies here, the crate ships **no** `SchemaType` impls for them (`grep chrono src/` only hits dev-deps), so chrono fields *must* keep the name-based fallback. Restricting the sniff to qualified paths (`chrono::NaiveDate`) was rejected as too breaking: the common import style is bare `use chrono::NaiveDate;`. Instead the ambiguity is resolved at compile time with an autoref-specialization probe (`schema::__private::SchemaProbe`, mirroring the existing `model::__private::Probe` used for recursive validation): if the field type implements `SchemaType`, its own schema wins; otherwise the sniffed `string`/`format` fallback is emitted. This is least-breaking and sound:

- user `struct Date` deriving `Instructor` → real object schema (hard requirement) ✅
- `chrono::NaiveDate` / `DateTime<Utc>` / `NaiveDateTime`, bare or qualified, direct, `Option<...>`, and as `Vec<...>` items → unchanged `string`/`format` schemas ✅ (regression-tested against real chrono types)

## 3. `Option<Box<Self>>` recursion stack-overflows at `schema()` time

**Symptom:** `struct Node { value: i32, next: Option<Box<Node>> }` compiled, but calling `Node::schema()` recursed infinitely and overflowed the stack.

**Root cause:** the `Box<T>` branch unconditionally embedded the inner type's schema via `<T as SchemaType>::schema()`, with no self-reference guard — unlike the array branch, which already emits `$ref` for recursive element types.

**Fix:** mirror the array guard: when the boxed inner type (after unwrapping `Option`) refers back to the deriving struct, emit `{"$ref": "#/$defs/<Name>"}`. The existing `has_self_reference` pass already roots such schemas under `$defs`, so the ref resolves. Tests cover `Option<Box<Self>>` (linked list) and `Vec<Box<Self>>` (tree), plus the pathological combination of bugs 2+3 — a recursive struct *itself named* `Date` — for which the `$ref` guard is ordered ahead of the name-sniff probe.

## 4. Generic structs fail to compile

**Symptom:** deriving `Instructor` on any generic type (e.g. `struct Wrapper<T: SchemaType + Serialize + DeserializeOwned> { value: T }`) failed to compile: the emitted impls had no type parameters.

**Root cause:** `struct_schema.rs`, `enum_schema.rs` (all five tagging modes), and the `Instructor` impl in `lib.rs` emitted bare `impl Trait for Name` without `generics.split_for_impl()`.

**Fix:** thread `input.generics` through both generators and emit every impl header via `split_for_impl()`:
- `SchemaType` impls bind each type parameter by `SchemaType` (the generated code calls `<T as SchemaType>::schema()` for type-parameter fields);
- the `Instructor` impl additionally binds type parameters by `serde::Serialize` + `serde::de::DeserializeOwned`, which `Instructor` requires as supertraits (same bounding strategy as serde's own derive).

Tests cover a bounded generic struct (schema + validate, instantiated with both a primitive and a derived struct), an unbounded `Pair<A, B>`, and a generic enum with a default type parameter. (Note: the literal `Wrapper<T: ... + DeserializeOwned>` shape additionally needs `#[serde(bound(deserialize = "T: DeserializeOwned"))]` for **serde's own derive** to accept it — a known serde limitation unrelated to this macro, documented in the test.)

## Verification

- `cargo fmt` — clean
- `cargo clippy --all-targets` (default features, as CI runs) — clean, exit 0
- `cargo test` (root crate: 142 unit + 49 offline derive-schema tests + full integration suites + doctests) — all green
- `cargo test -p rstructor_derive` — all green
- No new tests call live LLM APIs; all new coverage is offline schema-shape assertions in `tests/derive_schema_offline_tests.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
