### PR TITLE
Add path-aware structured decode errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ categories = [
 [dependencies]
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+serde_path_to_error = { version = "0.1.20", optional = true }
 async-trait = "0.1.89"
 tokio = { version = "1.52.1", features = [
   "rt",
@@ -77,7 +78,7 @@ logging = ["tracing-subscriber", "tracing-futures"]
 # Not meant to be enabled directly — enable a provider feature instead. Disabling
 # all providers yields a dependency-light, schema-only build (derive + schema, no
 # tokio/reqwest) suitable for generating JSON Schema without making API calls.
-_client = ["reqwest", "tokio", "base64"]
+_client = ["reqwest", "tokio", "base64", "dep:serde_path_to_error"]
 # Opt-in streaming: text (`generate_stream`), object snapshots
 # (`materialize_stream`), and list streaming (`materialize_iter`). Enable a
 # provider feature too for the HTTP stack.
@@ -85,10 +86,10 @@ streaming = ["_client", "reqwest/stream", "futures-util", "async-stream"]
 # Opt-in tool/function calling (`Tool`, `Toolbox`, `client.with_tools(..).run(..)`).
 # The agentic loop is implemented for all providers (OpenAI, Anthropic, Grok, Gemini).
 tools = ["_client"]
-# Opt-in in-memory mock client (`MockClient`) for offline unit testing. Pulls in no
-# extra dependencies and works in schema-only builds (no `_client`); the streaming
-# and tool overrides additionally require the `streaming` / `tools` features.
-mock = []
+# Opt-in in-memory mock client (`MockClient`) for offline unit testing. Pulls in
+# only the path-aware decoder and works without `_client`; the streaming and tool
+# overrides additionally require the `streaming` / `tools` features.
+mock = ["dep:serde_path_to_error"]
 
 [[example]]
 name = "streaming_example"

--- a/README.md
+++ b/README.md
@@ -500,9 +500,10 @@ async fn extracts_a_movie() {
 Script multiple responses with `with_response`/`with_responses` (a FIFO queue), branch
 on the request with `with_responder`, simulate the validation re-ask loop with
 `with_retries`, attach token usage with `with_usage`, and assert on captured requests via
-`requests()` / `last_request()`. The `mock` feature pulls in no extra dependencies and
-works even in a schema-only build; streaming and tool-loop mocking light up when the
-`streaming` / `tools` features are also enabled. See `examples/mock_testing_example.rs`.
+`requests()` / `last_request()`. The `mock` feature pulls in only the lightweight
+path-aware decoder and works without the HTTP client; streaming and tool-loop mocking
+light up when the `streaming` / `tools` features are also enabled. See
+`examples/mock_testing_example.rs`.
 
 ## Feature Flags
 

--- a/rstructor_derive/src/parsers/array_parser.rs
+++ b/rstructor_derive/src/parsers/array_parser.rs
@@ -2,65 +2,6 @@ use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
 use syn::{Expr, ExprArray, Lit, Token, bracketed, parse::Parse};
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use quote::quote;
-    use syn::parse_str;
-
-    // Test the ArrayAttr structure directly
-    #[test]
-    fn test_array_attr_parse() {
-        // Create a string array
-        let input = "[\"apple\", \"banana\", \"cherry\"]";
-        let array_expr: syn::ExprArray = parse_str(input).unwrap();
-
-        // Create an ArrayAttr
-        let array_attr = ArrayAttr {
-            expr_array: array_expr,
-        };
-
-        // Check the array elements
-        assert_eq!(array_attr.expr_array.elems.len(), 3);
-    }
-
-    #[test]
-    fn test_array_attr_types() {
-        // Test with different types
-        let string_array = "[\"apple\", \"banana\"]";
-        let int_array = "[1, 2, 3]";
-        let bool_array = "[true, false]";
-        let mixed_array = "[\"string\", 42, true]";
-
-        // Parse each type
-        let string_expr: syn::ExprArray = parse_str(string_array).unwrap();
-        let int_expr: syn::ExprArray = parse_str(int_array).unwrap();
-        let bool_expr: syn::ExprArray = parse_str(bool_array).unwrap();
-        let mixed_expr: syn::ExprArray = parse_str(mixed_array).unwrap();
-
-        // Check lengths
-        assert_eq!(string_expr.elems.len(), 2);
-        assert_eq!(int_expr.elems.len(), 3);
-        assert_eq!(bool_expr.elems.len(), 2);
-        assert_eq!(mixed_expr.elems.len(), 3);
-    }
-
-    #[test]
-    fn test_tokenize_array_elements() {
-        // Test tokenizing array elements for strings
-        let string_array = "[\"apple\", \"banana\"]";
-        let string_expr: syn::ExprArray = parse_str(string_array).unwrap();
-
-        // Check first element using quote
-        let first_elem = &string_expr.elems[0];
-        let tokens = quote! { #first_elem };
-        let token_string = tokens.to_string();
-
-        // The tokenized string should include quotes
-        assert!(token_string.contains("apple"));
-    }
-}
-
 /// Utility struct to parse array literal expressions
 /// Handles array literals like [1, 2, 3] or ["a", "b", "c"]
 pub struct ArrayAttr {
@@ -152,5 +93,64 @@ pub fn parse_array_literal(value: &syn::parse::ParseBuffer) -> Option<Vec<TokenS
         Some(tokens)
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::quote;
+    use syn::parse_str;
+
+    // Test the ArrayAttr structure directly
+    #[test]
+    fn test_array_attr_parse() {
+        // Create a string array
+        let input = "[\"apple\", \"banana\", \"cherry\"]";
+        let array_expr: syn::ExprArray = parse_str(input).unwrap();
+
+        // Create an ArrayAttr
+        let array_attr = ArrayAttr {
+            expr_array: array_expr,
+        };
+
+        // Check the array elements
+        assert_eq!(array_attr.expr_array.elems.len(), 3);
+    }
+
+    #[test]
+    fn test_array_attr_types() {
+        // Test with different types
+        let string_array = "[\"apple\", \"banana\"]";
+        let int_array = "[1, 2, 3]";
+        let bool_array = "[true, false]";
+        let mixed_array = "[\"string\", 42, true]";
+
+        // Parse each type
+        let string_expr: syn::ExprArray = parse_str(string_array).unwrap();
+        let int_expr: syn::ExprArray = parse_str(int_array).unwrap();
+        let bool_expr: syn::ExprArray = parse_str(bool_array).unwrap();
+        let mixed_expr: syn::ExprArray = parse_str(mixed_array).unwrap();
+
+        // Check lengths
+        assert_eq!(string_expr.elems.len(), 2);
+        assert_eq!(int_expr.elems.len(), 3);
+        assert_eq!(bool_expr.elems.len(), 2);
+        assert_eq!(mixed_expr.elems.len(), 3);
+    }
+
+    #[test]
+    fn test_tokenize_array_elements() {
+        // Test tokenizing array elements for strings
+        let string_array = "[\"apple\", \"banana\"]";
+        let string_expr: syn::ExprArray = parse_str(string_array).unwrap();
+
+        // Check first element using quote
+        let first_elem = &string_expr.elems[0];
+        let tokens = quote! { #first_elem };
+        let token_string = tokens.to_string();
+
+        // The tokenized string should include quotes
+        assert!(token_string.contains("apple"));
     }
 }

--- a/rstructor_derive/tests/enum_date_format_tests.rs
+++ b/rstructor_derive/tests/enum_date_format_tests.rs
@@ -70,7 +70,7 @@ fn test_externally_tagged_enum_naive_date_format() {
         .find(|v| {
             v["properties"]
                 .as_object()
-                .map_or(false, |props| props.contains_key("SingleDay"))
+                .is_some_and(|props| props.contains_key("SingleDay"))
         })
         .expect("Should find SingleDay variant");
 
@@ -102,7 +102,7 @@ fn test_externally_tagged_enum_naive_datetime_format() {
         .find(|v| {
             v["properties"]
                 .as_object()
-                .map_or(false, |props| props.contains_key("Timestamped"))
+                .is_some_and(|props| props.contains_key("Timestamped"))
         })
         .expect("Should find Timestamped variant");
 
@@ -167,7 +167,7 @@ fn test_enum_vec_naive_date_items_format() {
         .find(|v| {
             v["properties"]
                 .as_object()
-                .map_or(false, |props| props.contains_key("Recurring"))
+                .is_some_and(|props| props.contains_key("Recurring"))
         })
         .expect("Should find Recurring variant");
 

--- a/rstructor_derive/tests/internally_tagged_tests.rs
+++ b/rstructor_derive/tests/internally_tagged_tests.rs
@@ -427,6 +427,7 @@ struct RecursiveNode {
     #[llm(description = "Node label")]
     label: String,
     #[llm(description = "Child nodes")]
+    #[allow(clippy::vec_box)] // Explicitly exercises schema generation through Vec<Box<T>>.
     children: Vec<Box<RecursiveNode>>,
 }
 

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -980,8 +980,7 @@ impl LLMClient for GeminiClient {
             if let Some(ref info) = adjacently_tagged_info {
                 crate::backend::utils::transform_internally_to_adjacently_tagged(&mut value, info);
             }
-            let item: T = serde_json::from_value(value)
-                .map_err(|e| RStructorError::SerializationError(e.to_string()))?;
+            let item: T = crate::decode::output_from_value(value)?;
             item.validate()?;
             Ok(item)
         };

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -7,8 +7,8 @@
 //! deserialize + [`Instructor::validate`](crate::Instructor::validate) round-trip:
 //! you can exercise schema/validation failures, not just happy paths.
 //!
-//! This module is only compiled with the `mock` feature. It pulls in **no extra
-//! dependencies** and works even in a schema-only build
+//! This module is only compiled with the `mock` feature. It pulls in only the
+//! lightweight path-aware decoder and works without the HTTP client
 //! (`default-features = false, features = ["derive", "mock"]`); the streaming and
 //! tool-calling overrides additionally require the `streaming` / `tools` features.
 //!
@@ -123,6 +123,16 @@ fn clone_error(e: &RStructorError) -> RStructorError {
         RStructorError::ValidationError(s) => RStructorError::ValidationError(s.clone()),
         RStructorError::SchemaError(s) => RStructorError::SchemaError(s.clone()),
         RStructorError::SerializationError(s) => RStructorError::SerializationError(s.clone()),
+        RStructorError::OutputDecodeError { path, message } => RStructorError::OutputDecodeError {
+            path: path.clone(),
+            message: message.clone(),
+        },
+        RStructorError::ToolArgumentDecodeError { path, message } => {
+            RStructorError::ToolArgumentDecodeError {
+                path: path.clone(),
+                message: message.clone(),
+            }
+        }
         RStructorError::Timeout => RStructorError::Timeout,
         RStructorError::Unsupported(s) => RStructorError::Unsupported(s.clone()),
         // Sources below don't implement Clone; preserve the message instead.
@@ -561,18 +571,12 @@ impl MockClient {
     }
 }
 
-/// Mirror of the real `parse_and_validate_response`: deserialize then validate,
-/// mapping a JSON parse failure to a [`ValidationError`](RStructorError::ValidationError)
-/// (matching live providers so tests behave identically against either).
+/// Mirror of the real `parse_and_validate_response`: deserialize then validate.
 fn parse_and_validate<T>(raw: &str) -> Result<T>
 where
     T: Instructor + DeserializeOwned,
 {
-    let value: T = serde_json::from_str(raw).map_err(|e| {
-        RStructorError::ValidationError(format!(
-            "Failed to parse response as JSON: {e}\nPartial JSON: {raw}"
-        ))
-    })?;
+    let value: T = crate::decode::output_from_str(raw)?;
     value.validate()?;
     Ok(value)
 }
@@ -691,11 +695,7 @@ impl LLMClient for MockClient {
                 MockResponse::Error(e) => Err(e)?,
             };
             // Emit one Partial snapshot, then the validated Complete value.
-            let snapshot: Value = serde_json::from_str(&s).map_err(|e| {
-                RStructorError::ValidationError(format!(
-                    "Failed to parse response as JSON: {e}\nPartial JSON: {s}"
-                ))
-            })?;
+            let snapshot: Value = crate::decode::output_from_str(&s)?;
             yield StreamedObject::Partial(snapshot);
             let value: T = parse_and_validate::<T>(&s)?;
             yield StreamedObject::Complete(value);
@@ -723,11 +723,7 @@ impl LLMClient for MockClient {
                 MockResponse::Text(s) => s,
                 MockResponse::Error(e) => Err(e)?,
             };
-            let root: Value = serde_json::from_str(&s).map_err(|e| {
-                RStructorError::ValidationError(format!(
-                    "Failed to parse response as JSON: {e}\nPartial JSON: {s}"
-                ))
-            })?;
+            let root: Value = crate::decode::output_from_str(&s)?;
             // Accept either a bare top-level array or an `{ "items": [...] }` wrapper.
             let items: Vec<Value> = if let Some(arr) = root.as_array() {
                 arr.clone()
@@ -844,10 +840,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bad_json_is_validation_error() {
+    async fn bad_json_is_output_decode_error() {
         let client = MockClient::new().with_response("not json");
         let err = client.materialize::<Movie>("p").await.unwrap_err();
-        assert!(matches!(err, RStructorError::ValidationError(_)));
+        assert!(matches!(
+            err,
+            RStructorError::OutputDecodeError { path, .. } if path == "$"
+        ));
     }
 
     #[tokio::test]

--- a/src/backend/streaming.rs
+++ b/src/backend/streaming.rs
@@ -757,8 +757,7 @@ where
 /// Default per-element finalizer for [`iter_stream`]: deserialize a streamed array
 /// element into `T` and run its validation.
 pub(crate) fn finalize_item<T: Instructor + DeserializeOwned>(value: Value) -> Result<T> {
-    let item: T = serde_json::from_value(value)
-        .map_err(|e| RStructorError::SerializationError(e.to_string()))?;
+    let item: T = crate::decode::output_from_value(value)?;
     item.validate()?;
     Ok(item)
 }
@@ -960,12 +959,15 @@ mod array_tests {
             "expected ValidationError, got {err:?}"
         );
 
-        // Wrong type for `title` fails deserialization → SerializationError.
+        // Wrong type for `title` reports the exact output path.
         let err = finalize_item::<Ticket>(json!({"title": 123, "priority": 1}))
             .expect_err("non-string title should fail deserialization");
         assert!(
-            matches!(err, RStructorError::SerializationError(_)),
-            "expected SerializationError, got {err:?}"
+            matches!(
+                err,
+                RStructorError::OutputDecodeError { ref path, .. } if path == "$.title"
+            ),
+            "expected path-aware OutputDecodeError, got {err:?}"
         );
 
         // Sanity: a valid element succeeds.

--- a/src/backend/tools.rs
+++ b/src/backend/tools.rs
@@ -75,8 +75,7 @@ impl<T: Tool> DynTool for T {
     }
 
     async fn invoke_json(&self, args: Value) -> Result<Value> {
-        let typed: T::Args = serde_json::from_value(args)
-            .map_err(|e| RStructorError::SerializationError(e.to_string()))?;
+        let typed: T::Args = crate::decode::tool_arguments_from_value(args)?;
         self.invoke(typed).await
     }
 }
@@ -355,14 +354,19 @@ pub(crate) async fn run_openai_compatible_tools(
                 .and_then(|f| f.get("arguments"))
                 .and_then(Value::as_str)
                 .unwrap_or("{}");
-            let args: Value = serde_json::from_str(args_str).unwrap_or_else(|_| json!({}));
 
             debug!(tool = name, "Model requested tool call");
             let result = match toolbox.get(name) {
-                Some(tool) => tool.invoke_json(args).await.unwrap_or_else(|e| {
-                    warn!(tool = name, error = %e, "Tool returned an error");
-                    json!({ "error": e.to_string() })
-                }),
+                Some(tool) => {
+                    let invocation = match crate::decode::tool_arguments_from_str(args_str) {
+                        Ok(args) => tool.invoke_json(args).await,
+                        Err(error) => Err(error),
+                    };
+                    invocation.unwrap_or_else(|error| {
+                        warn!(tool = name, error = %error, "Tool returned an error");
+                        json!({ "error": error.to_string() })
+                    })
+                }
                 None => {
                     warn!(tool = name, "Model called an unknown tool");
                     json!({ "error": format!("unknown tool: {name}") })

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -1042,20 +1042,13 @@ where
     T: Instructor + DeserializeOwned,
 {
     // Parse the JSON content into our target type
-    let result: T = match serde_json::from_str(raw_response) {
+    let result: T = match crate::decode::output_from_str(raw_response) {
         Ok(parsed) => parsed,
-        Err(e) => {
-            let error_msg = format!(
-                "Failed to parse response as JSON: {}\nPartial JSON: {}",
-                e, raw_response
-            );
-            error!(
-                error = %e,
-                content = %raw_response,
-                "JSON parsing error"
-            );
+        Err(error) => {
+            let error_msg = error.to_string();
+            error!(error = %error, "Structured output decoding failed");
             return Err((
-                RStructorError::ValidationError(error_msg.clone()),
+                error,
                 Some(ValidationFailureContext::new(
                     error_msg,
                     raw_response.to_string(),

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,0 +1,264 @@
+//! Path-aware deserialization for structured model output and tool arguments.
+
+use serde::de::DeserializeOwned;
+#[cfg(any(feature = "streaming", feature = "tools", test))]
+use serde_json::Value;
+use serde_path_to_error::{Error as PathError, Path, Segment};
+
+use crate::error::{RStructorError, Result};
+
+#[derive(Clone, Copy)]
+enum DecodeTarget {
+    Output,
+    #[cfg(feature = "tools")]
+    ToolArguments,
+}
+
+/// Deserialize structured model output while retaining the failing field path.
+///
+/// `serde_path_to_error::deserialize` consumes one JSON value but, unlike
+/// `serde_json::from_str`, does not reject trailing input. The explicit `end`
+/// call preserves the crate's existing strict whole-document behavior.
+pub(crate) fn output_from_str<T: DeserializeOwned>(raw: &str) -> Result<T> {
+    from_str(raw, DecodeTarget::Output)
+}
+
+#[cfg(feature = "tools")]
+pub(crate) fn tool_arguments_from_str<T: DeserializeOwned>(raw: &str) -> Result<T> {
+    from_str(raw, DecodeTarget::ToolArguments)
+}
+
+fn from_str<T: DeserializeOwned>(raw: &str, target: DecodeTarget) -> Result<T> {
+    let mut deserializer = serde_json::Deserializer::from_str(raw);
+    let value = serde_path_to_error::deserialize(&mut deserializer)
+        .map_err(|error| map_path_error(error, target))?;
+    deserializer
+        .end()
+        .map_err(|error| map_root_error(error, target))?;
+    Ok(value)
+}
+
+/// Deserialize a pre-parsed structured output value while retaining the field path.
+#[cfg(any(feature = "streaming", test))]
+pub(crate) fn output_from_value<T: DeserializeOwned>(value: Value) -> Result<T> {
+    serde_path_to_error::deserialize(value)
+        .map_err(|error| map_path_error(error, DecodeTarget::Output))
+}
+
+/// Deserialize tool-call arguments while retaining the failing field path.
+#[cfg(feature = "tools")]
+pub(crate) fn tool_arguments_from_value<T: DeserializeOwned>(value: Value) -> Result<T> {
+    serde_path_to_error::deserialize(value)
+        .map_err(|error| map_path_error(error, DecodeTarget::ToolArguments))
+}
+
+fn map_path_error(error: PathError<serde_json::Error>, target: DecodeTarget) -> RStructorError {
+    let path = json_path(error.path());
+    map_error(path, error.inner().to_string(), target)
+}
+
+fn map_root_error(error: serde_json::Error, target: DecodeTarget) -> RStructorError {
+    map_error("$".to_string(), error.to_string(), target)
+}
+
+fn map_error(path: String, message: String, target: DecodeTarget) -> RStructorError {
+    match target {
+        DecodeTarget::Output => RStructorError::OutputDecodeError { path, message },
+        #[cfg(feature = "tools")]
+        DecodeTarget::ToolArguments => RStructorError::ToolArgumentDecodeError { path, message },
+    }
+}
+
+/// Render Serde's structured path as an unambiguous JSONPath-style location.
+///
+/// Struct fields and identifier-like map keys use dot notation. Other map keys
+/// use JSON-escaped bracket notation, so keys such as `BRK.B` remain one segment.
+fn json_path(path: &Path) -> String {
+    let mut rendered = String::from("$");
+    for segment in path {
+        match segment {
+            Segment::Seq { index } => rendered.push_str(&format!("[{index}]")),
+            Segment::Map { key } => push_key(&mut rendered, key),
+            Segment::Enum { variant } => push_key(&mut rendered, variant),
+            Segment::Unknown => rendered.push_str("[\"?\"]"),
+        }
+    }
+    rendered
+}
+
+fn push_key(path: &mut String, key: &str) {
+    if is_identifier(key) {
+        path.push('.');
+        path.push_str(key);
+    } else {
+        path.push('[');
+        path.push_str(
+            &serde_json::to_string(key).expect("serializing a Rust string to JSON cannot fail"),
+        );
+        path.push(']');
+    }
+}
+
+fn is_identifier(key: &str) -> bool {
+    let mut chars = key.chars();
+    matches!(chars.next(), Some(first) if first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|character| character == '_' || character.is_ascii_alphanumeric())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use serde::Deserialize;
+    use serde_json::json;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Portfolio {
+        portfolio_id: String,
+        positions: Vec<Position>,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Position {
+        symbol: String,
+        quantity: i64,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct Book {
+        #[serde(rename = "holdings")]
+        _holdings: BTreeMap<String, Position>,
+    }
+
+    #[test]
+    fn output_string_reports_nested_sequence_path() {
+        let raw = include_str!("../tests/fixtures/structured/portfolio_invalid_quantity.json");
+        let error = output_from_str::<Portfolio>(raw).unwrap_err();
+
+        match error {
+            RStructorError::OutputDecodeError { path, message } => {
+                assert_eq!(path, "$.positions[1].quantity");
+                assert!(message.contains("invalid type"));
+                assert!(!message.contains("HF-ALPHA-001"));
+            }
+            other => panic!("expected OutputDecodeError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn output_value_reports_nested_sequence_path() {
+        let value: Value = serde_json::from_str(include_str!(
+            "../tests/fixtures/structured/portfolio_invalid_quantity.json"
+        ))
+        .unwrap();
+        let error = output_from_value::<Portfolio>(value).unwrap_err();
+
+        assert!(matches!(
+            error,
+            RStructorError::OutputDecodeError { path, .. }
+                if path == "$.positions[1].quantity"
+        ));
+    }
+
+    #[test]
+    fn complex_map_keys_use_escaped_bracket_notation() {
+        let value = json!({
+            "holdings": {
+                "BRK.B": {
+                    "symbol": "BRK.B",
+                    "quantity": "one hundred"
+                }
+            }
+        });
+        let error = output_from_value::<Book>(value).unwrap_err();
+
+        assert!(matches!(
+            error,
+            RStructorError::OutputDecodeError { path, .. }
+                if path == "$.holdings[\"BRK.B\"].quantity"
+        ));
+    }
+
+    #[test]
+    fn malformed_json_reports_the_active_nested_path() {
+        let raw = r#"{"portfolio_id":"HF-ALPHA-001","positions":["#;
+        let error = output_from_str::<Portfolio>(raw).unwrap_err();
+        assert!(
+            matches!(
+                error,
+                RStructorError::OutputDecodeError { ref path, .. }
+                    if path == "$.positions"
+            ),
+            "unexpected malformed-JSON error: {error:?}"
+        );
+    }
+
+    #[test]
+    fn trailing_json_reports_the_root() {
+        let raw = r#"{"portfolio_id":"HF-ALPHA-001","positions":[]} trailing"#;
+        let error = output_from_str::<Portfolio>(raw).unwrap_err();
+        assert!(
+            matches!(
+                error,
+                RStructorError::OutputDecodeError { ref path, .. } if path == "$"
+            ),
+            "unexpected trailing-input error: {error:?}"
+        );
+    }
+
+    #[test]
+    fn valid_output_still_deserializes() {
+        let raw = include_str!("../tests/fixtures/structured/portfolio_valid.json");
+        let portfolio = output_from_str::<Portfolio>(raw).unwrap();
+
+        assert_eq!(portfolio.portfolio_id, "HF-ALPHA-001");
+        assert_eq!(portfolio.positions[1].symbol, "ESU6");
+        assert_eq!(portfolio.positions[1].quantity, -240);
+    }
+
+    #[cfg(feature = "tools")]
+    #[test]
+    fn tool_arguments_have_a_phase_specific_error() {
+        #[derive(Debug, Deserialize)]
+        struct RebalanceArgs {
+            #[serde(rename = "order")]
+            _order: RebalanceOrder,
+        }
+
+        #[derive(Debug, Deserialize)]
+        struct RebalanceOrder {
+            #[serde(rename = "quantity")]
+            _quantity: i64,
+        }
+
+        let error = tool_arguments_from_value::<RebalanceArgs>(json!({
+            "order": { "quantity": "ten thousand shares" }
+        }))
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RStructorError::ToolArgumentDecodeError { path, .. }
+                if path == "$.order.quantity"
+        ));
+    }
+
+    #[cfg(feature = "tools")]
+    #[test]
+    fn malformed_tool_arguments_report_the_active_path() {
+        let error = tool_arguments_from_str::<Value>(r#"{"order":"#).unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                RStructorError::ToolArgumentDecodeError {
+                    ref path,
+                    ref message,
+                } if path == "$.order" && message.contains("EOF")
+            ),
+            "unexpected malformed-tool-argument error: {error:?}"
+        );
+    }
+}

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -308,6 +308,24 @@ pub enum RStructorError {
     #[error("Serialization error: {0}")]
     SerializationError(String),
 
+    /// Structured model output could not be decoded into the requested Rust type.
+    #[error("Failed to decode structured output at {path}: {message}")]
+    OutputDecodeError {
+        /// JSONPath-style location of the first value that failed to decode.
+        path: String,
+        /// Serde's explanation of the type or JSON syntax mismatch.
+        message: String,
+    },
+
+    /// Tool-call arguments could not be decoded into the tool's argument type.
+    #[error("Failed to decode tool arguments at {path}: {message}")]
+    ToolArgumentDecodeError {
+        /// JSONPath-style location of the first argument that failed to decode.
+        path: String,
+        /// Serde's explanation of the type or JSON syntax mismatch.
+        message: String,
+    },
+
     /// Operation timed out
     #[error("Timeout error")]
     Timeout,
@@ -432,6 +450,26 @@ impl PartialEq for RStructorError {
             (Self::ValidationError(a), Self::ValidationError(b)) => a == b,
             (Self::SchemaError(a), Self::SchemaError(b)) => a == b,
             (Self::SerializationError(a), Self::SerializationError(b)) => a == b,
+            (
+                Self::OutputDecodeError {
+                    path: path_a,
+                    message: message_a,
+                },
+                Self::OutputDecodeError {
+                    path: path_b,
+                    message: message_b,
+                },
+            ) => path_a == path_b && message_a == message_b,
+            (
+                Self::ToolArgumentDecodeError {
+                    path: path_a,
+                    message: message_a,
+                },
+                Self::ToolArgumentDecodeError {
+                    path: path_b,
+                    message: message_b,
+                },
+            ) => path_a == path_b && message_a == message_b,
             (Self::Unsupported(a), Self::Unsupported(b)) => a == b,
             (Self::Timeout, Self::Timeout) => true,
             // HttpError and JsonError don't implement PartialEq, so we always return false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@
 extern crate self as rstructor;
 
 mod backend;
+#[cfg(any(feature = "_client", feature = "mock"))]
+mod decode;
 pub mod error;
 #[cfg(feature = "logging")]
 pub mod logging;

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -280,6 +280,20 @@ mod error_tests {
         assert!(!RStructorError::ValidationError("test".into()).is_retryable());
         assert!(!RStructorError::SchemaError("test".into()).is_retryable());
         assert!(!RStructorError::SerializationError("test".into()).is_retryable());
+        assert!(
+            !RStructorError::OutputDecodeError {
+                path: "$.positions[1].quantity".into(),
+                message: "invalid type".into(),
+            }
+            .is_retryable()
+        );
+        assert!(
+            !RStructorError::ToolArgumentDecodeError {
+                path: "$.order.quantity".into(),
+                message: "invalid type".into(),
+            }
+            .is_retryable()
+        );
     }
 
     #[test]
@@ -309,6 +323,41 @@ mod error_tests {
         let err = RStructorError::SerializationError("Failed to serialize".to_string());
         let err_string = format!("{}", err);
         assert_eq!(err_string, "Serialization error: Failed to serialize");
+    }
+
+    #[test]
+    fn test_path_aware_decode_error_display_and_equality() {
+        let output = RStructorError::OutputDecodeError {
+            path: "$.positions[1].quantity".to_string(),
+            message: "invalid type: string, expected i64".to_string(),
+        };
+        assert_eq!(
+            output.to_string(),
+            "Failed to decode structured output at $.positions[1].quantity: invalid type: string, expected i64"
+        );
+        assert_eq!(
+            output,
+            RStructorError::OutputDecodeError {
+                path: "$.positions[1].quantity".to_string(),
+                message: "invalid type: string, expected i64".to_string(),
+            }
+        );
+
+        let tool = RStructorError::ToolArgumentDecodeError {
+            path: "$.order.quantity".to_string(),
+            message: "invalid type: string, expected i64".to_string(),
+        };
+        assert_eq!(
+            tool.to_string(),
+            "Failed to decode tool arguments at $.order.quantity: invalid type: string, expected i64"
+        );
+        assert_eq!(
+            tool,
+            RStructorError::ToolArgumentDecodeError {
+                path: "$.order.quantity".to_string(),
+                message: "invalid type: string, expected i64".to_string(),
+            }
+        );
     }
 
     #[test]

--- a/tests/fixtures/structured/portfolio_invalid_quantity.json
+++ b/tests/fixtures/structured/portfolio_invalid_quantity.json
@@ -1,0 +1,13 @@
+{
+  "portfolio_id": "HF-ALPHA-001",
+  "positions": [
+    {
+      "symbol": "AAPL",
+      "quantity": 125000
+    },
+    {
+      "symbol": "ESU6",
+      "quantity": "short two hundred forty contracts"
+    }
+  ]
+}

--- a/tests/fixtures/structured/portfolio_valid.json
+++ b/tests/fixtures/structured/portfolio_valid.json
@@ -1,0 +1,13 @@
+{
+  "portfolio_id": "HF-ALPHA-001",
+  "positions": [
+    {
+      "symbol": "AAPL",
+      "quantity": 125000
+    },
+    {
+      "symbol": "ESU6",
+      "quantity": -240
+    }
+  ]
+}

--- a/tests/http_mock_tests.rs
+++ b/tests/http_mock_tests.rs
@@ -18,6 +18,18 @@ struct Movie {
     year: u16,
 }
 
+#[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
+struct Portfolio {
+    portfolio_id: String,
+    positions: Vec<Position>,
+}
+
+#[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
+struct Position {
+    symbol: String,
+    quantity: i64,
+}
+
 fn validate_movie(m: &Movie) -> rstructor::Result<()> {
     if m.year < 1888 {
         return Err(RStructorError::ValidationError(
@@ -94,6 +106,41 @@ async fn reask_loop_recovers_from_validation_failure() {
 
     let movie: Movie = client(&server).materialize("a film").await.unwrap();
     assert_eq!(movie.year, 1927);
+    bad.assert_async().await;
+    good.assert_async().await;
+}
+
+#[tokio::test]
+async fn reask_feedback_includes_the_nested_decode_path() {
+    let mut server = mockito::Server::new_async().await;
+    let invalid = include_str!("fixtures/structured/portfolio_invalid_quantity.json");
+    let valid = include_str!("fixtures/structured/portfolio_valid.json");
+
+    let bad = server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_body(chat_completion(invalid))
+        .expect(1)
+        .create_async()
+        .await;
+    let good = server
+        .mock("POST", "/chat/completions")
+        .match_body(mockito::Matcher::Regex(
+            r"\$\.positions\[1\]\.quantity".to_string(),
+        ))
+        .with_status(200)
+        .with_body(chat_completion(valid))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let portfolio: Portfolio = client(&server)
+        .materialize("reconcile the portfolio positions")
+        .await
+        .unwrap();
+
+    assert_eq!(portfolio.portfolio_id, "HF-ALPHA-001");
+    assert_eq!(portfolio.positions[1].quantity, -240);
     bad.assert_async().await;
     good.assert_async().await;
 }

--- a/tests/mock_client_tests.rs
+++ b/tests/mock_client_tests.rs
@@ -14,6 +14,18 @@ struct Movie {
     year: u16,
 }
 
+#[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
+struct Portfolio {
+    portfolio_id: String,
+    positions: Vec<Position>,
+}
+
+#[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
+struct Position {
+    symbol: String,
+    quantity: i64,
+}
+
 fn validate_movie(m: &Movie) -> rstructor::Result<()> {
     if m.year < 1888 {
         return Err(RStructorError::ValidationError(format!(
@@ -162,6 +174,25 @@ async fn nested_validation_recurses_through_the_mock() {
     assert!(matches!(err, RStructorError::ValidationError(_)));
 }
 
+#[tokio::test]
+async fn nested_decode_error_reports_fixture_path_without_echoing_payload() {
+    let raw = include_str!("fixtures/structured/portfolio_invalid_quantity.json");
+    let client = MockClient::new().with_response(raw);
+
+    let error = client
+        .materialize::<Portfolio>("reconcile positions")
+        .await
+        .unwrap_err();
+    match error {
+        RStructorError::OutputDecodeError { path, message } => {
+            assert_eq!(path, "$.positions[1].quantity");
+            assert!(message.contains("invalid type"));
+            assert!(!message.contains("HF-ALPHA-001"));
+        }
+        other => panic!("expected OutputDecodeError, got {other:?}"),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Streaming (requires `streaming`, which implies `_client`)
 // ---------------------------------------------------------------------------
@@ -210,6 +241,27 @@ mod streaming {
             }
         }
         assert!(matches!(last_err, Some(RStructorError::ValidationError(_))));
+    }
+
+    #[tokio::test]
+    async fn materialize_stream_decode_failure_reports_the_nested_path() {
+        let client = MockClient::new().with_response(include_str!(
+            "fixtures/structured/portfolio_invalid_quantity.json"
+        ));
+        let mut stream = client.materialize_stream::<Portfolio>("p");
+        let mut last_error = None;
+
+        while let Some(item) = stream.next().await {
+            if let Err(error) = item {
+                last_error = Some(error);
+            }
+        }
+
+        assert!(matches!(
+            last_error,
+            Some(RStructorError::OutputDecodeError { path, .. })
+                if path == "$.positions[1].quantity"
+        ));
     }
 
     #[tokio::test]

--- a/tests/mock_edge_tests.rs
+++ b/tests/mock_edge_tests.rs
@@ -197,6 +197,25 @@ fn mock_response_json_serialization_error_branch() {
     assert!(matches!(err, RStructorError::SerializationError(_)));
 }
 
+#[tokio::test]
+async fn path_aware_errors_are_preserved_when_mock_defaults_are_cloned() {
+    for error in [
+        RStructorError::OutputDecodeError {
+            path: "$.positions[1].quantity".to_string(),
+            message: "invalid type".to_string(),
+        },
+        RStructorError::ToolArgumentDecodeError {
+            path: "$.order.quantity".to_string(),
+            message: "invalid type".to_string(),
+        },
+    ] {
+        let client = MockClient::new().with_default_response(MockResponse::error(error));
+        let first = client.generate("p").await.unwrap_err();
+        let second = client.generate("p").await.unwrap_err();
+        assert_eq!(first, second);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // generate_with_metadata: usage attachment + error arm
 // ---------------------------------------------------------------------------
@@ -269,21 +288,18 @@ mod streaming {
         }
     }
 
-    /// `materialize_iter` on malformed JSON yields a `ValidationError` reporting a
-    /// parse failure.
+    /// `materialize_iter` on malformed JSON reports a root output-decode failure.
     #[tokio::test]
-    async fn materialize_iter_malformed_json_is_validation_error() {
+    async fn materialize_iter_malformed_json_is_output_decode_error() {
         let client = MockClient::new().with_response("not json");
         let mut stream = client.materialize_iter::<Movie>("p");
         let item = stream.next().await.expect("an error item is yielded");
         match item {
-            Err(RStructorError::ValidationError(msg)) => {
-                assert!(
-                    msg.contains("Failed to parse response as JSON"),
-                    "expected a parse-failure message, got: {msg}"
-                );
+            Err(RStructorError::OutputDecodeError { path, message }) => {
+                assert_eq!(path, "$");
+                assert!(message.contains("expected ident"));
             }
-            other => panic!("expected ValidationError, got {other:?}"),
+            other => panic!("expected OutputDecodeError, got {other:?}"),
         }
     }
 

--- a/tests/tool_calling_tests.rs
+++ b/tests/tool_calling_tests.rs
@@ -4,7 +4,7 @@
 //! live provider APIs and are gated on each provider's feature.
 #![cfg(feature = "tools")]
 
-use rstructor::{DynTool, FnTool, Instructor, RequestExt, Toolbox};
+use rstructor::{DynTool, FnTool, Instructor, RStructorError, RequestExt, Toolbox};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -39,13 +39,43 @@ async fn fn_tool_invokes_with_deserialized_args() {
 }
 
 #[tokio::test]
-async fn unknown_args_error_is_surfaced() {
-    let tool = FnTool::new("add", "Add", |args: AddArgs| async move {
-        Ok(json!(args.a + args.b))
-    });
-    // Missing required field `b`.
-    let err = tool.invoke_json(json!({ "a": 1 })).await;
-    assert!(err.is_err());
+async fn nested_argument_error_reports_the_tool_phase_and_path() {
+    #[derive(Instructor, Serialize, Deserialize)]
+    struct RebalanceArgs {
+        order: RebalanceOrder,
+    }
+
+    #[derive(Instructor, Serialize, Deserialize)]
+    struct RebalanceOrder {
+        symbol: String,
+        quantity: i64,
+    }
+
+    let tool = FnTool::new(
+        "rebalance",
+        "Submit a rebalance order",
+        |args: RebalanceArgs| async move {
+            Ok(json!({
+                "symbol": args.order.symbol,
+                "quantity": args.order.quantity,
+            }))
+        },
+    );
+    let error = tool
+        .invoke_json(json!({
+            "order": {
+                "symbol": "AAPL",
+                "quantity": "ten thousand shares"
+            }
+        }))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        RStructorError::ToolArgumentDecodeError { path, message }
+            if path == "$.order.quantity" && message.contains("invalid type")
+    ));
 }
 
 // ---- Live agentic-loop tests (one per provider) ----


### PR DESCRIPTION
## Summary

- add phase-specific `OutputDecodeError` and `ToolArgumentDecodeError` variants
- report the first failing field with an unambiguous JSONPath-style path
- use the same decoder for ordinary materialization, mocks, streaming items, Gemini transformed items, and tool arguments
- keep strict whole-document parsing, including rejection of trailing JSON
- retain failed output internally for retry/re-ask feedback without echoing the raw payload in public errors or default logs
- add realistic portfolio and rebalance-order regression fixtures

## Why

Typed decoding failures previously surfaced as broad `ValidationError` or
`SerializationError` values. That made a mismatch inside a large nested response
hard to diagnose, and some error strings included the complete model payload.

The shared decoder now identifies locations such as
`$.positions[1].quantity`, and the retry loop sends that precise location back to
the model when requesting a corrected response.

## Usage example

```rust
use rstructor::{LLMClient, RStructorError};

match client.materialize::<Portfolio>("Reconcile the portfolio").await {
    Ok(portfolio) => process(portfolio),
    Err(RStructorError::OutputDecodeError { path, message }) => {
        eprintln!("model output mismatch at {path}: {message}");
        // Example: $.positions[1].quantity
    }
    Err(error) => return Err(error),
}
```

For tool calls, the equivalent failure is
`RStructorError::ToolArgumentDecodeError { path, message }`, so callers can
distinguish malformed model output from malformed tool arguments.

## API and behavior impact

- This is an intentional API change for error matching: structured decode
  failures now use the two new variants instead of `ValidationError` or
  `SerializationError`.
- Successful decoding, custom validation, retry counts, and retry control flow
  are unchanged.
- Malformed OpenAI-compatible tool argument JSON is no longer replaced with an
  empty object; it is returned to the model as a path-aware tool error while the
  existing tool loop continues.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo test --no-default-features --features derive,mock --lib`
- `cargo test --no-default-features --features derive,mock --test mock_client_tests --test mock_edge_tests`
- `cargo check --no-default-features --features derive --lib`
- `cargo check --no-default-features --features mock --lib`
- `git diff --check`
