### PR TITLE
Update provider models to current releases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,18 +47,18 @@
 ### Official Model Documentation Sources
 
 **OpenAI:**
-- Model Documentation: https://platform.openai.com/docs/models
+- Model Documentation: https://developers.openai.com/api/docs/models
 - Models API Endpoint: https://platform.openai.com/docs/api-reference/models/list
 
 **Anthropic:**
-- All Models Overview: https://docs.anthropic.com/en/docs/about-claude/models/all-models
+- All Models Overview: https://platform.claude.com/docs/en/about-claude/models/overview
 - Models List API: https://docs.anthropic.com/en/api/models-list
 
 **xAI (Grok):**
-- Models Documentation: https://docs.x.ai/docs/models
+- Models Documentation: https://docs.x.ai/developers/models
 
 **Google (Gemini):**
-- Models Documentation: https://ai.google.dev/models
+- Models Documentation: https://ai.google.dev/gemini-api/docs/models
 - Models API Endpoint: `GET https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY`
 
 ### Update Process
@@ -67,20 +67,20 @@
 1. **ALWAYS use API endpoints to get current models** - Never guess or rely on web search. Use the official API endpoints:
    - **OpenAI**: `GET https://api.openai.com/v1/models` (requires `Authorization: Bearer $OPENAI_API_KEY`)
    - **Anthropic**: `GET https://api.anthropic.com/v1/models` (requires `x-api-key: $ANTHROPIC_API_KEY` and `anthropic-version: 2023-06-01`)
-   - **xAI (Grok)**: Check `https://docs.x.ai/docs/models` or use their API if available
+   - **xAI (Grok)**: Check `https://docs.x.ai/developers/models` or use their API if available
    - **Google (Gemini)**: `GET https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY` (API key as query parameter)
 2. **NEVER guess model identifiers** - Always get exact model names from API responses or official documentation
 3. **NEVER rely on web search results** - Web search often returns outdated, incorrect, or speculative information
-4. **ALWAYS use exact API identifiers** - Model identifiers must match exactly what the API expects (e.g., `gpt-5-chat-latest`, `claude-sonnet-4-5-20250929`, `grok-4-0709`, `gemini-1.5-flash`)
+4. **ALWAYS use exact API identifiers** - Model identifiers must match exactly what the API expects (e.g., `gpt-5.6-sol`, `claude-sonnet-5`, `grok-4.5`, `gemini-3.5-flash`)
 5. **If API key is not available**: Ask the user to provide the exact model identifiers from the API endpoint response, rather than guessing or using web search
 6. **NEVER use web search for model lists** - Web search results are often outdated, incorrect, or speculative. Always use official API endpoints or documentation
-7. **Verify date stamps make sense** - If version X.Y is newer than X.Z, its date stamp should be later (e.g., Claude 3.7 date should be after Claude 3.5 date)
-8. **Check for new major versions** - Don't assume only minor version updates; check for major version releases (e.g., Claude 4, GPT-5, Gemini 2.0)
+7. **Verify versioning conventions** - Some providers use dated snapshots while newer Anthropic models use dateless pinned IDs; confirm the current provider convention rather than inferring one
+8. **Check for new major versions** - Don't assume only minor version updates; check for major version releases (e.g., Claude 5, GPT-5.6, Gemini 3.5)
 9. **Verify model name format** - Different providers may use different naming conventions:
-   - OpenAI: `gpt-4-turbo`, `gpt-5-chat-latest`
-   - Anthropic: `claude-sonnet-4-20250514` (includes date)
-   - Grok: `grok-4-0709` (includes date)
-   - Gemini: `gemini-1.5-flash`, `gemini-2.0-flash` (may include version and suffix)
+   - OpenAI: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`
+   - Anthropic: `claude-sonnet-5` (dateless pinned ID for current generations)
+   - Grok: `grok-4.5`
+   - Gemini: `gemini-3.5-flash`, `gemini-3.1-pro-preview` (may include a preview suffix)
 10. **Filter for chat completion models** - Only include models suitable for chat completions:
     - **OpenAI**: Filter for chat completion models (exclude `whisper-*`, `text-embedding-*`, `text-moderation-*`, etc.)
     - **Anthropic**: Filter for chat completion models (exclude specialized variants unless needed)
@@ -92,18 +92,18 @@
    - **OpenAI**: `curl https://api.openai.com/v1/models -H "Authorization: Bearer $OPENAI_API_KEY"`
    - **Anthropic**: `curl https://api.anthropic.com/v1/models -H "x-api-key: $ANTHROPIC_API_KEY" -H "anthropic-version: 2023-06-01"`
    - **Gemini**: `curl "https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY"`
-   - **Grok**: Check documentation at `https://docs.x.ai/docs/models` (API endpoint may not be publicly available)
+   - **Grok**: Check documentation at `https://docs.x.ai/developers/models` (API endpoint may not be publicly available)
 2. **Parse API response**: Extract model identifiers from the JSON response (field names vary by provider):
-   - **OpenAI**: Extract `id` field (e.g., `"id": "gpt-4-turbo"`)
-   - **Anthropic**: Extract `id` field (e.g., `"id": "claude-sonnet-4-20250514"`)
-   - **Gemini**: Extract `name` field and remove `models/` prefix (e.g., `"name": "models/gemini-1.5-flash"` → use `gemini-1.5-flash`)
+   - **OpenAI**: Extract `id` field (e.g., `"id": "gpt-5.6-sol"`)
+   - **Anthropic**: Extract `id` field (e.g., `"id": "claude-sonnet-5"`)
+   - **Gemini**: Extract `name` field and remove `models/` prefix (e.g., `"name": "models/gemini-3.5-flash"` → use `gemini-3.5-flash`)
    - **Grok**: Extract from documentation or ask user for exact identifiers
 3. **Filter appropriate models**: For chat completions, include main chat models and exclude specialized variants:
    - **OpenAI**: Filter for chat completion models (exclude `whisper-*`, `text-embedding-*`, `text-moderation-*`, etc.)
    - **Anthropic**: Filter for chat completion models (exclude specialized variants unless needed)
    - **Gemini**: Filter for models with `generateContent` in `supportedGenerationMethods` array (check API response structure)
    - **Grok**: Include all documented chat completion models
-4. **Verify model identifiers**: Ensure date stamps and version numbers are correct (e.g., Claude 3.7 date should be after Claude 3.5 date)
+4. **Verify model identifiers**: Ensure version numbers and provider-specific snapshot conventions match the API response and official documentation
 5. **When updating**: Add new models to the appropriate enum (`Model`, `AnthropicModel`, `GrokModel`, `GeminiModel`) in the respective backend files, ordered newest to oldest
 6. **Remove deprecated models**: Check API response for models that are no longer available and remove them
 7. **Default models**: Update default model selection to use the latest recommended model when appropriate

--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ attached tools in a loop). Builders compose: `with_system`, `with_media`, and
 use rstructor::{OpenAIClient, AnthropicClient, GrokClient, GeminiClient, LLMClient};
 
 // OpenAI (reads OPENAI_API_KEY)
-let client = OpenAIClient::from_env()?.model("gpt-5.5");
+let client = OpenAIClient::from_env()?.model("gpt-5.6");
 
 // Anthropic (reads ANTHROPIC_API_KEY)
-let client = AnthropicClient::from_env()?.model("claude-sonnet-4-6");
+let client = AnthropicClient::from_env()?.model("claude-sonnet-5");
 
 // Grok/xAI (reads XAI_API_KEY)
-let client = GrokClient::from_env()?.model("grok-4.3");
+let client = GrokClient::from_env()?.model("grok-4.5");
 
 // Gemini (reads GEMINI_API_KEY)
 let client = GeminiClient::from_env()?.model("gemini-3.5-flash");
@@ -149,7 +149,7 @@ let movie: Movie = client.materialize("Describe Inception").await?;
 let client = AnyClient::from_env()?;
 
 // Or wrap a pre-configured client:
-let client: AnyClient = OpenAIClient::from_env()?.model("gpt-5.5").into();
+let client: AnyClient = OpenAIClient::from_env()?.model("gpt-5.6").into();
 ```
 
 ## Validation
@@ -351,9 +351,9 @@ Configure reasoning depth for supported models:
 ```rust
 use rstructor::ThinkingLevel;
 
-// GPT-5.5, Claude 4.6 Sonnet, Gemini 3.1
+// GPT-5.6, Claude 4.6 Sonnet, Gemini 3.1
 let client = OpenAIClient::from_env()?
-    .model("gpt-5.5")
+    .model("gpt-5.6")
     .thinking_level(ThinkingLevel::High);
 
 // Levels: Off, Minimal, Low, Medium, High

--- a/examples/anthropic_multimodal_example.rs
+++ b/examples/anthropic_multimodal_example.rs
@@ -25,9 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image_bytes = reqwest::get(image_url).await?.bytes().await?;
     let media = MediaFile::from_bytes(&image_bytes, "image/png");
 
-    let client = AnthropicClient::from_env()?
-        .model(AnthropicModel::ClaudeSonnet46)
-        .temperature(0.0);
+    let client = AnthropicClient::from_env()?.model(AnthropicModel::ClaudeSonnet5);
 
     let analysis: ImageAnalysis = client
         .materialize_with_media("Describe this image and list dominant colors.", &[media])

--- a/examples/grok_multimodal_example.rs
+++ b/examples/grok_multimodal_example.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let media = MediaFile::from_bytes(&image_bytes, "image/png");
 
     let client = GrokClient::from_env()?
-        .model(GrokModel::Grok43)
+        .model(GrokModel::Grok45)
         .temperature(0.0);
 
     let analysis: ImageAnalysis = client

--- a/examples/openai_multimodal_example.rs
+++ b/examples/openai_multimodal_example.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let media = MediaFile::from_bytes(&image_bytes, "image/png");
 
     let client = OpenAIClient::from_env()?
-        .model(OpenAIModel::Gpt55)
+        .model(OpenAIModel::Gpt56)
         .temperature(0.0);
 
     let analysis: ImageAnalysis = client

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -20,7 +20,7 @@ define_model_enum! {
     /// Anthropic models available for completion
     ///
     /// For the latest available models and their identifiers, check the
-    /// [Anthropic Models Documentation](https://docs.anthropic.com/en/docs/about-claude/models/all-models).
+    /// [Anthropic Models Documentation](https://platform.claude.com/docs/en/about-claude/models/overview).
     ///
     /// # Using Custom Models
     ///
@@ -40,11 +40,15 @@ define_model_enum! {
     /// let model = AnthropicModel::from_string("claude-custom");
     /// ```
     pub enum AnthropicModel {
-        /// Claude Opus 4.8 (latest most capable generally available model)
+        /// Claude Fable 5 (latest highest-capability generally available model)
+        ClaudeFable5 => "claude-fable-5",
+        /// Claude Sonnet 5 (latest balanced model)
+        ClaudeSonnet5 => "claude-sonnet-5",
+        /// Claude Opus 4.8 (recommended for complex agentic and enterprise work)
         ClaudeOpus48 => "claude-opus-4-8",
         /// Claude Opus 4.7 (previous most capable model)
         ClaudeOpus47 => "claude-opus-4-7",
-        /// Claude Sonnet 4.6 (latest balanced model)
+        /// Claude Sonnet 4.6 (previous balanced model)
         ClaudeSonnet46 => "claude-sonnet-4-6",
         /// Claude Opus 4.6 (previous most capable model)
         ClaudeOpus46 => "claude-opus-4-6",
@@ -56,10 +60,6 @@ define_model_enum! {
         ClaudeSonnet45 => "claude-sonnet-4-5-20250929",
         /// Claude Opus 4.1 (enhanced reasoning capabilities)
         ClaudeOpus41 => "claude-opus-4-1-20250805",
-        /// Claude Opus 4 (high-intelligence model)
-        ClaudeOpus4 => "claude-opus-4-20250514",
-        /// Claude Sonnet 4 (balanced performance model)
-        ClaudeSonnet4 => "claude-sonnet-4-20250514",
     }
 }
 
@@ -68,6 +68,8 @@ define_model_enum! {
 pub struct AnthropicConfig {
     pub api_key: String,
     pub model: AnthropicModel,
+    /// Sampling temperature. Claude 5 and recent Opus models require the API
+    /// default, so requests for those models normalize this value to `1.0`.
     pub temperature: f32,
     pub max_tokens: Option<u32>,
     /// Total timeout for each HTTP request.
@@ -114,6 +116,21 @@ struct CompletionRequest {
     thinking: Option<ClaudeThinkingConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     output_format: Option<OutputFormat>,
+}
+
+/// Claude 5 and recent Opus models reject non-default sampling parameters.
+/// Sending `1.0` preserves the API default while keeping the shared request
+/// shape stable for older Claude models that still accept custom sampling.
+fn effective_temperature(model: &str, configured: f32, thinking_enabled: bool) -> f32 {
+    let requires_default_sampling = matches!(
+        model,
+        "claude-fable-5" | "claude-sonnet-5" | "claude-opus-4-8" | "claude-opus-4-7"
+    );
+    if thinking_enabled || requires_default_sampling {
+        1.0
+    } else {
+        configured
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -183,7 +200,7 @@ impl AnthropicClient {
     /// # Ok(())
     /// # }
     /// ```
-    #[instrument(name = "anthropic_client_new", skip(api_key), fields(model = ?AnthropicModel::ClaudeSonnet46))]
+    #[instrument(name = "anthropic_client_new", skip(api_key), fields(model = ?AnthropicModel::ClaudeSonnet5))]
     pub fn new(api_key: impl Into<String>) -> Result<Self> {
         let api_key = api_key.into();
         if api_key.is_empty() {
@@ -197,7 +214,7 @@ impl AnthropicClient {
 
         let config = AnthropicConfig {
             api_key,
-            model: AnthropicModel::ClaudeSonnet46, // Default to Claude Sonnet 4.6 (latest balanced model)
+            model: AnthropicModel::ClaudeSonnet5, // Default to Claude Sonnet 5 (latest balanced model)
             temperature: 0.0,
             max_tokens: None,
             timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
@@ -228,7 +245,7 @@ impl AnthropicClient {
     /// # Ok(())
     /// # }
     /// ```
-    #[instrument(name = "anthropic_client_from_env", fields(model = ?AnthropicModel::ClaudeSonnet46))]
+    #[instrument(name = "anthropic_client_from_env", fields(model = ?AnthropicModel::ClaudeSonnet5))]
     pub fn from_env() -> Result<Self> {
         let api_key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| {
             RStructorError::api_error("Anthropic", ApiErrorKind::AuthenticationFailed)
@@ -239,7 +256,7 @@ impl AnthropicClient {
 
         let config = AnthropicConfig {
             api_key,
-            model: AnthropicModel::ClaudeSonnet46, // Default to Claude Sonnet 4.6 (latest balanced model)
+            model: AnthropicModel::ClaudeSonnet5, // Default to Claude Sonnet 5 (latest balanced model)
             temperature: 0.0,
             max_tokens: None,
             timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
@@ -314,12 +331,11 @@ impl AnthropicClient {
             }
         });
 
-        // Claude requires temperature=1 when thinking is enabled
-        let effective_temp = if thinking_config.is_some() {
-            1.0
-        } else {
-            self.config.temperature
-        };
+        let effective_temp = effective_temperature(
+            self.config.model.as_str(),
+            self.config.temperature,
+            thinking_config.is_some(),
+        );
 
         // Create output format for native structured outputs
         let output_format = OutputFormat {
@@ -443,12 +459,11 @@ impl AnthropicClient {
             }
         });
 
-        // Claude requires temperature=1 when thinking is enabled
-        let effective_temp = if thinking_config.is_some() {
-            1.0
-        } else {
-            self.config.temperature
-        };
+        let effective_temp = effective_temperature(
+            self.config.model.as_str(),
+            self.config.temperature,
+            thinking_config.is_some(),
+        );
 
         // Build API messages, including any attached media blocks
         let api_messages: Vec<AnthropicMessage> = messages
@@ -628,11 +643,11 @@ impl AnthropicClient {
                 None
             }
         });
-        let effective_temp = if thinking_config.is_some() {
-            1.0
-        } else {
-            self.config.temperature
-        };
+        let effective_temp = effective_temperature(
+            self.config.model.as_str(),
+            self.config.temperature,
+            thinking_config.is_some(),
+        );
         let max_tokens = effective_max_tokens(self.config.max_tokens, thinking_config.as_ref());
 
         let mut body = serde_json::json!({
@@ -702,7 +717,7 @@ impl crate::backend::tools::ToolRunner for AnthropicClient {
             base_url,
             &self.config.api_key,
             self.config.model.as_str(),
-            self.config.temperature,
+            effective_temperature(self.config.model.as_str(), self.config.temperature, false),
             self.config
                 .max_tokens
                 .unwrap_or(DEFAULT_ANTHROPIC_MAX_TOKENS),
@@ -960,7 +975,10 @@ impl LLMClient for AnthropicClient {
 
 #[cfg(test)]
 mod tests {
-    use super::{ClaudeThinkingConfig, DEFAULT_ANTHROPIC_MAX_TOKENS, effective_max_tokens};
+    use super::{
+        ClaudeThinkingConfig, DEFAULT_ANTHROPIC_MAX_TOKENS, effective_max_tokens,
+        effective_temperature,
+    };
 
     fn thinking_config_with_budget(budget_tokens: u32) -> ClaudeThinkingConfig {
         ClaudeThinkingConfig {
@@ -1010,12 +1028,43 @@ mod tests {
     }
 
     #[test]
+    fn latest_models_use_default_sampling_temperature() {
+        for model in [
+            "claude-fable-5",
+            "claude-sonnet-5",
+            "claude-opus-4-8",
+            "claude-opus-4-7",
+        ] {
+            assert_eq!(effective_temperature(model, 0.0, false), 1.0);
+        }
+    }
+
+    #[test]
+    fn older_models_preserve_configured_temperature_without_thinking() {
+        assert_eq!(
+            effective_temperature("claude-sonnet-4-6", 0.25, false),
+            0.25
+        );
+    }
+
+    #[test]
+    fn thinking_forces_default_temperature_on_older_models() {
+        assert_eq!(effective_temperature("claude-sonnet-4-6", 0.25, true), 1.0);
+    }
+
+    #[test]
     fn default_config_has_default_timeout() {
         let client = super::AnthropicClient::new("test-key").unwrap();
         assert_eq!(
             client.config.timeout,
             Some(crate::backend::DEFAULT_REQUEST_TIMEOUT)
         );
+    }
+
+    #[test]
+    fn default_config_uses_latest_balanced_model() {
+        let client = super::AnthropicClient::new("test-key").unwrap();
+        assert_eq!(client.config.model, super::AnthropicModel::ClaudeSonnet5);
     }
 
     #[test]

--- a/src/backend/any_client.rs
+++ b/src/backend/any_client.rs
@@ -81,7 +81,7 @@ pub enum Provider {
 /// # fn ex() -> Result<(), Box<dyn std::error::Error>> {
 /// use rstructor::{AnyClient, OpenAIClient, OpenAIModel};
 ///
-/// let configured = OpenAIClient::from_env()?.model(OpenAIModel::Gpt55);
+/// let configured = OpenAIClient::from_env()?.model(OpenAIModel::Gpt56);
 /// let client: AnyClient = configured.into();
 /// # let _ = client;
 /// # Ok(())

--- a/src/backend/client.rs
+++ b/src/backend/client.rs
@@ -151,7 +151,7 @@ impl MediaFile {
 ///
 /// // Create a client
 /// let client = OpenAIClient::new("your-openai-api-key")?
-///     .model(OpenAIModel::Gpt55)
+///     .model(OpenAIModel::Gpt56)
 ///     .temperature(0.0)
 ///     .timeout(Duration::from_secs(30));  // Optional: set 30 second timeout
 ///
@@ -184,8 +184,7 @@ impl MediaFile {
 ///
 /// // Create a client
 /// let client = AnthropicClient::new("your-anthropic-api-key")?
-///     .model(AnthropicModel::ClaudeSonnet4)
-///     .temperature(0.0)
+///     .model(AnthropicModel::ClaudeSonnet5)
 ///     .timeout(Duration::from_secs(30));  // Optional: set 30 second timeout
 ///
 /// // Materialize a structured response

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -19,7 +19,7 @@ define_model_enum! {
     /// Gemini models available for completion
     ///
     /// For the latest available models and their identifiers, check the
-    /// [Google AI Models Documentation](https://ai.google.dev/models).
+    /// [Google AI Models Documentation](https://ai.google.dev/gemini-api/docs/models).
     /// Use the API endpoint `GET https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY`
     /// to get the current list of available models.
     ///
@@ -1146,6 +1146,12 @@ mod tests {
             client.config.timeout,
             Some(crate::backend::DEFAULT_REQUEST_TIMEOUT)
         );
+    }
+
+    #[test]
+    fn default_config_uses_latest_stable_model() {
+        let client = super::GeminiClient::new("test-key").unwrap();
+        assert_eq!(client.config.model, super::Model::Gemini35Flash);
     }
 
     #[test]

--- a/src/backend/grok.rs
+++ b/src/backend/grok.rs
@@ -22,7 +22,7 @@ define_model_enum! {
     ///
     /// These are convenience variants for common Grok models.
     /// For the latest available models and their identifiers, check the
-    /// [xAI Models Documentation](https://docs.x.ai/docs/models).
+    /// [xAI Models Documentation](https://docs.x.ai/developers/models).
     ///
     /// # Using Custom Models
     ///
@@ -42,7 +42,9 @@ define_model_enum! {
     /// let model = GrokModel::from_string("grok-custom");
     /// ```
     pub enum Model {
-        /// Grok 4.3 (latest recommended chat model, multimodal text + image input)
+        /// Grok 4.5 (latest recommended chat and coding model)
+        Grok45 => "grok-4.5",
+        /// Grok 4.3 (previous recommended chat model, multimodal text + image input)
         Grok43 => "grok-4.3",
         /// Grok 4.20 Reasoning (reasoning-optimized variant)
         Grok420Reasoning => "grok-4.20-0309-reasoning",
@@ -96,7 +98,7 @@ impl GrokClient {
     /// # Ok(())
     /// # }
     /// ```
-    #[instrument(name = "grok_client_new", skip(api_key), fields(model = ?Model::Grok43))]
+    #[instrument(name = "grok_client_new", skip(api_key), fields(model = ?Model::Grok45))]
     pub fn new(api_key: impl Into<String>) -> Result<Self> {
         let api_key = api_key.into();
         if api_key.is_empty() {
@@ -111,7 +113,7 @@ impl GrokClient {
 
         let config = GrokConfig {
             api_key,
-            model: Model::Grok43, // Default to Grok 4.3 (latest recommended chat model)
+            model: Model::Grok45, // Default to Grok 4.5 (latest recommended chat model)
             temperature: 0.0,
             max_tokens: None,
             timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
@@ -141,7 +143,7 @@ impl GrokClient {
     /// # Ok(())
     /// # }
     /// ```
-    #[instrument(name = "grok_client_from_env", fields(model = ?Model::Grok43))]
+    #[instrument(name = "grok_client_from_env", fields(model = ?Model::Grok45))]
     pub fn from_env() -> Result<Self> {
         let api_key = std::env::var("XAI_API_KEY")
             .map_err(|_| RStructorError::api_error("Grok", ApiErrorKind::AuthenticationFailed))?;
@@ -151,7 +153,7 @@ impl GrokClient {
 
         let config = GrokConfig {
             api_key,
-            model: Model::Grok43, // Default to Grok 4.3 (latest recommended chat model)
+            model: Model::Grok45, // Default to Grok 4.5 (latest recommended chat model)
             temperature: 0.0,
             max_tokens: None,
             timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
@@ -749,6 +751,12 @@ mod tests {
     fn default_config_has_default_timeout() {
         let client = GrokClient::new("test-key").unwrap();
         assert_eq!(client.config.timeout, Some(DEFAULT_REQUEST_TIMEOUT));
+    }
+
+    #[test]
+    fn default_config_uses_latest_model() {
+        let client = GrokClient::new("test-key").unwrap();
+        assert_eq!(client.config.model, Model::Grok45);
     }
 
     #[test]

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -41,9 +41,17 @@ define_model_enum! {
     /// let model = OpenAIModel::from_string("gpt-4-custom");
     /// ```
     pub enum Model {
+        /// GPT-5.6 (alias for GPT-5.6 Sol, the latest flagship model)
+        Gpt56 => "gpt-5.6",
+        /// GPT-5.6 Sol (flagship model for frontier capability)
+        Gpt56Sol => "gpt-5.6-sol",
+        /// GPT-5.6 Terra (balanced intelligence, latency, and cost)
+        Gpt56Terra => "gpt-5.6-terra",
+        /// GPT-5.6 Luna (efficient model for high-volume workloads)
+        Gpt56Luna => "gpt-5.6-luna",
         /// GPT-5.5 Pro (most capable GPT-5.5 model)
         Gpt55Pro => "gpt-5.5-pro",
-        /// GPT-5.5 (latest frontier model for complex professional work)
+        /// GPT-5.5 (previous frontier model for complex professional work)
         Gpt55 => "gpt-5.5",
         /// GPT-5.4 Pro (most capable GPT-5.4-class model)
         Gpt54Pro => "gpt-5.4-pro",
@@ -141,7 +149,7 @@ impl OpenAIClient {
     /// # Ok(())
     /// # }
     /// ```
-    #[instrument(name = "openai_client_new", skip(api_key), fields(model = ?Model::Gpt55))]
+    #[instrument(name = "openai_client_new", skip(api_key), fields(model = ?Model::Gpt56))]
     pub fn new(api_key: impl Into<String>) -> Result<Self> {
         let api_key = api_key.into();
         if api_key.is_empty() {
@@ -155,13 +163,13 @@ impl OpenAIClient {
 
         let config = OpenAIConfig {
             api_key,
-            model: Model::Gpt55, // Default to GPT-5.5 (latest frontier model)
+            model: Model::Gpt56, // Default to GPT-5.6 (latest flagship alias)
             temperature: 0.0,
             max_tokens: None,
             timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
             max_retries: Some(3),                   // Default: 3 retries with error feedback
             base_url: None,                         // Default: use official OpenAI API
-            thinking_level: Some(ThinkingLevel::Medium), // GPT-5.5 defaults to medium reasoning
+            thinking_level: Some(ThinkingLevel::Medium), // GPT-5.6 defaults to medium reasoning
         };
 
         debug!("OpenAI client created with default configuration");
@@ -186,7 +194,7 @@ impl OpenAIClient {
     /// # Ok(())
     /// # }
     /// ```
-    #[instrument(name = "openai_client_from_env", fields(model = ?Model::Gpt55))]
+    #[instrument(name = "openai_client_from_env", fields(model = ?Model::Gpt56))]
     pub fn from_env() -> Result<Self> {
         let api_key = std::env::var("OPENAI_API_KEY")
             .map_err(|_| RStructorError::api_error("OpenAI", ApiErrorKind::AuthenticationFailed))?;
@@ -196,13 +204,13 @@ impl OpenAIClient {
 
         let config = OpenAIConfig {
             api_key,
-            model: Model::Gpt55, // Default to GPT-5.5 (latest frontier model)
+            model: Model::Gpt56, // Default to GPT-5.6 (latest flagship alias)
             temperature: 0.0,
             max_tokens: None,
             timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
             max_retries: Some(3),                   // Default: 3 retries with error feedback
             base_url: None,                         // Default: use official OpenAI API
-            thinking_level: Some(ThinkingLevel::Medium), // GPT-5.5 defaults to medium reasoning
+            thinking_level: Some(ThinkingLevel::Medium), // GPT-5.6 defaults to medium reasoning
         };
 
         debug!("OpenAI client created with default configuration");
@@ -615,6 +623,11 @@ impl OpenAIClient {
 }
 
 #[cfg(feature = "tools")]
+fn tool_reasoning_effort(model: &str) -> Option<String> {
+    model.starts_with("gpt-5.6").then(|| "none".to_string())
+}
+
+#[cfg(feature = "tools")]
 #[async_trait]
 impl crate::backend::tools::ToolRunner for OpenAIClient {
     async fn run_tool_loop(
@@ -632,15 +645,16 @@ impl crate::backend::tools::ToolRunner for OpenAIClient {
             .unwrap_or("https://api.openai.com/v1");
         let url = format!("{}/chat/completions", base_url);
 
-        // GPT-5.x models require temperature=1.0. `reasoning_effort` combined with
-        // function tools is rejected on /v1/chat/completions, so it is omitted for
-        // the tool loop.
+        // GPT-5.x models require temperature=1.0. GPT-5.6 defaults to medium
+        // reasoning, but Chat Completions function tools require effective
+        // reasoning `none`, so make that override explicit for the 5.6 family.
         let is_gpt5 = self.config.model.as_str().starts_with("gpt-5");
         let effective_temp = if is_gpt5 {
             1.0
         } else {
             self.config.temperature
         };
+        let reasoning_effort = tool_reasoning_effort(self.config.model.as_str());
 
         crate::backend::tools::run_openai_compatible_tools(
             &self.client,
@@ -650,7 +664,7 @@ impl crate::backend::tools::ToolRunner for OpenAIClient {
             self.config.model.as_str(),
             effective_temp,
             self.config.max_tokens,
-            None,
+            reasoning_effort,
             system,
             prompt,
             media,
@@ -921,10 +935,26 @@ mod tests {
     }
 
     #[test]
+    fn default_config_uses_latest_model() {
+        let client = OpenAIClient::new("test-key").unwrap();
+        assert_eq!(client.config.model, Model::Gpt56);
+    }
+
+    #[test]
     fn explicit_timeout_overrides_default() {
         let client = OpenAIClient::new("test-key")
             .unwrap()
             .timeout(Duration::from_secs(10));
         assert_eq!(client.config.timeout, Some(Duration::from_secs(10)));
+    }
+
+    #[cfg(feature = "tools")]
+    #[test]
+    fn gpt56_tool_calls_explicitly_disable_reasoning() {
+        for model in ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
+            assert_eq!(tool_reasoning_effort(model), Some("none".to_string()));
+        }
+        assert_eq!(tool_reasoning_effort("gpt-5.5"), None);
+        assert_eq!(tool_reasoning_effort("gpt-4.1-mini"), None);
     }
 }

--- a/src/backend/streaming.rs
+++ b/src/backend/streaming.rs
@@ -337,11 +337,8 @@ fn repair_json(s: &str) -> Option<String> {
         }
         if out.ends_with(':') {
             // Drop the dangling `"key":` back to the previous `{` or `,`.
-            if let Some(cut) = out.rfind(['{', ',']) {
-                out.truncate(cut + 1);
-            } else {
-                return None;
-            }
+            let cut = out.rfind(['{', ','])?;
+            out.truncate(cut + 1);
             continue;
         }
         break;

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -1224,11 +1224,13 @@ fn extract_model_from_error(error_text: &str) -> Option<String> {
 fn suggest_model(error_text: &str) -> Option<String> {
     // Common model name patterns and their suggestions
     if error_text.contains("gpt") {
-        Some("gpt-5.5".to_string())
+        Some("gpt-5.6".to_string())
     } else if error_text.contains("claude") || error_text.contains("sonnet") {
-        Some("claude-sonnet-4-6".to_string())
+        Some("claude-sonnet-5".to_string())
+    } else if error_text.contains("grok") {
+        Some("grok-4.5".to_string())
     } else if error_text.contains("gemini") {
-        Some("gemini-3.1-pro-preview".to_string())
+        Some("gemini-3.5-flash".to_string())
     } else {
         None
     }
@@ -2902,7 +2904,7 @@ mod tests {
             ApiErrorKind::InvalidModel { model, suggestion } => {
                 assert_eq!(model, "override-model");
                 // "gpt" appears in the (lowercased) error text -> gpt suggestion.
-                assert_eq!(suggestion, Some("gpt-5.5".to_string()));
+                assert_eq!(suggestion, Some("gpt-5.6".to_string()));
             }
             other => panic!("expected InvalidModel, got {:?}", other),
         }
@@ -2919,7 +2921,7 @@ mod tests {
         match kind {
             ApiErrorKind::InvalidModel { model, suggestion } => {
                 assert_eq!(model, "gemini-2.0-flash");
-                assert_eq!(suggestion, Some("gemini-3.1-pro-preview".to_string()));
+                assert_eq!(suggestion, Some("gemini-3.5-flash".to_string()));
             }
             other => panic!("expected InvalidModel, got {:?}", other),
         }
@@ -2967,16 +2969,20 @@ mod tests {
     fn suggest_model_matches_provider_keywords() {
         assert_eq!(
             suggest_model("sonnet is down"),
-            Some("claude-sonnet-4-6".to_string())
+            Some("claude-sonnet-5".to_string())
         );
         assert_eq!(
             suggest_model("claude unavailable"),
-            Some("claude-sonnet-4-6".to_string())
+            Some("claude-sonnet-5".to_string())
         );
-        assert_eq!(suggest_model("gpt is gone"), Some("gpt-5.5".to_string()));
+        assert_eq!(suggest_model("gpt is gone"), Some("gpt-5.6".to_string()));
+        assert_eq!(
+            suggest_model("grok unavailable"),
+            Some("grok-4.5".to_string())
+        );
         assert_eq!(
             suggest_model("gemini missing"),
-            Some("gemini-3.1-pro-preview".to_string())
+            Some("gemini-3.5-flash".to_string())
         );
         assert_eq!(suggest_model("totally unknown provider"), None);
     }

--- a/src/model/instructor.rs
+++ b/src/model/instructor.rs
@@ -88,7 +88,7 @@ use crate::schema::SchemaType;
 ///
 /// // Create a client
 /// let client = OpenAIClient::new("your-api-key")?
-///     .model(OpenAIModel::Gpt55);
+///     .model(OpenAIModel::Gpt56);
 ///
 /// // Get structured data with automatic validation
 /// let product = client.materialize::<ProductInfo>("Describe a laptop").await?;

--- a/tests/anthropic_multimodal_tests.rs
+++ b/tests/anthropic_multimodal_tests.rs
@@ -34,8 +34,7 @@ mod anthropic_multimodal_tests {
         let media = download_media(RUST_LOGO_URL, RUST_LOGO_MIME).await;
         let client = AnthropicClient::from_env()
             .expect("ANTHROPIC_API_KEY must be set for this test")
-            .model(AnthropicModel::ClaudeSonnet46)
-            .temperature(0.0);
+            .model(AnthropicModel::ClaudeSonnet5);
 
         let result: ImageSummary = client
             .materialize_with_media(
@@ -55,8 +54,7 @@ mod anthropic_multimodal_tests {
         let media = media_url(RUST_LOGO_URL, RUST_LOGO_MIME);
         let client = AnthropicClient::from_env()
             .expect("ANTHROPIC_API_KEY must be set for this test")
-            .model(AnthropicModel::ClaudeSonnet46)
-            .temperature(0.0);
+            .model(AnthropicModel::ClaudeSonnet5);
 
         let result: ImageSummary = client
             .materialize_with_media(
@@ -77,8 +75,7 @@ mod anthropic_multimodal_tests {
         let lake_media = media_url(RUST_LOGO_URL, RUST_LOGO_MIME);
         let client = AnthropicClient::from_env()
             .expect("ANTHROPIC_API_KEY must be set for this test")
-            .model(AnthropicModel::ClaudeSonnet46)
-            .temperature(0.0);
+            .model(AnthropicModel::ClaudeSonnet5);
 
         let result: MultiImageSummary = client
             .materialize_with_media(

--- a/tests/grok_multimodal_tests.rs
+++ b/tests/grok_multimodal_tests.rs
@@ -34,7 +34,7 @@ mod grok_multimodal_tests {
         let media = download_media(RUST_LOGO_URL, RUST_LOGO_MIME).await;
         let client = GrokClient::from_env()
             .expect("XAI_API_KEY must be set for this test")
-            .model(GrokModel::Grok43)
+            .model(GrokModel::Grok45)
             .temperature(0.0);
 
         let result: ImageSummary = client
@@ -55,7 +55,7 @@ mod grok_multimodal_tests {
         let media = media_url(RUST_LOGO_URL, RUST_LOGO_MIME);
         let client = GrokClient::from_env()
             .expect("XAI_API_KEY must be set for this test")
-            .model(GrokModel::Grok43)
+            .model(GrokModel::Grok45)
             .temperature(0.0);
 
         let result: ImageSummary = client
@@ -77,7 +77,7 @@ mod grok_multimodal_tests {
         let lake_media = media_url(RUST_LOGO_URL, RUST_LOGO_MIME);
         let client = GrokClient::from_env()
             .expect("XAI_API_KEY must be set for this test")
-            .model(GrokModel::Grok43)
+            .model(GrokModel::Grok45)
             .temperature(0.0);
 
         let result: MultiImageSummary = client

--- a/tests/http_mock_tests.rs
+++ b/tests/http_mock_tests.rs
@@ -607,6 +607,50 @@ struct AddArgs {
     b: i64,
 }
 
+/// GPT-5.6 rejects Chat Completions function tools unless reasoning is disabled.
+/// Verify the compatibility override reaches the serialized HTTP request rather
+/// than only testing the model-name predicate in isolation.
+#[cfg(feature = "tools")]
+#[tokio::test]
+async fn gpt56_tool_request_disables_reasoning() {
+    use rstructor::{RequestExt, Toolbox};
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+
+    let mut server = mockito::Server::new_async().await;
+    let captured: Arc<std::sync::Mutex<Option<Value>>> = Arc::new(std::sync::Mutex::new(None));
+    let sink = captured.clone();
+    let request = server
+        .mock("POST", "/chat/completions")
+        .match_request(move |req| {
+            let body = serde_json::from_str(&req.utf8_lossy_body().unwrap()).unwrap();
+            *sink.lock().unwrap() = Some(body);
+            true
+        })
+        .with_status(200)
+        .with_body(chat_completion("tools are ready"))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let toolbox = Toolbox::new().with(recording_add_tool(Arc::new(AtomicBool::new(false))));
+    let answer = OpenAIClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("gpt-5.6")
+        .with_tools(&toolbox)
+        .run("say hello")
+        .await
+        .unwrap();
+
+    assert_eq!(answer, "tools are ready");
+    request.assert_async().await;
+    let body = captured.lock().unwrap();
+    let body = body.as_ref().expect("request body should be captured");
+    assert_eq!(body["reasoning_effort"], json!("none"));
+    assert_eq!(body["temperature"], json!(1.0));
+}
+
 /// Full OpenAI tool round-trip: the first response asks for a tool call, the loop
 /// executes the (real) tool and feeds the result back as a `role: tool` message
 /// carrying the original `tool_call_id`, and the second response returns the final

--- a/tests/llm_integration_tests.rs
+++ b/tests/llm_integration_tests.rs
@@ -76,7 +76,7 @@ mod llm_integration_tests {
 
         let client = OpenAIClient::new(api_key)
             .expect("Failed to create OpenAI client")
-            .model(OpenAIModel::Gpt55)
+            .model(OpenAIModel::Gpt56)
             .temperature(0.0);
 
         let prompt = "Provide information about the movie Inception";
@@ -104,8 +104,7 @@ mod llm_integration_tests {
 
         let client = AnthropicClient::new(api_key)
             .expect("Failed to create Anthropic client")
-            .model(AnthropicModel::ClaudeSonnet46)
-            .temperature(0.0);
+            .model(AnthropicModel::ClaudeSonnet5);
 
         let prompt = "Provide information about the movie Inception";
         let movie_result = client.materialize::<Movie>(prompt).await;
@@ -130,7 +129,7 @@ mod llm_integration_tests {
         // Read from XAI_API_KEY env var
         let client = GrokClient::from_env()
             .expect("XAI_API_KEY must be set for this test")
-            .model(GrokModel::Grok43)
+            .model(GrokModel::Grok45)
             .temperature(0.0);
 
         let prompt = "Provide information about the movie Inception";

--- a/tests/model_string_test.rs
+++ b/tests/model_string_test.rs
@@ -20,8 +20,17 @@ mod tests {
         let model = OpenAIModel::from_str("gpt-4o-mini").unwrap();
         assert_eq!(model, OpenAIModel::Gpt4OMini);
 
-        let model = OpenAIModel::from_str("gpt-5.5").unwrap();
-        assert_eq!(model, OpenAIModel::Gpt55);
+        let model = OpenAIModel::from_str("gpt-5.6").unwrap();
+        assert_eq!(model, OpenAIModel::Gpt56);
+
+        let model = OpenAIModel::from_str("gpt-5.6-sol").unwrap();
+        assert_eq!(model, OpenAIModel::Gpt56Sol);
+
+        let model = OpenAIModel::from_str("gpt-5.6-terra").unwrap();
+        assert_eq!(model, OpenAIModel::Gpt56Terra);
+
+        let model = OpenAIModel::from_str("gpt-5.6-luna").unwrap();
+        assert_eq!(model, OpenAIModel::Gpt56Luna);
 
         let model = OpenAIModel::from_str("gpt-5.5-pro").unwrap();
         assert_eq!(model, OpenAIModel::Gpt55Pro);
@@ -37,8 +46,11 @@ mod tests {
     #[test]
     fn test_anthropic_model_from_string() {
         // Test known model
-        let model = AnthropicModel::from_string("claude-sonnet-4-6");
-        assert_eq!(model, AnthropicModel::ClaudeSonnet46);
+        let model = AnthropicModel::from_string("claude-sonnet-5");
+        assert_eq!(model, AnthropicModel::ClaudeSonnet5);
+
+        let model = AnthropicModel::from_string("claude-fable-5");
+        assert_eq!(model, AnthropicModel::ClaudeFable5);
 
         let model = AnthropicModel::from_string("claude-opus-4-7");
         assert_eq!(model, AnthropicModel::ClaudeOpus47);
@@ -54,6 +66,7 @@ mod tests {
     #[test]
     fn test_grok_model_as_str() {
         let models = vec![
+            GrokModel::Grok45,
             GrokModel::Grok43,
             GrokModel::Grok420Reasoning,
             GrokModel::Grok420NonReasoning,
@@ -71,6 +84,7 @@ mod tests {
     #[test]
     fn test_grok_model_from_string() {
         let test_strings = vec![
+            "grok-4.5",
             "grok-4.3",
             "grok-4.20-0309-reasoning",
             "grok-4.20-0309-non-reasoning",

--- a/tests/openai_enum_anyof_test.rs
+++ b/tests/openai_enum_anyof_test.rs
@@ -65,7 +65,7 @@ mod openai_enum_anyof_tests {
 
         let client = OpenAIClient::new(api_key)
             .expect("Failed to create OpenAI client")
-            .model(OpenAIModel::Gpt55)
+            .model(OpenAIModel::Gpt56)
             .temperature(0.0);
 
         let result = client

--- a/tests/openai_multimodal_tests.rs
+++ b/tests/openai_multimodal_tests.rs
@@ -34,7 +34,7 @@ mod openai_multimodal_tests {
         let media = download_media(RUST_LOGO_URL, RUST_LOGO_MIME).await;
         let client = OpenAIClient::from_env()
             .expect("OPENAI_API_KEY must be set for this test")
-            .model(OpenAIModel::Gpt55)
+            .model(OpenAIModel::Gpt56)
             .temperature(0.0);
 
         let result: ImageSummary = client
@@ -55,7 +55,7 @@ mod openai_multimodal_tests {
         let media = media_url(RUST_LOGO_URL, RUST_LOGO_MIME);
         let client = OpenAIClient::from_env()
             .expect("OPENAI_API_KEY must be set for this test")
-            .model(OpenAIModel::Gpt55)
+            .model(OpenAIModel::Gpt56)
             .temperature(0.0);
 
         let result: ImageSummary = client
@@ -77,7 +77,7 @@ mod openai_multimodal_tests {
         let lake_media = media_url(RUST_LOGO_URL, RUST_LOGO_MIME);
         let client = OpenAIClient::from_env()
             .expect("OPENAI_API_KEY must be set for this test")
-            .model(OpenAIModel::Gpt55)
+            .model(OpenAIModel::Gpt56)
             .temperature(0.0);
 
         let result: MultiImageSummary = client

--- a/tests/provider_offline_tests.rs
+++ b/tests/provider_offline_tests.rs
@@ -187,6 +187,10 @@ macro_rules! assert_model_roundtrip {
 fn openai_model_roundtrip_all_variants() {
     use OpenAIModel::*;
     let table: &[(OpenAIModel, &str)] = &[
+        (Gpt56, "gpt-5.6"),
+        (Gpt56Sol, "gpt-5.6-sol"),
+        (Gpt56Terra, "gpt-5.6-terra"),
+        (Gpt56Luna, "gpt-5.6-luna"),
         (Gpt55Pro, "gpt-5.5-pro"),
         (Gpt55, "gpt-5.5"),
         (Gpt54Pro, "gpt-5.4-pro"),
@@ -214,7 +218,7 @@ fn openai_model_roundtrip_all_variants() {
         (Gpt4, "gpt-4"),
         (Gpt35Turbo, "gpt-3.5-turbo"),
     ];
-    assert_eq!(table.len(), 26, "OpenAI variant table drifted from source");
+    assert_eq!(table.len(), 30, "OpenAI variant table drifted from source");
     for (variant, id) in table {
         assert_model_roundtrip!(OpenAIModel, variant.clone(), id);
     }
@@ -224,6 +228,8 @@ fn openai_model_roundtrip_all_variants() {
 fn anthropic_model_roundtrip_all_variants() {
     use AnthropicModel::*;
     let table: &[(AnthropicModel, &str)] = &[
+        (ClaudeFable5, "claude-fable-5"),
+        (ClaudeSonnet5, "claude-sonnet-5"),
         (ClaudeOpus48, "claude-opus-4-8"),
         (ClaudeOpus47, "claude-opus-4-7"),
         (ClaudeSonnet46, "claude-sonnet-4-6"),
@@ -232,8 +238,6 @@ fn anthropic_model_roundtrip_all_variants() {
         (ClaudeHaiku45, "claude-haiku-4-5-20251001"),
         (ClaudeSonnet45, "claude-sonnet-4-5-20250929"),
         (ClaudeOpus41, "claude-opus-4-1-20250805"),
-        (ClaudeOpus4, "claude-opus-4-20250514"),
-        (ClaudeSonnet4, "claude-sonnet-4-20250514"),
     ];
     assert_eq!(
         table.len(),
@@ -281,13 +285,14 @@ fn gemini_model_roundtrip_all_variants() {
 fn grok_model_roundtrip_all_variants() {
     use GrokModel::*;
     let table: &[(GrokModel, &str)] = &[
+        (Grok45, "grok-4.5"),
         (Grok43, "grok-4.3"),
         (Grok420Reasoning, "grok-4.20-0309-reasoning"),
         (Grok420NonReasoning, "grok-4.20-0309-non-reasoning"),
         (Grok420MultiAgent, "grok-4.20-multi-agent-0309"),
         (GrokBuild01, "grok-build-0.1"),
     ];
-    assert_eq!(table.len(), 5, "Grok variant table drifted from source");
+    assert_eq!(table.len(), 6, "Grok variant table drifted from source");
     for (variant, id) in table {
         assert_model_roundtrip!(GrokModel, variant.clone(), id);
     }

--- a/tests/timeout_tests.rs
+++ b/tests/timeout_tests.rs
@@ -35,7 +35,7 @@ mod timeout_tests {
         // Test with a very short timeout (should likely timeout)
         let client = OpenAIClient::new(api_key)
             .expect("Failed to create OpenAI client")
-            .model(OpenAIModel::Gpt55)
+            .model(OpenAIModel::Gpt56)
             .temperature(0.0)
             .timeout(Duration::from_millis(1)); // 1ms timeout - should timeout
 
@@ -61,7 +61,7 @@ mod timeout_tests {
 
         let _client = OpenAIClient::new(api_key)
             .expect("Failed to create OpenAI client")
-            .model(OpenAIModel::Gpt55)
+            .model(OpenAIModel::Gpt56)
             .temperature(0.5)
             .max_tokens(100)
             .timeout(Duration::from_secs(2)); // 2 second timeout for unit tests
@@ -81,8 +81,7 @@ mod timeout_tests {
         // Test with a very short timeout (should likely timeout)
         let client = AnthropicClient::new(api_key)
             .expect("Failed to create Anthropic client")
-            .model(AnthropicModel::ClaudeSonnet46)
-            .temperature(0.0)
+            .model(AnthropicModel::ClaudeSonnet5)
             .timeout(Duration::from_millis(1)); // 1ms timeout - should timeout
 
         // Try to make a request - it should timeout
@@ -108,7 +107,7 @@ mod timeout_tests {
 
         let _client = AnthropicClient::new(api_key)
             .expect("Failed to create Anthropic client")
-            .model(AnthropicModel::ClaudeSonnet46)
+            .model(AnthropicModel::ClaudeSonnet5)
             .temperature(0.5)
             .max_tokens(100)
             .timeout(Duration::from_secs(2)); // 2 second timeout for unit tests
@@ -150,7 +149,7 @@ mod timeout_tests {
         // Test with empty string to use XAI_API_KEY env var
         let client = GrokClient::from_env()
             .expect("XAI_API_KEY must be set for this test")
-            .model(GrokModel::Grok43)
+            .model(GrokModel::Grok45)
             .temperature(0.0)
             .timeout(Duration::from_millis(1)); // 1ms timeout - should timeout
 
@@ -175,7 +174,7 @@ mod timeout_tests {
         // Test with empty string to use XAI_API_KEY env var
         let _client = GrokClient::from_env()
             .expect("XAI_API_KEY must be set for this test")
-            .model(GrokModel::Grok43)
+            .model(GrokModel::Grok45)
             .temperature(0.5)
             .max_tokens(100)
             .timeout(Duration::from_secs(2)); // 2 second timeout for unit tests


### PR DESCRIPTION
## What changed

- add the current OpenAI GPT-5.6 family and make `gpt-5.6` the default
- add Claude Sonnet 5 and Claude Fable 5, make Sonnet 5 the default, and remove retired Claude 4.0 variants
- add Grok 4.5 and make it the xAI default
- confirm Gemini 3.5 Flash remains the current stable default
- update model suggestions, examples, tests, and official documentation links
- normalize provider-specific sampling/reasoning settings required by the latest APIs
- adopt the current Clippy idiom in streaming JSON repair

## Compatibility details

- GPT-5.6 Chat Completions tool requests explicitly send `reasoning_effort: "none"`
- Claude 5 and current Opus requests use the provider's required default sampling temperature
- older available model variants remain selectable

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- live structured-output and multimodal tests against OpenAI, Anthropic, xAI, and Gemini
- request-body regression test for GPT-5.6 tool compatibility
