### PR TITLE
Make dynamic map schemas fidelity-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,72 @@ let client = OpenAIClient::from_env()?.no_retries();
 
 ## Complex Types
 
+### Dynamic Maps
+
+Use `HashMap<String, V>` when keys are runtime data such as ticker symbols,
+account IDs, or category names. The map values remain fully typed:
+
+```rust
+use std::collections::HashMap;
+
+use rstructor::{GeminiClient, Instructor, LLMClient};
+use serde::{Deserialize, Serialize};
+
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct Position {
+    asset_class: String,
+    quantity: i64,
+    mark_price: f64,
+}
+
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+struct Portfolio {
+    portfolio_id: String,
+    positions: HashMap<String, Position>,
+}
+
+let client = GeminiClient::from_env()?;
+let portfolio: Portfolio = client
+    .materialize(
+        "AAPL: 125,000 equity shares at 213.76; \
+         ESU6: short 240 futures at 6378.25",
+    )
+    .await?;
+
+assert_eq!(portfolio.positions["AAPL"].quantity, 125_000);
+assert_eq!(portfolio.positions["ESU6"].quantity, -240);
+```
+
+Gemini accepts native typed dynamic-map schemas. OpenAI, Anthropic, and Grok
+strict structured-output dialects cannot currently represent arbitrary keys
+without weakening or changing the Rust contract. Those clients return a
+non-retryable `SchemaCompatibilityError` before making an HTTP request instead
+of silently constraining the map to `{}`:
+
+```rust
+use rstructor::{OpenAIClient, RStructorError};
+
+let result = OpenAIClient::from_env()?
+    .materialize::<Portfolio>("Extract the positions")
+    .await;
+
+match result {
+    Err(RStructorError::SchemaCompatibilityError {
+        provider,
+        path,
+        ..
+    }) => {
+        assert_eq!(provider.as_ref(), "OpenAI");
+        assert_eq!(path.as_ref(), "$.properties.positions");
+    }
+    other => panic!("expected a map compatibility error, got {other:?}"),
+}
+```
+
+Use a struct instead when the keys are a fixed part of the contract. Dynamic-map
+fallback encodings are deliberately not selected automatically because doing so
+would change the provider wire schema and structured-output guarantee.
+
 ### Nested Structures
 
 ```rust

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -8,10 +8,10 @@ use tracing::{debug, error, info, instrument, trace, warn};
 use crate::backend::model_macro::define_model_enum;
 use crate::backend::{
     AnthropicMessageContent, ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient,
-    MaterializeInternalOutput, MaterializeResult, ModelInfo, ThinkingLevel, TokenUsage,
-    ValidationFailureContext, build_anthropic_message_content, build_http_client,
-    check_response_status, generate_with_retry_with_history, handle_http_error,
-    materialize_with_media_with_retry, parse_validate_and_create_output, prepare_strict_schema,
+    MaterializeInternalOutput, MaterializeResult, ModelInfo, StrictSchemaProvider, ThinkingLevel,
+    TokenUsage, ValidationFailureContext, build_anthropic_message_content, build_http_client,
+    check_response_status, compile_strict_schema, generate_with_retry_with_history,
+    handle_http_error, materialize_with_media_with_retry, parse_validate_and_create_output,
 };
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
@@ -301,8 +301,14 @@ impl AnthropicClient {
         let schema = T::schema();
         trace!("Retrieved JSON schema for type");
 
-        // Prepare schema with additionalProperties: false recursively for all nested objects
-        let schema_json = prepare_strict_schema(&schema);
+        // Reject dynamic maps before Anthropic's strict object transform can
+        // silently narrow them to empty objects.
+        let schema_json = compile_strict_schema(
+            &schema,
+            StrictSchemaProvider::Anthropic,
+            "structured output",
+        )
+        .map_err(|error| (error, None))?;
 
         // Build API messages from conversation history
         // With native structured outputs, we don't need to include schema instructions in the prompt
@@ -879,7 +885,14 @@ impl LLMClient for AnthropicClient {
         T: Instructor + DeserializeOwned + Send + 'static,
         Self: Sync,
     {
-        let schema_json = prepare_strict_schema(&T::schema());
+        let schema_json = match compile_strict_schema(
+            &T::schema(),
+            StrictSchemaProvider::Anthropic,
+            "streamed structured output",
+        ) {
+            Ok(schema) => schema,
+            Err(error) => return crate::backend::streaming::error_stream(error),
+        };
         let output_format = serde_json::json!({
             "type": "json_schema",
             "schema": schema_json,
@@ -900,7 +913,14 @@ impl LLMClient for AnthropicClient {
         T: Instructor + DeserializeOwned + Send + 'static,
         Self: Sync,
     {
-        let item_schema = prepare_strict_schema(&T::schema());
+        let item_schema = match compile_strict_schema(
+            &T::schema(),
+            StrictSchemaProvider::Anthropic,
+            "streamed item",
+        ) {
+            Ok(schema) => schema,
+            Err(error) => return crate::backend::streaming::error_stream(error),
+        };
         let wrapper = crate::backend::streaming::array_wrapper_schema(item_schema, true);
         let output_format = serde_json::json!({ "type": "json_schema", "schema": wrapper });
         let body = self.stream_body(prompt, Some(output_format));

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -157,8 +157,8 @@ struct GenerationConfig {
     max_output_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     response_mime_type: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    response_schema: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "responseJsonSchema")]
+    response_json_schema: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "thinkingConfig")]
     thinking_config: Option<ThinkingConfig>,
 }
@@ -344,7 +344,7 @@ impl GeminiClient {
     /// Accepts conversation history for multi-turn interactions.
     /// Returns the data, raw response, and optional usage info.
     ///
-    /// Uses Gemini's native Structured Outputs with `response_schema`
+    /// Uses Gemini's native Structured Outputs with `responseJsonSchema`
     /// for guaranteed schema compliance via constrained decoding.
     ///
     /// The raw response is included to enable conversation history tracking for retries,
@@ -366,7 +366,7 @@ impl GeminiClient {
         trace!(schema_name = schema_name, "Retrieved JSON schema for type");
 
         // Build API contents from conversation history
-        // With native response_schema, we don't need to include schema instructions in the prompt
+        // With native responseJsonSchema, we don't need to include schema instructions in the prompt
         let contents = chat_messages_to_contents(messages);
 
         // Build thinking config only for Gemini 3.x models
@@ -392,7 +392,7 @@ impl GeminiClient {
             temperature: self.config.temperature,
             max_output_tokens: self.config.max_tokens,
             response_mime_type: Some("application/json".to_string()),
-            response_schema: Some(gemini_schema),
+            response_json_schema: Some(gemini_schema),
             thinking_config,
         };
 
@@ -472,7 +472,7 @@ impl GeminiClient {
             if let Some(text) = &part.text {
                 let mut raw_response = text.clone();
                 debug!(content_len = raw_response.len(), "Processing text part");
-                // With native response_schema, the response is guaranteed to be valid JSON
+                // With native responseJsonSchema, the response is guaranteed to be valid JSON
                 trace!(json = %raw_response, "Parsing structured output response");
 
                 // Transform internally tagged enums back to adjacently tagged format if needed
@@ -532,7 +532,7 @@ impl GeminiClient {
                 temperature: self.config.temperature,
                 max_output_tokens: self.config.max_tokens,
                 response_mime_type: None,
-                response_schema: None,
+                response_json_schema: None,
                 thinking_config,
             },
         };
@@ -691,9 +691,9 @@ impl GeminiClient {
 #[cfg(feature = "streaming")]
 impl GeminiClient {
     /// Build the JSON request body for a streaming call, optionally with a
-    /// structured-output `response_schema`. (Gemini streams via the
+    /// structured-output `responseJsonSchema`. (Gemini streams via the
     /// `:streamGenerateContent?alt=sse` endpoint; the body itself is unchanged.)
-    fn stream_body(&self, prompt: &str, response_schema: Option<Value>) -> Value {
+    fn stream_body(&self, prompt: &str, response_json_schema: Option<Value>) -> Value {
         let is_gemini3 = self.config.model.as_str().starts_with("gemini-3");
         let thinking_config = if is_gemini3 {
             self.config.thinking_level.and_then(|level| {
@@ -714,10 +714,10 @@ impl GeminiClient {
             generation_config: GenerationConfig {
                 temperature: self.config.temperature,
                 max_output_tokens: self.config.max_tokens,
-                response_mime_type: response_schema
+                response_mime_type: response_json_schema
                     .as_ref()
                     .map(|_| "application/json".to_string()),
-                response_schema,
+                response_json_schema,
                 thinking_config,
             },
         };

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -385,7 +385,8 @@ impl GeminiClient {
         let adjacently_tagged_info =
             crate::backend::utils::extract_adjacently_tagged_info(&schema.to_json());
 
-        // Prepare schema for Gemini by stripping unsupported keywords (examples, additionalProperties, etc.)
+        // Prepare schema for Gemini by stripping unsupported metadata while
+        // preserving supported typed-map constraints.
         let gemini_schema = crate::backend::utils::prepare_gemini_schema(&schema);
         let generation_config = GenerationConfig {
             temperature: self.config.temperature,

--- a/src/backend/grok.rs
+++ b/src/backend/grok.rs
@@ -7,10 +7,10 @@ use crate::backend::model_macro::define_model_enum;
 use crate::backend::{
     ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient, MaterializeInternalOutput,
     MaterializeResult, ModelInfo, OpenAICompatibleChatCompletionRequest,
-    OpenAICompatibleChatCompletionResponse, ResponseFormat, TokenUsage, ValidationFailureContext,
-    build_http_client, check_response_status, convert_openai_compatible_chat_messages,
-    generate_with_retry_with_history, handle_http_error, materialize_with_media_with_retry,
-    parse_validate_and_create_output, prepare_strict_schema,
+    OpenAICompatibleChatCompletionResponse, ResponseFormat, StrictSchemaProvider, TokenUsage,
+    ValidationFailureContext, build_http_client, check_response_status, compile_strict_schema,
+    convert_openai_compatible_chat_messages, generate_with_retry_with_history, handle_http_error,
+    materialize_with_media_with_retry, parse_validate_and_create_output,
 };
 #[cfg(feature = "streaming")]
 use crate::backend::{OpenAICompatibleChatMessage, OpenAICompatibleMessageContent};
@@ -198,8 +198,11 @@ impl GrokClient {
         let schema_name = T::schema_name().unwrap_or_else(|| "output".to_string());
         trace!(schema_name = schema_name, "Retrieved JSON schema for type");
 
-        // Prepare schema with additionalProperties: false recursively for all nested objects
-        let schema_json = prepare_strict_schema(&schema);
+        // Reject typed dynamic maps before Grok's strict object transform can
+        // silently narrow them to empty objects.
+        let schema_json =
+            compile_strict_schema(&schema, StrictSchemaProvider::Grok, "structured output")
+                .map_err(|error| (error, None))?;
 
         // Build API messages from conversation history
         // With native structured outputs, we don't need to include schema instructions in the prompt
@@ -656,7 +659,14 @@ impl LLMClient for GrokClient {
     {
         let schema = T::schema();
         let schema_name = T::schema_name().unwrap_or_else(|| "output".to_string());
-        let schema_json = prepare_strict_schema(&schema);
+        let schema_json = match compile_strict_schema(
+            &schema,
+            StrictSchemaProvider::Grok,
+            "streamed structured output",
+        ) {
+            Ok(schema) => schema,
+            Err(error) => return crate::backend::streaming::error_stream(error),
+        };
         let response_format = ResponseFormat::json_schema(schema_name, schema_json, None);
         let body = self.stream_body(prompt, Some(response_format));
         crate::backend::streaming::object_stream(
@@ -674,7 +684,14 @@ impl LLMClient for GrokClient {
         T: Instructor + DeserializeOwned + Send + 'static,
         Self: Sync,
     {
-        let item_schema = prepare_strict_schema(&T::schema());
+        let item_schema = match compile_strict_schema(
+            &T::schema(),
+            StrictSchemaProvider::Grok,
+            "streamed item",
+        ) {
+            Ok(schema) => schema,
+            Err(error) => return crate::backend::streaming::error_stream(error),
+        };
         let wrapper = crate::backend::streaming::array_wrapper_schema(item_schema, true);
         let response_format = ResponseFormat::json_schema("items".to_string(), wrapper, None);
         let body = self.stream_body(prompt, Some(response_format));

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -122,6 +122,17 @@ fn clone_error(e: &RStructorError) -> RStructorError {
         },
         RStructorError::ValidationError(s) => RStructorError::ValidationError(s.clone()),
         RStructorError::SchemaError(s) => RStructorError::SchemaError(s.clone()),
+        RStructorError::SchemaCompatibilityError {
+            provider,
+            context,
+            path,
+            message,
+        } => RStructorError::SchemaCompatibilityError {
+            provider: provider.clone(),
+            context: context.clone(),
+            path: path.clone(),
+            message: message.clone(),
+        },
         RStructorError::SerializationError(s) => RStructorError::SerializationError(s.clone()),
         RStructorError::OutputDecodeError { path, message } => RStructorError::OutputDecodeError {
             path: path.clone(),

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -12,6 +12,8 @@ mod model_macro;
 mod openai_compatible;
 #[cfg(feature = "_client")]
 mod request;
+#[cfg(feature = "_client")]
+mod schema_compatibility;
 #[cfg(feature = "streaming")]
 pub mod streaming;
 #[cfg(feature = "tools")]
@@ -86,12 +88,13 @@ pub(crate) use openai_compatible::{
     convert_openai_compatible_chat_messages,
 };
 #[cfg(feature = "_client")]
+pub(crate) use schema_compatibility::{StrictSchemaProvider, compile_strict_schema};
+#[cfg(feature = "_client")]
 pub use utils::{DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT};
 #[cfg(feature = "_client")]
 pub(crate) use utils::{
     ResponseFormat, build_http_client, check_response_status, generate_with_retry_with_history,
     handle_http_error, materialize_with_media_with_retry, parse_validate_and_create_output,
-    prepare_strict_schema,
 };
 
 /// Thinking level configuration for models that support extended reasoning.

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -7,10 +7,11 @@ use crate::backend::model_macro::define_model_enum;
 use crate::backend::{
     ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient, MaterializeInternalOutput,
     MaterializeResult, ModelInfo, OpenAICompatibleChatCompletionRequest,
-    OpenAICompatibleChatCompletionResponse, ResponseFormat, ThinkingLevel, TokenUsage,
-    ValidationFailureContext, build_http_client, check_response_status,
-    convert_openai_compatible_chat_messages, generate_with_retry_with_history, handle_http_error,
-    materialize_with_media_with_retry, parse_validate_and_create_output, prepare_strict_schema,
+    OpenAICompatibleChatCompletionResponse, ResponseFormat, StrictSchemaProvider, ThinkingLevel,
+    TokenUsage, ValidationFailureContext, build_http_client, check_response_status,
+    compile_strict_schema, convert_openai_compatible_chat_messages,
+    generate_with_retry_with_history, handle_http_error, materialize_with_media_with_retry,
+    parse_validate_and_create_output,
 };
 #[cfg(feature = "streaming")]
 use crate::backend::{OpenAICompatibleChatMessage, OpenAICompatibleMessageContent};
@@ -327,8 +328,11 @@ impl OpenAIClient {
         // Avoid calling to_string() in trace to prevent potential stack overflow with complex schemas
         trace!(schema_name = schema_name, "Retrieved JSON schema for type");
 
-        // Prepare schema with additionalProperties: false recursively for all nested objects
-        let schema_json = prepare_strict_schema(&schema);
+        // Reject dynamic maps before OpenAI's strict object transform can
+        // silently narrow them to empty objects.
+        let schema_json =
+            compile_strict_schema(&schema, StrictSchemaProvider::OpenAI, "structured output")
+                .map_err(|error| (error, None))?;
 
         // Create response format with JSON schema (strict mode)
         let response_format = ResponseFormat::json_schema(
@@ -825,7 +829,14 @@ impl LLMClient for OpenAIClient {
     {
         let schema = T::schema();
         let schema_name = T::schema_name().unwrap_or_else(|| "output".to_string());
-        let schema_json = prepare_strict_schema(&schema);
+        let schema_json = match compile_strict_schema(
+            &schema,
+            StrictSchemaProvider::OpenAI,
+            "streamed structured output",
+        ) {
+            Ok(schema) => schema,
+            Err(error) => return crate::backend::streaming::error_stream(error),
+        };
         let response_format = ResponseFormat::json_schema(
             schema_name,
             schema_json,
@@ -847,7 +858,14 @@ impl LLMClient for OpenAIClient {
         T: Instructor + DeserializeOwned + Send + 'static,
         Self: Sync,
     {
-        let item_schema = prepare_strict_schema(&T::schema());
+        let item_schema = match compile_strict_schema(
+            &T::schema(),
+            StrictSchemaProvider::OpenAI,
+            "streamed item",
+        ) {
+            Ok(schema) => schema,
+            Err(error) => return crate::backend::streaming::error_stream(error),
+        };
         let wrapper = crate::backend::streaming::array_wrapper_schema(item_schema, true);
         let response_format = ResponseFormat::json_schema(
             "items".to_string(),

--- a/src/backend/schema_compatibility.rs
+++ b/src/backend/schema_compatibility.rs
@@ -1,0 +1,288 @@
+//! Provider schema compatibility checks.
+//!
+//! The canonical schema must continue to describe the values accepted by the
+//! requested Rust type. Provider-specific compilation may remove unsupported
+//! annotations, but it must not silently narrow a dynamic map into an object
+//! that permits no keys.
+
+use std::fmt;
+
+use serde_json::Value;
+
+use crate::backend::utils::prepare_strict_schema;
+use crate::error::{RStructorError, Result};
+use crate::schema::Schema;
+
+/// Providers whose constrained-output dialect closes every object.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StrictSchemaProvider {
+    OpenAI,
+    Anthropic,
+    Grok,
+}
+
+impl fmt::Display for StrictSchemaProvider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::OpenAI => "OpenAI",
+            Self::Anthropic => "Anthropic",
+            Self::Grok => "Grok",
+        })
+    }
+}
+
+/// Compile a canonical schema for a provider that requires closed objects.
+///
+/// Dynamic maps are rejected before the strict transform can overwrite their
+/// schema-valued `additionalProperties` with `false`.
+pub(crate) fn compile_strict_schema(
+    schema: &Schema,
+    provider: StrictSchemaProvider,
+    context: impl Into<String>,
+) -> Result<Value> {
+    let schema_json = schema.to_json();
+    if let Some(path) = dynamic_object_path(&schema_json) {
+        return Err(RStructorError::SchemaCompatibilityError {
+            provider: provider.to_string().into_boxed_str(),
+            context: context.into().into_boxed_str(),
+            path: path.into_boxed_str(),
+            message: concat!(
+                "dynamic object keys require `additionalProperties`, but this provider's ",
+                "strict structured-output dialect closes objects with ",
+                "`additionalProperties: false`; use a provider with native typed-map ",
+                "support because automatic fallback encodings are intentionally not selected"
+            )
+            .into(),
+        });
+    }
+
+    Ok(prepare_strict_schema(schema))
+}
+
+/// Find the first schema node that permits dynamic properties.
+///
+/// Returns the path of the object schema rather than the path of its
+/// `additionalProperties` keyword, which makes errors point at the affected
+/// Rust field (for example `$.properties.positions`).
+fn dynamic_object_path(schema: &Value) -> Option<String> {
+    find_dynamic_object(schema, "$")
+}
+
+fn find_dynamic_object(schema: &Value, path: &str) -> Option<String> {
+    match schema {
+        Value::Object(object) => {
+            if object
+                .get("additionalProperties")
+                .is_some_and(|additional| additional != &Value::Bool(false))
+            {
+                return Some(path.to_string());
+            }
+
+            for (key, value) in object {
+                let child_path = append_key(path, key);
+                if let Some(path) = find_dynamic_object(value, &child_path) {
+                    return Some(path);
+                }
+            }
+            None
+        }
+        Value::Array(array) => array
+            .iter()
+            .enumerate()
+            .find_map(|(index, value)| find_dynamic_object(value, &format!("{path}[{index}]"))),
+        _ => None,
+    }
+}
+
+fn append_key(path: &str, key: &str) -> String {
+    if is_identifier(key) {
+        format!("{path}.{key}")
+    } else {
+        let quoted = serde_json::to_string(key).expect("serializing a string cannot fail");
+        format!("{path}[{quoted}]")
+    }
+}
+
+fn is_identifier(key: &str) -> bool {
+    let mut chars = key.chars();
+    matches!(chars.next(), Some(first) if first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|character| character == '_' || character.is_ascii_alphanumeric())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn schema(value: Value) -> Schema {
+        Schema::new(value)
+    }
+
+    #[test]
+    fn root_dynamic_map_is_rejected() {
+        let error = compile_strict_schema(
+            &schema(json!({
+                "type": "object",
+                "additionalProperties": { "type": "integer" }
+            })),
+            StrictSchemaProvider::OpenAI,
+            "structured output",
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RStructorError::SchemaCompatibilityError {
+                provider,
+                context,
+                path,
+                message,
+            } if provider.as_ref() == "OpenAI"
+                && context.as_ref() == "structured output"
+                && path.as_ref() == "$"
+                && message.contains("additionalProperties: false")
+        ));
+    }
+
+    #[test]
+    fn nested_map_reports_the_affected_field() {
+        let error = compile_strict_schema(
+            &schema(json!({
+                "type": "object",
+                "properties": {
+                    "portfolio": {
+                        "type": "object",
+                        "properties": {
+                            "positions": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "object",
+                                    "properties": {
+                                        "quantity": { "type": "integer" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            })),
+            StrictSchemaProvider::Anthropic,
+            "structured output",
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RStructorError::SchemaCompatibilityError {
+                provider,
+                path,
+                ..
+            } if provider.as_ref() == "Anthropic"
+                && path.as_ref() == "$.properties.portfolio.properties.positions"
+        ));
+    }
+
+    #[test]
+    fn maps_inside_arrays_and_unions_are_detected() {
+        let array_error = compile_strict_schema(
+            &schema(json!({
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": { "type": "number" }
+                }
+            })),
+            StrictSchemaProvider::Grok,
+            "streamed item",
+        )
+        .unwrap_err();
+        assert!(matches!(
+            array_error,
+            RStructorError::SchemaCompatibilityError { path, .. }
+                if path.as_ref() == "$.items"
+        ));
+
+        let union_error = compile_strict_schema(
+            &schema(json!({
+                "anyOf": [
+                    { "type": "null" },
+                    {
+                        "type": "object",
+                        "additionalProperties": { "type": "string" }
+                    }
+                ]
+            })),
+            StrictSchemaProvider::OpenAI,
+            "structured output",
+        )
+        .unwrap_err();
+        assert!(matches!(
+            union_error,
+            RStructorError::SchemaCompatibilityError { path, .. }
+                if path.as_ref() == "$.anyOf[1]"
+        ));
+    }
+
+    #[test]
+    fn definitions_and_complex_property_names_use_unambiguous_paths() {
+        let error = compile_strict_schema(
+            &schema(json!({
+                "$defs": {
+                    "Risk.Bucket": {
+                        "type": "object",
+                        "additionalProperties": true
+                    }
+                }
+            })),
+            StrictSchemaProvider::OpenAI,
+            "structured output",
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RStructorError::SchemaCompatibilityError { path, .. }
+                if path.as_ref() == r#"$["$defs"]["Risk.Bucket"]"#
+        ));
+    }
+
+    #[test]
+    fn closed_objects_still_receive_the_normal_strict_transform() {
+        let compiled = compile_strict_schema(
+            &schema(json!({
+                "type": "object",
+                "properties": {
+                    "symbol": { "type": "string" },
+                    "quantity": { "type": "integer" }
+                },
+                "required": ["symbol"]
+            })),
+            StrictSchemaProvider::OpenAI,
+            "structured output",
+        )
+        .unwrap();
+
+        assert_eq!(compiled["additionalProperties"], false);
+        assert_eq!(compiled["required"], json!(["quantity", "symbol"]));
+        assert_eq!(
+            compiled["properties"]["quantity"]["type"],
+            json!(["integer", "null"])
+        );
+    }
+
+    #[test]
+    fn explicitly_closed_additional_properties_is_compatible() {
+        let compiled = compile_strict_schema(
+            &schema(json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            })),
+            StrictSchemaProvider::Anthropic,
+            "tool `rebalance` arguments",
+        )
+        .unwrap();
+
+        assert_eq!(compiled["additionalProperties"], false);
+    }
+}

--- a/src/backend/streaming.rs
+++ b/src/backend/streaming.rs
@@ -36,6 +36,20 @@ pub type TextStream<'a> = Pin<Box<dyn Stream<Item = Result<String>> + Send + 'a>
 /// A boxed stream of [`StreamedObject`] items for a streaming structured request.
 pub type ObjectStream<'a, T> = Pin<Box<dyn Stream<Item = Result<StreamedObject<T>>> + Send + 'a>>;
 
+/// Build a stream that yields one locally detected error and performs no I/O.
+///
+/// Provider methods use this when synchronous request construction discovers an
+/// incompatible schema but their public streaming API cannot return `Result`
+/// directly.
+pub(crate) fn error_stream<'a, T>(
+    error: RStructorError,
+) -> Pin<Box<dyn Stream<Item = Result<T>> + Send + 'a>>
+where
+    T: Send + 'a,
+{
+    Box::pin(futures_util::stream::once(async move { Err(error) }))
+}
+
 /// An item yielded by a streaming structured ("object") request.
 #[derive(Debug, Clone)]
 pub enum StreamedObject<T> {

--- a/src/backend/tools.rs
+++ b/src/backend/tools.rs
@@ -47,8 +47,10 @@ pub trait DynTool: Send + Sync {
     fn name(&self) -> String;
     /// The tool description.
     fn description(&self) -> String;
-    /// The JSON Schema for the tool's arguments (strict form: `additionalProperties:
-    /// false`), as used by OpenAI/Grok/Anthropic.
+    /// The canonical JSON Schema for the tool's arguments.
+    ///
+    /// Provider-specific compatibility checks and transformations are applied
+    /// when the toolbox is rendered for a request.
     fn parameters_schema(&self) -> Value;
     /// The argument schema with Gemini-unsupported keywords stripped.
     fn parameters_schema_gemini(&self) -> Value;
@@ -67,7 +69,7 @@ impl<T: Tool> DynTool for T {
     }
 
     fn parameters_schema(&self) -> Value {
-        crate::backend::utils::prepare_strict_schema(&<T::Args as SchemaType>::schema())
+        <T::Args as SchemaType>::schema().to_json()
     }
 
     fn parameters_schema_gemini(&self) -> Value {
@@ -193,33 +195,50 @@ impl Toolbox {
 
     /// Render the tools as OpenAI-compatible `tools` JSON.
     #[cfg(any(feature = "openai", feature = "grok"))]
-    fn openai_tools_json(&self) -> Vec<Value> {
+    fn openai_tools_json(
+        &self,
+        provider: crate::backend::StrictSchemaProvider,
+    ) -> Result<Vec<Value>> {
         self.tools
             .iter()
             .map(|t| {
-                serde_json::json!({
+                let name = t.name();
+                let schema = crate::schema::Schema::new(t.parameters_schema());
+                let parameters = crate::backend::compile_strict_schema(
+                    &schema,
+                    provider,
+                    format!("tool `{name}` arguments"),
+                )?;
+                Ok(serde_json::json!({
                     "type": "function",
                     "function": {
-                        "name": t.name(),
+                        "name": name,
                         "description": t.description(),
-                        "parameters": t.parameters_schema(),
+                        "parameters": parameters,
                     }
-                })
+                }))
             })
             .collect()
     }
 
     /// Render the tools as Anthropic `tools` JSON.
     #[cfg(feature = "anthropic")]
-    fn anthropic_tools_json(&self) -> Vec<Value> {
+    fn anthropic_tools_json(&self) -> Result<Vec<Value>> {
         self.tools
             .iter()
             .map(|t| {
-                serde_json::json!({
-                    "name": t.name(),
+                let name = t.name();
+                let schema = crate::schema::Schema::new(t.parameters_schema());
+                let input_schema = crate::backend::compile_strict_schema(
+                    &schema,
+                    crate::backend::StrictSchemaProvider::Anthropic,
+                    format!("tool `{name}` arguments"),
+                )?;
+                Ok(serde_json::json!({
+                    "name": name,
                     "description": t.description(),
-                    "input_schema": t.parameters_schema(),
-                })
+                    "input_schema": input_schema,
+                }))
             })
             .collect()
     }
@@ -271,7 +290,16 @@ pub(crate) async fn run_openai_compatible_tools(
     use serde_json::json;
     use tracing::{debug, warn};
 
-    let tools_json = toolbox.openai_tools_json();
+    let schema_provider = match provider {
+        "OpenAI" => crate::backend::StrictSchemaProvider::OpenAI,
+        "Grok" => crate::backend::StrictSchemaProvider::Grok,
+        other => {
+            return Err(RStructorError::SchemaError(format!(
+                "unsupported OpenAI-compatible tool schema provider: {other}"
+            )));
+        }
+    };
+    let tools_json = toolbox.openai_tools_json(schema_provider)?;
     let mut messages: Vec<Value> = Vec::new();
     if let Some(system) = system {
         messages.push(json!({ "role": "system", "content": system }));
@@ -414,7 +442,7 @@ pub(crate) async fn run_anthropic_tools(
     use serde_json::json;
     use tracing::debug;
 
-    let tools_json = toolbox.anthropic_tools_json();
+    let tools_json = toolbox.anthropic_tools_json()?;
     let url = format!("{base_url}/messages");
     // Encode any attached media with the same content builder as materialize, so
     // images/PDFs are carried (or rejected with a clear error) per provider rules.
@@ -635,6 +663,7 @@ mod tests {
     use super::*;
     use serde::{Deserialize, Serialize};
     use serde_json::json;
+    use std::collections::HashMap;
 
     /// Argument type for the test tool; its schema is derived via `Instructor`.
     #[derive(crate::Instructor, Serialize, Deserialize)]
@@ -657,6 +686,25 @@ mod tests {
         FnTool::new("echo", "Echo the first addend", |args: AddArgs| {
             std::future::ready(Ok(json!({ "value": args.a })))
         })
+    }
+
+    #[derive(crate::Instructor, Serialize, Deserialize)]
+    struct ScenarioPriceArgs {
+        scenario_prices: HashMap<String, f64>,
+    }
+
+    fn scenario_price_tool()
+    -> FnTool<ScenarioPriceArgs, impl Fn(ScenarioPriceArgs) -> std::future::Ready<Result<Value>>>
+    {
+        FnTool::new(
+            "scenario_price",
+            "Apply per-symbol scenario prices",
+            |args: ScenarioPriceArgs| {
+                std::future::ready(Ok(json!({
+                    "symbol_count": args.scenario_prices.len()
+                })))
+            },
+        )
     }
 
     // ---- Toolbox add()/len()/is_empty() ----
@@ -740,7 +788,9 @@ mod tests {
     #[test]
     fn openai_tools_json_render_shape() {
         let toolbox = Toolbox::new().with(add_tool());
-        let rendered = toolbox.openai_tools_json();
+        let rendered = toolbox
+            .openai_tools_json(crate::backend::StrictSchemaProvider::OpenAI)
+            .unwrap();
         assert_eq!(rendered.len(), 1);
 
         let entry = &rendered[0];
@@ -772,7 +822,7 @@ mod tests {
     #[test]
     fn anthropic_tools_json_uses_input_schema() {
         let toolbox = Toolbox::new().with(add_tool());
-        let rendered = toolbox.anthropic_tools_json();
+        let rendered = toolbox.anthropic_tools_json().unwrap();
         assert_eq!(rendered.len(), 1);
 
         let entry = &rendered[0];
@@ -792,6 +842,56 @@ mod tests {
         let input_schema = &entry["input_schema"];
         assert_eq!(input_schema["type"], "object");
         assert_eq!(input_schema["additionalProperties"], json!(false));
+    }
+
+    #[test]
+    fn dyn_tool_exposes_canonical_typed_map_schema() {
+        let tool = scenario_price_tool();
+        let schema = tool.parameters_schema();
+        let map = &schema["properties"]["scenario_prices"];
+
+        assert_eq!(map["type"], "object");
+        assert_eq!(map["additionalProperties"]["type"], "number");
+    }
+
+    #[cfg(any(feature = "openai", feature = "grok"))]
+    #[test]
+    fn strict_openai_compatible_tool_rejects_dynamic_map_with_tool_context() {
+        let toolbox = Toolbox::new().with(scenario_price_tool());
+        let error = toolbox
+            .openai_tools_json(crate::backend::StrictSchemaProvider::Grok)
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RStructorError::SchemaCompatibilityError {
+                provider,
+                context,
+                path,
+                ..
+            } if provider.as_ref() == "Grok"
+                && context.as_ref() == "tool `scenario_price` arguments"
+                && path.as_ref() == "$.properties.scenario_prices"
+        ));
+    }
+
+    #[cfg(feature = "anthropic")]
+    #[test]
+    fn strict_anthropic_tool_rejects_dynamic_map() {
+        let toolbox = Toolbox::new().with(scenario_price_tool());
+        let error = toolbox.anthropic_tools_json().unwrap_err();
+
+        assert!(matches!(
+            error,
+            RStructorError::SchemaCompatibilityError {
+                provider,
+                context,
+                path,
+                ..
+            } if provider.as_ref() == "Anthropic"
+                && context.as_ref() == "tool `scenario_price` arguments"
+                && path.as_ref() == "$.properties.scenario_prices"
+        ));
     }
 
     // ---- gemini_tools_json functionDeclarations wrapper + empty early-return ----
@@ -830,5 +930,18 @@ mod tests {
             decl["parameters"].get("title").is_none(),
             "title should be stripped from Gemini schema"
         );
+    }
+
+    #[cfg(feature = "gemini")]
+    #[test]
+    fn gemini_tool_preserves_typed_dynamic_map() {
+        let toolbox = Toolbox::new().with(scenario_price_tool());
+        let rendered = toolbox.gemini_tools_json();
+        let map =
+            &rendered[0]["functionDeclarations"][0]["parameters"]["properties"]["scenario_prices"];
+
+        assert_eq!(map["type"], "object");
+        assert_eq!(map["additionalProperties"]["type"], "number");
+        assert!(map.get("properties").is_none());
     }
 }

--- a/src/backend/tools.rs
+++ b/src/backend/tools.rs
@@ -52,7 +52,7 @@ pub trait DynTool: Send + Sync {
     /// Provider-specific compatibility checks and transformations are applied
     /// when the toolbox is rendered for a request.
     fn parameters_schema(&self) -> Value;
-    /// The argument schema with Gemini-unsupported keywords stripped.
+    /// The argument schema prepared for Gemini's JSON Schema transport.
     fn parameters_schema_gemini(&self) -> Value;
     /// Invoke the tool with raw JSON arguments (deserialized into `Args`).
     async fn invoke_json(&self, args: Value) -> Result<Value>;
@@ -256,7 +256,7 @@ impl Toolbox {
                 serde_json::json!({
                     "name": t.name(),
                     "description": t.description(),
-                    "parameters": t.parameters_schema_gemini(),
+                    "parametersJsonSchema": t.parameters_schema_gemini(),
                 })
             })
             .collect();
@@ -919,15 +919,16 @@ mod tests {
         let decl = &declarations[0];
         assert_eq!(decl["name"], "add");
         assert_eq!(decl["description"], "Add two integers");
-        assert_eq!(decl["parameters"]["type"], "object");
+        assert_eq!(decl["parametersJsonSchema"]["type"], "object");
+        assert!(decl.get("parameters").is_none());
 
         // Gemini schema strips examples/title.
         assert!(
-            decl["parameters"].get("examples").is_none(),
+            decl["parametersJsonSchema"].get("examples").is_none(),
             "examples should be stripped from Gemini schema"
         );
         assert!(
-            decl["parameters"].get("title").is_none(),
+            decl["parametersJsonSchema"].get("title").is_none(),
             "title should be stripped from Gemini schema"
         );
     }
@@ -937,11 +938,12 @@ mod tests {
     fn gemini_tool_preserves_typed_dynamic_map() {
         let toolbox = Toolbox::new().with(scenario_price_tool());
         let rendered = toolbox.gemini_tools_json();
-        let map =
-            &rendered[0]["functionDeclarations"][0]["parameters"]["properties"]["scenario_prices"];
+        let declaration = &rendered[0]["functionDeclarations"][0];
+        let map = &declaration["parametersJsonSchema"]["properties"]["scenario_prices"];
 
         assert_eq!(map["type"], "object");
         assert_eq!(map["additionalProperties"]["type"], "number");
         assert!(map.get("properties").is_none());
+        assert!(declaration.get("parameters").is_none());
     }
 }

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -454,8 +454,8 @@ pub fn transform_internally_to_adjacently_tagged(
 /// Prepare a JSON schema for Gemini by stripping unsupported keywords.
 ///
 /// Gemini's structured outputs API doesn't support certain JSON Schema keywords like
-/// `examples`, `additionalProperties`, `title`, etc. This function recursively removes
-/// them from the schema.
+/// `examples` and schema metadata. Supported object constraints, including boolean
+/// and schema-valued `additionalProperties`, are preserved.
 ///
 /// # Arguments
 ///
@@ -784,95 +784,7 @@ fn strip_gemini_unsupported_keywords_recursive(schema: &mut Value) {
         obj.remove("definitions");
         obj.remove("$ref"); // Should be resolved by now, but remove if any remain
 
-        // Handle additionalProperties: remove if boolean, keep if it's a schema for maps
-        if let Some(additional) = obj.get("additionalProperties")
-            && additional.is_boolean()
-        {
-            obj.remove("additionalProperties");
-        }
-
-        // For object types with additionalProperties but no properties, this is a Map type
-        // Gemini requires properties to be non-empty for object types
-        // Since Gemini doesn't support map types natively, we remove type constraint
-        // and add a description. The response won't be strictly validated but should
-        // parse correctly.
-        let is_object = obj.get("type").and_then(|t| t.as_str()) == Some("object");
-        let has_properties = obj.contains_key("properties");
-        let has_additional_props = obj.contains_key("additionalProperties");
-
-        if is_object && !has_properties && has_additional_props {
-            // This is a map type - Gemini doesn't support this natively
-            // We need to generate a workaround schema that Gemini can understand
-            let additional = obj.remove("additionalProperties");
-
-            // Get existing description if any
-            let existing_desc = obj
-                .get("description")
-                .and_then(|d| d.as_str())
-                .map(|s| s.to_string())
-                .unwrap_or_default();
-
-            // For Gemini, we'll define a few placeholder property keys that represent
-            // the expected dynamic key structure. This is a workaround since Gemini
-            // requires properties to be defined.
-            let value_schema = additional.unwrap_or(serde_json::json!({}));
-
-            // Try to extract specific keys from x-enum-keys extension field first,
-            // then fall back to parsing the description string for backward compatibility
-            let mut keys = vec!["key1".to_string(), "key2".to_string(), "key3".to_string()];
-            if let Some(enum_keys) = obj.remove("x-enum-keys")
-                && let Some(arr) = enum_keys.as_array()
-            {
-                let extracted_keys: Vec<String> = arr
-                    .iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                    .collect();
-                if !extracted_keys.is_empty() {
-                    keys = extracted_keys;
-                }
-            } else if let Some(start) = existing_desc.find("Keys: [")
-                && let Some(end) = existing_desc[start..].find(']')
-            {
-                let keys_str = &existing_desc[start + 7..start + end];
-                let extracted_keys: Vec<String> = keys_str
-                    .split(',')
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty())
-                    .collect();
-                if !extracted_keys.is_empty() {
-                    keys = extracted_keys;
-                }
-            }
-
-            // Create placeholder properties with the value schema
-            // Using extracted keys if available, otherwise generic key names
-            let mut placeholder_props = serde_json::Map::new();
-            for key in &keys {
-                placeholder_props.insert(key.clone(), value_schema.clone());
-            }
-
-            obj.insert("properties".to_string(), Value::Object(placeholder_props));
-
-            // Update description to explain this is a map with specific or example keys
-            let map_desc = if existing_desc.contains("Keys: [") {
-                // If keys were specified, keep the original description as-is
-                existing_desc
-            } else if existing_desc.is_empty() {
-                format!(
-                    "Object with any string keys ({} are examples - use actual meaningful key names)",
-                    keys.join(", ")
-                )
-            } else {
-                format!(
-                    "{} ({} are example keys - use actual meaningful key names)",
-                    existing_desc,
-                    keys.join(", ")
-                )
-            };
-            obj.insert("description".to_string(), Value::String(map_desc));
-        }
-
-        // Strip x-enum-keys extension (consumed above for maps, not needed in final schema)
+        // `x-enum-keys` is a rstructor hint, not part of Gemini's schema dialect.
         obj.remove("x-enum-keys");
 
         // Recursively process nested schemas
@@ -2381,7 +2293,7 @@ mod tests {
     }
 
     #[test]
-    fn test_gemini_schema_strips_additional_properties() {
+    fn test_gemini_schema_preserves_closed_object_constraint() {
         let mut schema_json = serde_json::json!({
             "type": "object",
             "properties": {
@@ -2392,10 +2304,7 @@ mod tests {
 
         strip_gemini_unsupported_keywords(&mut schema_json);
 
-        assert!(
-            schema_json.get("additionalProperties").is_none(),
-            "additionalProperties should be stripped"
-        );
+        assert_eq!(schema_json["additionalProperties"], false);
     }
 
     #[test]
@@ -2526,7 +2435,7 @@ mod tests {
     }
 
     #[test]
-    fn test_gemini_map_with_x_enum_keys() {
+    fn test_gemini_map_preserves_typed_additional_properties() {
         let mut schema = serde_json::json!({
             "type": "object",
             "properties": {
@@ -2539,25 +2448,18 @@ mod tests {
             }
         });
         strip_gemini_unsupported_keywords_recursive(&mut schema);
-        let props = schema["properties"]["counts"]["properties"]
-            .as_object()
-            .unwrap();
-        assert!(props.contains_key("info"), "should have 'info' key");
-        assert!(props.contains_key("warn"), "should have 'warn' key");
-        assert!(props.contains_key("error"), "should have 'error' key");
+        let counts = &schema["properties"]["counts"];
+        assert_eq!(counts["type"], "object");
+        assert_eq!(counts["additionalProperties"]["type"], "integer");
+        assert!(counts.get("properties").is_none());
         assert!(
-            !props.contains_key("key1"),
-            "should not have placeholder 'key1'"
-        );
-        assert!(
-            schema["properties"]["counts"].get("x-enum-keys").is_none(),
+            counts.get("x-enum-keys").is_none(),
             "x-enum-keys should be stripped from final schema"
         );
     }
 
     #[test]
-    fn test_gemini_map_with_description_only_keys_hint() {
-        // Backward compat: description-only "Keys: [...]" pattern still works
+    fn test_gemini_map_description_does_not_change_map_shape() {
         let mut schema = serde_json::json!({
             "type": "object",
             "properties": {
@@ -2569,16 +2471,10 @@ mod tests {
             }
         });
         strip_gemini_unsupported_keywords_recursive(&mut schema);
-        let props = schema["properties"]["counts"]["properties"]
-            .as_object()
-            .unwrap();
-        assert!(props.contains_key("alpha"), "should have 'alpha' key");
-        assert!(props.contains_key("beta"), "should have 'beta' key");
-        assert!(props.contains_key("gamma"), "should have 'gamma' key");
-        assert!(
-            !props.contains_key("key1"),
-            "should not have placeholder 'key1'"
-        );
+        let counts = &schema["properties"]["counts"];
+        assert_eq!(counts["description"], "Keys: [alpha, beta, gamma]");
+        assert_eq!(counts["additionalProperties"]["type"], "integer");
+        assert!(counts.get("properties").is_none());
     }
 
     #[test]
@@ -3518,10 +3414,10 @@ mod tests {
     }
 
     #[test]
-    fn strict_then_gemini_combination_strips_added_props_keeps_required() {
+    fn strict_then_gemini_combination_preserves_closed_objects_and_required() {
         // First run strict mode (adds additionalProperties:false + required at
-        // every object level), then run gemini stripping (removes the boolean
-        // additionalProperties but leaves `required` intact at both levels).
+        // every object level), then run Gemini cleanup. Gemini now supports the
+        // boolean constraint, so both compatibility requirements survive.
         let mut schema = serde_json::json!({
             "type": "object",
             "properties": {
@@ -3545,12 +3441,10 @@ mod tests {
 
         strip_gemini_unsupported_keywords(&mut schema);
 
-        // Boolean additionalProperties stripped at both levels.
-        assert!(schema.get("additionalProperties").is_none());
-        assert!(
-            schema["properties"]["nested"]
-                .get("additionalProperties")
-                .is_none()
+        assert_eq!(schema["additionalProperties"], serde_json::json!(false));
+        assert_eq!(
+            schema["properties"]["nested"]["additionalProperties"],
+            serde_json::json!(false)
         );
 
         // required survives at both levels (strict populated it from properties).
@@ -3566,8 +3460,8 @@ mod tests {
     #[test]
     fn gemini_map_value_with_nested_keywords_is_recleaned() {
         // A map (additionalProperties object) whose value schema itself carries
-        // unsupported keywords (title/examples). After the map placeholder keys
-        // are synthesized, the value schemas must be re-cleaned.
+        // unsupported keywords (title/examples). The map shape is preserved while
+        // its value schema is recursively cleaned.
         let mut schema = serde_json::json!({
             "type": "object",
             "additionalProperties": {
@@ -3582,17 +3476,18 @@ mod tests {
         });
         strip_gemini_unsupported_keywords_recursive(&mut schema);
 
-        let placeholder = &schema["properties"]["alpha"];
-        assert_eq!(placeholder["type"], "object");
+        let value_schema = &schema["additionalProperties"];
+        assert_eq!(value_schema["type"], "object");
         assert!(
-            placeholder.get("title").is_none(),
+            value_schema.get("title").is_none(),
             "nested title should be re-cleaned"
         );
         assert!(
-            placeholder.get("examples").is_none(),
+            value_schema.get("examples").is_none(),
             "nested examples should be re-cleaned"
         );
-        assert_eq!(placeholder["properties"]["a"]["type"], "integer");
+        assert_eq!(value_schema["properties"]["a"]["type"], "integer");
+        assert!(schema.get("properties").is_none());
         assert!(schema.get("x-enum-keys").is_none());
     }
 
@@ -3672,18 +3567,16 @@ mod tests {
     }
 
     #[test]
-    fn gemini_map_additional_properties_true_no_placeholders() {
-        // additionalProperties: true (boolean) is simply removed; no placeholder
-        // properties are synthesized.
+    fn gemini_map_preserves_additional_properties_true() {
         let mut schema = serde_json::json!({
             "type": "object",
             "additionalProperties": true
         });
         strip_gemini_unsupported_keywords_recursive(&mut schema);
-        assert!(schema.get("additionalProperties").is_none());
+        assert_eq!(schema["additionalProperties"], true);
         assert!(
             schema.get("properties").is_none(),
-            "boolean additionalProperties should not synthesize placeholder properties"
+            "dynamic maps should not synthesize placeholder properties"
         );
     }
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -304,6 +304,20 @@ pub enum RStructorError {
     #[error("Schema error: {0}")]
     SchemaError(String),
 
+    /// A provider cannot represent part of the requested schema without changing
+    /// which values the Rust type accepts.
+    #[error("{provider} cannot represent {context} at {path}: {message}")]
+    SchemaCompatibilityError {
+        /// Provider whose structured-output dialect rejected the schema.
+        provider: Box<str>,
+        /// Human-readable schema context, such as a structured output or tool arguments.
+        context: Box<str>,
+        /// JSONPath-style location of the incompatible schema node.
+        path: Box<str>,
+        /// Explanation of the unsupported construct and available remediation.
+        message: Box<str>,
+    },
+
     /// Error serializing or deserializing data
     #[error("Serialization error: {0}")]
     SerializationError(String),
@@ -449,6 +463,25 @@ impl PartialEq for RStructorError {
             ) => p1 == p2 && k1 == k2,
             (Self::ValidationError(a), Self::ValidationError(b)) => a == b,
             (Self::SchemaError(a), Self::SchemaError(b)) => a == b,
+            (
+                Self::SchemaCompatibilityError {
+                    provider: provider_a,
+                    context: context_a,
+                    path: path_a,
+                    message: message_a,
+                },
+                Self::SchemaCompatibilityError {
+                    provider: provider_b,
+                    context: context_b,
+                    path: path_b,
+                    message: message_b,
+                },
+            ) => {
+                provider_a == provider_b
+                    && context_a == context_b
+                    && path_a == path_b
+                    && message_a == message_b
+            }
             (Self::SerializationError(a), Self::SerializationError(b)) => a == b,
             (
                 Self::OutputDecodeError {

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -306,6 +306,38 @@ pub enum RStructorError {
 
     /// A provider cannot represent part of the requested schema without changing
     /// which values the Rust type accepts.
+    ///
+    /// Dynamic map keys are one example: OpenAI strict structured outputs close
+    /// every object, so rstructor reports the affected field before making an
+    /// HTTP request.
+    ///
+    /// ```no_run
+    /// use std::collections::HashMap;
+    ///
+    /// use rstructor::{Instructor, LLMClient, OpenAIClient, RStructorError};
+    /// use serde::{Deserialize, Serialize};
+    ///
+    /// #[derive(Instructor, Serialize, Deserialize, Debug)]
+    /// struct Portfolio {
+    ///     positions: HashMap<String, i64>,
+    /// }
+    ///
+    /// # async fn example() -> rstructor::Result<()> {
+    /// let client = OpenAIClient::new("api-key")?;
+    /// let error = client
+    ///     .materialize::<Portfolio>("AAPL: 1,000 shares")
+    ///     .await
+    ///     .unwrap_err();
+    ///
+    /// assert!(matches!(
+    ///     error,
+    ///     RStructorError::SchemaCompatibilityError { provider, path, .. }
+    ///         if provider.as_ref() == "OpenAI"
+    ///             && path.as_ref() == "$.properties.positions"
+    /// ));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[error("{provider} cannot represent {context} at {path}: {message}")]
     SchemaCompatibilityError {
         /// Provider whose structured-output dialect rejected the schema.

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -279,6 +279,15 @@ mod error_tests {
         // Other errors are not retryable
         assert!(!RStructorError::ValidationError("test".into()).is_retryable());
         assert!(!RStructorError::SchemaError("test".into()).is_retryable());
+        assert!(
+            !RStructorError::SchemaCompatibilityError {
+                provider: "OpenAI".into(),
+                context: "structured output".into(),
+                path: "$.properties.positions".into(),
+                message: "dynamic maps are unsupported".into(),
+            }
+            .is_retryable()
+        );
         assert!(!RStructorError::SerializationError("test".into()).is_retryable());
         assert!(
             !RStructorError::OutputDecodeError {
@@ -316,6 +325,30 @@ mod error_tests {
         let err = RStructorError::SchemaError("Invalid schema".to_string());
         let err_string = format!("{}", err);
         assert_eq!(err_string, "Schema error: Invalid schema");
+    }
+
+    #[test]
+    fn test_schema_compatibility_error_display_and_equality() {
+        let error = RStructorError::SchemaCompatibilityError {
+            provider: "OpenAI".into(),
+            context: "structured output".into(),
+            path: "$.properties.positions".into(),
+            message: "dynamic object keys are unsupported".into(),
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "OpenAI cannot represent structured output at $.properties.positions: dynamic object keys are unsupported"
+        );
+        assert_eq!(
+            error,
+            RStructorError::SchemaCompatibilityError {
+                provider: "OpenAI".into(),
+                context: "structured output".into(),
+                path: "$.properties.positions".into(),
+                message: "dynamic object keys are unsupported".into(),
+            }
+        );
     }
 
     #[test]

--- a/tests/fixtures/structured/portfolio_map_valid.json
+++ b/tests/fixtures/structured/portfolio_map_valid.json
@@ -1,0 +1,16 @@
+{
+  "portfolio_id": "HF-ALPHA-001",
+  "as_of": "2026-07-24",
+  "positions": {
+    "AAPL": {
+      "asset_class": "equity",
+      "quantity": 125000,
+      "mark_price": 213.76
+    },
+    "ESU6": {
+      "asset_class": "future",
+      "quantity": -240,
+      "mark_price": 6378.25
+    }
+  }
+}

--- a/tests/hashmap_integration_tests.rs
+++ b/tests/hashmap_integration_tests.rs
@@ -39,7 +39,6 @@ mod hashmap_tests {
         let prompt = "Organize these items into categories: apple, hammer, banana, screwdriver, drill. Use category names like 'fruit', 'tools' as the keys.";
         let result: rstructor::Result<Inventory> = client.materialize(prompt).await;
 
-        // This is expected to fail or produce interesting schema errors if HashMap isn't handled
         assert!(
             result.is_ok(),
             "HashMap<String, Vec<String>> failed: {:?}",
@@ -47,7 +46,6 @@ mod hashmap_tests {
         );
         let inv = result.unwrap();
         // Check that we got some categories with items
-        // Note: Gemini may use different key names due to schema limitations
         assert!(
             !inv.categories.is_empty(),
             "Expected categories to have entries, got empty map"
@@ -78,7 +76,6 @@ mod hashmap_tests {
         );
         let map = result.unwrap();
         // Check that we got user data entries with correct structure
-        // Note: Gemini may use different key names due to schema limitations
         assert!(
             !map.user_data.is_empty(),
             "Expected user_data to have entries, got empty map"

--- a/tests/map_fidelity_tests.rs
+++ b/tests/map_fidelity_tests.rs
@@ -1,0 +1,237 @@
+//! Provider-boundary tests for dynamic map schemas.
+//!
+//! `HashMap<String, V>` is the canonical Rust representation for runtime keys.
+//! Providers must either preserve those keys and the value schema or reject the
+//! request locally before a paid HTTP call.
+
+use std::collections::HashMap;
+
+use rstructor::{Instructor, LLMClient, RStructorError};
+use serde::{Deserialize, Serialize};
+
+#[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
+struct MappedPortfolio {
+    portfolio_id: String,
+    as_of: String,
+    positions: HashMap<String, Position>,
+}
+
+#[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
+struct Position {
+    asset_class: String,
+    quantity: i64,
+    mark_price: f64,
+}
+
+fn assert_map_compatibility_error(
+    error: RStructorError,
+    expected_provider: &str,
+    expected_context: &str,
+) {
+    assert!(matches!(
+        error,
+        RStructorError::SchemaCompatibilityError {
+            provider,
+            context,
+            path,
+            message,
+        } if provider.as_ref() == expected_provider
+            && context.as_ref() == expected_context
+            && path.as_ref() == "$.properties.positions"
+            && message.contains("additionalProperties: false")
+    ));
+}
+
+#[cfg(feature = "mock")]
+#[tokio::test]
+async fn mock_client_decodes_the_public_hashmap_representation() {
+    let response = include_str!("fixtures/structured/portfolio_map_valid.json");
+    let portfolio: MappedPortfolio = rstructor::MockClient::new()
+        .with_response(response)
+        .materialize("reconcile the portfolio")
+        .await
+        .unwrap();
+
+    assert_eq!(portfolio.positions.len(), 2);
+    assert_eq!(portfolio.positions["AAPL"].quantity, 125_000);
+    assert_eq!(portfolio.positions["ESU6"].quantity, -240);
+}
+
+#[cfg(feature = "openai")]
+#[tokio::test]
+async fn openai_rejects_dynamic_maps_before_http() {
+    let server = mockito::Server::new_async().await;
+    let error = rstructor::OpenAIClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .no_retries()
+        .materialize::<MappedPortfolio>("reconcile the portfolio")
+        .await
+        .unwrap_err();
+
+    assert_map_compatibility_error(error, "OpenAI", "structured output");
+}
+
+#[cfg(feature = "anthropic")]
+#[tokio::test]
+async fn anthropic_rejects_dynamic_maps_before_http() {
+    let server = mockito::Server::new_async().await;
+    let error = rstructor::AnthropicClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .no_retries()
+        .materialize::<MappedPortfolio>("reconcile the portfolio")
+        .await
+        .unwrap_err();
+
+    assert_map_compatibility_error(error, "Anthropic", "structured output");
+}
+
+#[cfg(feature = "grok")]
+#[tokio::test]
+async fn grok_rejects_dynamic_maps_before_http() {
+    let server = mockito::Server::new_async().await;
+    let error = rstructor::GrokClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .no_retries()
+        .materialize::<MappedPortfolio>("reconcile the portfolio")
+        .await
+        .unwrap_err();
+
+    assert_map_compatibility_error(error, "Grok", "structured output");
+}
+
+#[cfg(all(feature = "openai", feature = "streaming"))]
+#[tokio::test]
+async fn openai_object_stream_yields_local_map_error() {
+    use futures_util::StreamExt;
+
+    let server = mockito::Server::new_async().await;
+    let client = rstructor::OpenAIClient::new("test-key")
+        .unwrap()
+        .base_url(server.url());
+    let mut stream = client.materialize_stream::<MappedPortfolio>("reconcile the portfolio");
+    let error = stream.next().await.expect("one local error").unwrap_err();
+
+    assert_map_compatibility_error(error, "OpenAI", "streamed structured output");
+    assert!(stream.next().await.is_none());
+}
+
+#[cfg(all(feature = "openai", feature = "streaming"))]
+#[tokio::test]
+async fn openai_item_stream_yields_local_map_error() {
+    use futures_util::StreamExt;
+
+    let server = mockito::Server::new_async().await;
+    let client = rstructor::OpenAIClient::new("test-key")
+        .unwrap()
+        .base_url(server.url());
+    let mut stream = client.materialize_iter::<MappedPortfolio>("reconcile portfolios");
+    let error = stream.next().await.expect("one local error").unwrap_err();
+
+    assert_map_compatibility_error(error, "OpenAI", "streamed item");
+    assert!(stream.next().await.is_none());
+}
+
+#[cfg(all(feature = "openai", feature = "tools"))]
+#[tokio::test]
+async fn openai_tool_map_is_rejected_before_http() {
+    use rstructor::{FnTool, RequestExt, Toolbox};
+    use serde_json::json;
+
+    #[derive(Instructor, Serialize, Deserialize)]
+    struct ScenarioArgs {
+        scenario_prices: HashMap<String, f64>,
+    }
+
+    let server = mockito::Server::new_async().await;
+    let toolbox = Toolbox::new().with(FnTool::new(
+        "scenario_price",
+        "Apply per-symbol scenario prices",
+        |args: ScenarioArgs| async move { Ok(json!({ "count": args.scenario_prices.len() })) },
+    ));
+    let error = rstructor::OpenAIClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .with_tools(&toolbox)
+        .run("price the scenario")
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        RStructorError::SchemaCompatibilityError {
+            provider,
+            context,
+            path,
+            ..
+        } if provider.as_ref() == "OpenAI"
+            && context.as_ref() == "tool `scenario_price` arguments"
+            && path.as_ref() == "$.properties.scenario_prices"
+    ));
+}
+
+#[cfg(feature = "gemini")]
+#[tokio::test]
+async fn gemini_sends_and_decodes_a_native_typed_map() {
+    use serde_json::{Value, json};
+    use std::sync::{Arc, Mutex};
+
+    let response = include_str!("fixtures/structured/portfolio_map_valid.json");
+    let captured: Arc<Mutex<Option<Value>>> = Arc::new(Mutex::new(None));
+    let sink = captured.clone();
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/models/test-map-model:generateContent")
+        .match_query(mockito::Matcher::UrlEncoded(
+            "key".to_string(),
+            "test-key".to_string(),
+        ))
+        .match_request(move |request| {
+            let body: Value =
+                serde_json::from_str(&request.utf8_lossy_body().expect("UTF-8 request body"))
+                    .expect("JSON request body");
+            *sink.lock().expect("capture lock") = Some(body);
+            true
+        })
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{ "text": response }]
+                    },
+                    "finishReason": "STOP"
+                }]
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let portfolio: MappedPortfolio = rstructor::GeminiClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("test-map-model")
+        .no_retries()
+        .materialize("reconcile the portfolio")
+        .await
+        .unwrap();
+
+    request.assert_async().await;
+    assert_eq!(portfolio.positions["AAPL"].quantity, 125_000);
+    assert_eq!(portfolio.positions["ESU6"].quantity, -240);
+
+    let body = captured.lock().expect("capture lock");
+    let positions_schema = &body.as_ref().expect("captured request")["generation_config"]["response_schema"]
+        ["properties"]["positions"];
+    assert_eq!(positions_schema["type"], "object");
+    assert_eq!(
+        positions_schema["additionalProperties"]["properties"]["quantity"]["type"],
+        "integer"
+    );
+    assert!(positions_schema.get("properties").is_none());
+}

--- a/tests/map_fidelity_tests.rs
+++ b/tests/map_fidelity_tests.rs
@@ -23,6 +23,25 @@ struct Position {
     mark_price: f64,
 }
 
+#[cfg(feature = "tools")]
+#[derive(Instructor, Serialize, Deserialize)]
+struct ScenarioArgs {
+    scenario_prices: HashMap<String, f64>,
+}
+
+#[cfg(feature = "tools")]
+fn scenario_price_toolbox() -> rstructor::Toolbox {
+    rstructor::Toolbox::new().with(rstructor::FnTool::new(
+        "scenario_price",
+        "Apply per-symbol scenario prices",
+        |args: ScenarioArgs| async move {
+            Ok(serde_json::json!({
+                "count": args.scenario_prices.len()
+            }))
+        },
+    ))
+}
+
 fn assert_map_compatibility_error(
     error: RStructorError,
     expected_provider: &str,
@@ -134,23 +153,77 @@ async fn openai_item_stream_yields_local_map_error() {
     assert!(stream.next().await.is_none());
 }
 
+#[cfg(all(feature = "anthropic", feature = "streaming"))]
+#[tokio::test]
+async fn anthropic_object_stream_yields_local_map_error() {
+    use futures_util::StreamExt;
+
+    let server = mockito::Server::new_async().await;
+    let client = rstructor::AnthropicClient::new("test-key")
+        .unwrap()
+        .base_url(server.url());
+    let mut stream = client.materialize_stream::<MappedPortfolio>("reconcile the portfolio");
+    let error = stream.next().await.expect("one local error").unwrap_err();
+
+    assert_map_compatibility_error(error, "Anthropic", "streamed structured output");
+    assert!(stream.next().await.is_none());
+}
+
+#[cfg(all(feature = "anthropic", feature = "streaming"))]
+#[tokio::test]
+async fn anthropic_item_stream_yields_local_map_error() {
+    use futures_util::StreamExt;
+
+    let server = mockito::Server::new_async().await;
+    let client = rstructor::AnthropicClient::new("test-key")
+        .unwrap()
+        .base_url(server.url());
+    let mut stream = client.materialize_iter::<MappedPortfolio>("reconcile portfolios");
+    let error = stream.next().await.expect("one local error").unwrap_err();
+
+    assert_map_compatibility_error(error, "Anthropic", "streamed item");
+    assert!(stream.next().await.is_none());
+}
+
+#[cfg(all(feature = "grok", feature = "streaming"))]
+#[tokio::test]
+async fn grok_object_stream_yields_local_map_error() {
+    use futures_util::StreamExt;
+
+    let server = mockito::Server::new_async().await;
+    let client = rstructor::GrokClient::new("test-key")
+        .unwrap()
+        .base_url(server.url());
+    let mut stream = client.materialize_stream::<MappedPortfolio>("reconcile the portfolio");
+    let error = stream.next().await.expect("one local error").unwrap_err();
+
+    assert_map_compatibility_error(error, "Grok", "streamed structured output");
+    assert!(stream.next().await.is_none());
+}
+
+#[cfg(all(feature = "grok", feature = "streaming"))]
+#[tokio::test]
+async fn grok_item_stream_yields_local_map_error() {
+    use futures_util::StreamExt;
+
+    let server = mockito::Server::new_async().await;
+    let client = rstructor::GrokClient::new("test-key")
+        .unwrap()
+        .base_url(server.url());
+    let mut stream = client.materialize_iter::<MappedPortfolio>("reconcile portfolios");
+    let error = stream.next().await.expect("one local error").unwrap_err();
+
+    assert_map_compatibility_error(error, "Grok", "streamed item");
+    assert!(stream.next().await.is_none());
+}
+
 #[cfg(all(feature = "openai", feature = "tools"))]
 #[tokio::test]
 async fn openai_tool_map_is_rejected_before_http() {
-    use rstructor::{FnTool, RequestExt, Toolbox};
-    use serde_json::json;
-
-    #[derive(Instructor, Serialize, Deserialize)]
-    struct ScenarioArgs {
-        scenario_prices: HashMap<String, f64>,
-    }
+    use rstructor::RequestExt;
 
     let server = mockito::Server::new_async().await;
-    let toolbox = Toolbox::new().with(FnTool::new(
-        "scenario_price",
-        "Apply per-symbol scenario prices",
-        |args: ScenarioArgs| async move { Ok(json!({ "count": args.scenario_prices.len() })) },
-    ));
+    let toolbox = scenario_price_toolbox();
     let error = rstructor::OpenAIClient::new("test-key")
         .unwrap()
         .base_url(server.url())
@@ -172,16 +245,67 @@ async fn openai_tool_map_is_rejected_before_http() {
     ));
 }
 
+#[cfg(all(feature = "anthropic", feature = "tools"))]
+#[tokio::test]
+async fn anthropic_tool_map_is_rejected_before_http() {
+    use rstructor::RequestExt;
+
+    let server = mockito::Server::new_async().await;
+    let toolbox = scenario_price_toolbox();
+    let error = rstructor::AnthropicClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .with_tools(&toolbox)
+        .run("price the scenario")
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        RStructorError::SchemaCompatibilityError {
+            provider,
+            context,
+            path,
+            ..
+        } if provider.as_ref() == "Anthropic"
+            && context.as_ref() == "tool `scenario_price` arguments"
+            && path.as_ref() == "$.properties.scenario_prices"
+    ));
+}
+
+#[cfg(all(feature = "grok", feature = "tools"))]
+#[tokio::test]
+async fn grok_tool_map_is_rejected_before_http() {
+    use rstructor::RequestExt;
+
+    let server = mockito::Server::new_async().await;
+    let toolbox = scenario_price_toolbox();
+    let error = rstructor::GrokClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .with_tools(&toolbox)
+        .run("price the scenario")
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        RStructorError::SchemaCompatibilityError {
+            provider,
+            context,
+            path,
+            ..
+        } if provider.as_ref() == "Grok"
+            && context.as_ref() == "tool `scenario_price` arguments"
+            && path.as_ref() == "$.properties.scenario_prices"
+    ));
+}
+
 #[cfg(all(feature = "gemini", feature = "tools"))]
 #[tokio::test]
 async fn gemini_tool_sends_and_invokes_a_native_typed_map() {
-    use rstructor::{FnTool, RequestExt, Toolbox};
+    use rstructor::RequestExt;
     use serde_json::{Value, json};
-
-    #[derive(Instructor, Serialize, Deserialize)]
-    struct ScenarioArgs {
-        scenario_prices: HashMap<String, f64>,
-    }
 
     let mut server = mockito::Server::new_async().await;
     let first_request = server
@@ -259,11 +383,7 @@ async fn gemini_tool_sends_and_invokes_a_native_typed_map() {
         .create_async()
         .await;
 
-    let toolbox = Toolbox::new().with(FnTool::new(
-        "scenario_price",
-        "Apply per-symbol scenario prices",
-        |args: ScenarioArgs| async move { Ok(json!({ "count": args.scenario_prices.len() })) },
-    ));
+    let toolbox = scenario_price_toolbox();
     let answer = rstructor::GeminiClient::new("test-key")
         .unwrap()
         .base_url(server.url())
@@ -341,4 +461,135 @@ async fn gemini_sends_and_decodes_a_native_typed_map() {
     );
     assert!(positions_schema.get("properties").is_none());
     assert!(generation_config.get("response_schema").is_none());
+}
+
+#[cfg(all(feature = "gemini", feature = "streaming"))]
+#[tokio::test]
+async fn gemini_object_stream_sends_and_decodes_a_native_typed_map() {
+    use futures_util::StreamExt;
+    use serde_json::{Value, json};
+
+    let response = include_str!("fixtures/structured/portfolio_map_valid.json");
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/models/test-map-model:streamGenerateContent")
+        .match_query(mockito::Matcher::AllOf(vec![
+            mockito::Matcher::UrlEncoded("alt".to_string(), "sse".to_string()),
+            mockito::Matcher::UrlEncoded("key".to_string(), "test-key".to_string()),
+        ]))
+        .match_request(|request| {
+            let body: Value =
+                serde_json::from_str(&request.utf8_lossy_body().expect("UTF-8 request body"))
+                    .expect("JSON request body");
+            let config = &body["generation_config"];
+            let positions = &config["responseJsonSchema"]["properties"]["positions"];
+
+            config["response_mime_type"] == "application/json"
+                && config.get("response_schema").is_none()
+                && positions["type"] == "object"
+                && positions["additionalProperties"]["properties"]["quantity"]["type"] == "integer"
+                && positions.get("properties").is_none()
+        })
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(format!(
+            "data: {}\n\n",
+            json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{ "text": response }]
+                    }
+                }]
+            })
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let client = rstructor::GeminiClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("test-map-model");
+    let mut stream = client.materialize_stream::<MappedPortfolio>("reconcile the portfolio");
+    let mut complete = None;
+    while let Some(update) = stream.next().await {
+        match update.unwrap() {
+            rstructor::StreamedObject::Partial(value) => {
+                assert!(value.is_object());
+            }
+            rstructor::StreamedObject::Complete(portfolio) => complete = Some(portfolio),
+        }
+    }
+
+    request.assert_async().await;
+    let portfolio = complete.expect("complete streamed portfolio");
+    assert_eq!(portfolio.positions["AAPL"].quantity, 125_000);
+    assert_eq!(portfolio.positions["ESU6"].quantity, -240);
+}
+
+#[cfg(all(feature = "gemini", feature = "streaming"))]
+#[tokio::test]
+async fn gemini_item_stream_sends_and_decodes_native_typed_maps() {
+    use futures_util::StreamExt;
+    use serde_json::{Value, json};
+
+    let portfolio: Value =
+        serde_json::from_str(include_str!("fixtures/structured/portfolio_map_valid.json"))
+            .expect("portfolio fixture");
+    let stream_payload = json!({ "items": [portfolio.clone(), portfolio] }).to_string();
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/models/test-map-model:streamGenerateContent")
+        .match_query(mockito::Matcher::AllOf(vec![
+            mockito::Matcher::UrlEncoded("alt".to_string(), "sse".to_string()),
+            mockito::Matcher::UrlEncoded("key".to_string(), "test-key".to_string()),
+        ]))
+        .match_request(|request| {
+            let body: Value =
+                serde_json::from_str(&request.utf8_lossy_body().expect("UTF-8 request body"))
+                    .expect("JSON request body");
+            let config = &body["generation_config"];
+            let positions =
+                &config["responseJsonSchema"]["properties"]["items"]["items"]["properties"]
+                    ["positions"];
+
+            config["response_mime_type"] == "application/json"
+                && config.get("response_schema").is_none()
+                && positions["type"] == "object"
+                && positions["additionalProperties"]["properties"]["quantity"]["type"] == "integer"
+                && positions.get("properties").is_none()
+        })
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(format!(
+            "data: {}\n\n",
+            json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{ "text": stream_payload }]
+                    }
+                }]
+            })
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let client = rstructor::GeminiClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("test-map-model");
+    let portfolios = client
+        .materialize_iter::<MappedPortfolio>("reconcile portfolios")
+        .map(|item| item.unwrap())
+        .collect::<Vec<_>>()
+        .await;
+
+    request.assert_async().await;
+    assert_eq!(portfolios.len(), 2);
+    assert!(
+        portfolios
+            .iter()
+            .all(|portfolio| portfolio.positions["AAPL"].quantity == 125_000)
+    );
 }

--- a/tests/map_fidelity_tests.rs
+++ b/tests/map_fidelity_tests.rs
@@ -172,6 +172,112 @@ async fn openai_tool_map_is_rejected_before_http() {
     ));
 }
 
+#[cfg(all(feature = "gemini", feature = "tools"))]
+#[tokio::test]
+async fn gemini_tool_sends_and_invokes_a_native_typed_map() {
+    use rstructor::{FnTool, RequestExt, Toolbox};
+    use serde_json::{Value, json};
+
+    #[derive(Instructor, Serialize, Deserialize)]
+    struct ScenarioArgs {
+        scenario_prices: HashMap<String, f64>,
+    }
+
+    let mut server = mockito::Server::new_async().await;
+    let first_request = server
+        .mock("POST", "/models/test-map-model:generateContent")
+        .match_query(mockito::Matcher::UrlEncoded(
+            "key".to_string(),
+            "test-key".to_string(),
+        ))
+        .match_request(|request| {
+            let body: Value =
+                serde_json::from_str(&request.utf8_lossy_body().expect("UTF-8 request body"))
+                    .expect("JSON request body");
+            let declaration = &body["tools"][0]["functionDeclarations"][0];
+            let map = &declaration["parametersJsonSchema"]["properties"]["scenario_prices"];
+
+            declaration["name"] == "scenario_price"
+                && declaration.get("parameters").is_none()
+                && map["type"] == "object"
+                && map["additionalProperties"]["type"] == "number"
+                && map.get("properties").is_none()
+                && body["contents"]
+                    .as_array()
+                    .is_some_and(|items| items.len() == 1)
+        })
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{
+                            "functionCall": {
+                                "name": "scenario_price",
+                                "args": {
+                                    "scenario_prices": {
+                                        "AAPL": 190.25,
+                                        "ESU6": 6200.0
+                                    }
+                                }
+                            }
+                        }]
+                    }
+                }]
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+    let second_request = server
+        .mock("POST", "/models/test-map-model:generateContent")
+        .match_query(mockito::Matcher::UrlEncoded(
+            "key".to_string(),
+            "test-key".to_string(),
+        ))
+        .match_request(|request| {
+            let body: Value =
+                serde_json::from_str(&request.utf8_lossy_body().expect("UTF-8 request body"))
+                    .expect("JSON request body");
+            body.pointer("/contents/2/parts/0/functionResponse/response/count") == Some(&json!(2))
+        })
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{ "text": "priced 2 symbols" }]
+                    }
+                }]
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let toolbox = Toolbox::new().with(FnTool::new(
+        "scenario_price",
+        "Apply per-symbol scenario prices",
+        |args: ScenarioArgs| async move { Ok(json!({ "count": args.scenario_prices.len() })) },
+    ));
+    let answer = rstructor::GeminiClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("test-map-model")
+        .with_tools(&toolbox)
+        .run("Apply AAPL at 190.25 and ESU6 at 6200")
+        .await
+        .unwrap();
+
+    first_request.assert_async().await;
+    second_request.assert_async().await;
+    assert_eq!(answer, "priced 2 symbols");
+}
+
 #[cfg(feature = "gemini")]
 #[tokio::test]
 async fn gemini_sends_and_decodes_a_native_typed_map() {
@@ -226,12 +332,13 @@ async fn gemini_sends_and_decodes_a_native_typed_map() {
     assert_eq!(portfolio.positions["ESU6"].quantity, -240);
 
     let body = captured.lock().expect("capture lock");
-    let positions_schema = &body.as_ref().expect("captured request")["generation_config"]["response_schema"]
-        ["properties"]["positions"];
+    let generation_config = &body.as_ref().expect("captured request")["generation_config"];
+    let positions_schema = &generation_config["responseJsonSchema"]["properties"]["positions"];
     assert_eq!(positions_schema["type"], "object");
     assert_eq!(
         positions_schema["additionalProperties"]["properties"]["quantity"]["type"],
         "integer"
     );
     assert!(positions_schema.get("properties").is_none());
+    assert!(generation_config.get("response_schema").is_none());
 }

--- a/tests/mock_edge_tests.rs
+++ b/tests/mock_edge_tests.rs
@@ -208,6 +208,12 @@ async fn path_aware_errors_are_preserved_when_mock_defaults_are_cloned() {
             path: "$.order.quantity".to_string(),
             message: "invalid type".to_string(),
         },
+        RStructorError::SchemaCompatibilityError {
+            provider: "OpenAI".into(),
+            context: "structured output".into(),
+            path: "$.properties.positions".into(),
+            message: "dynamic maps are unsupported".into(),
+        },
     ] {
         let client = MockClient::new().with_default_response(MockResponse::error(error));
         let first = client.generate("p").await.unwrap_err();


### PR DESCRIPTION
## Summary

- keep `HashMap<String, V>` / `BTreeMap<String, V>` as the exact public representation for runtime-keyed objects
- send Gemini output and tool schemas through `responseJsonSchema` and `parametersJsonSchema`, preserving typed `additionalProperties`
- reject dynamic maps locally for OpenAI, Anthropic, and Grok strict schemas instead of silently closing them to `{}`
- add a path-aware, non-retryable `SchemaCompatibilityError`
- make `DynTool::parameters_schema()` return the canonical schema and apply provider transforms only when rendering a request

## Why

The previous provider transforms could turn this Rust contract:

```rust
positions: HashMap<String, Position>
```

into an object with `additionalProperties: false`. That schema accepts no runtime keys, so a request could silently stop representing the Rust type it claimed to materialize.

This PR makes schema fidelity the invariant:

- Gemini preserves arbitrary keys and the complete value schema.
- Strict providers fail before HTTP when their dialect cannot express that contract.
- No provider silently chooses placeholder keys or an entry-array fallback.

## Usage

Gemini supports the native map shape:

```rust
use std::collections::HashMap;
use rstructor::{GeminiClient, Instructor, LLMClient};
use serde::{Deserialize, Serialize};

#[derive(Instructor, Serialize, Deserialize, Debug)]
struct Position {
    quantity: i64,
    mark_price: f64,
}

#[derive(Instructor, Serialize, Deserialize, Debug)]
struct Portfolio {
    positions: HashMap<String, Position>,
}

let portfolio: Portfolio = GeminiClient::from_env()?
    .materialize("AAPL: 125,000 shares at 213.76; ESU6: short 240 at 6378.25")
    .await?;

assert_eq!(portfolio.positions["AAPL"].quantity, 125_000);
assert_eq!(portfolio.positions["ESU6"].quantity, -240);
```

Strict-provider incompatibility is explicit and path-aware:

```rust
use rstructor::{LLMClient, OpenAIClient, RStructorError};

let result = OpenAIClient::from_env()?
    .materialize::<Portfolio>("Extract the positions")
    .await;

assert!(matches!(
    result,
    Err(RStructorError::SchemaCompatibilityError {
        provider,
        path,
        ..
    }) if provider.as_ref() == "OpenAI"
        && path.as_ref() == "$.properties.positions"
));
```

## Behavior and compatibility

- This is an intentional behavior change: OpenAI, Anthropic, and Grok now return a non-retryable local error for dynamic maps rather than sending a schema with different semantics.
- Fixed-key objects should remain structs.
- Gemini `generateContent` requests now use the current JSON Schema fields. Custom Gemini-compatible base URLs must support `responseJsonSchema` and `parametersJsonSchema`.
- Adding `SchemaCompatibilityError` and changing `DynTool::parameters_schema()` from strict-transformed to canonical schema may affect exhaustive error matching or code that directly inspects dynamic tool schemas.

## Test coverage

- 17 dedicated map-fidelity tests cover:
  - real-world portfolio fixture decoding
  - non-streaming, object-streaming, item-streaming, and tool paths
  - every strict provider's local/no-HTTP error
  - Gemini output and tool request shapes
  - Gemini streamed output and item decoding
- live Gemini verification covers typed maps, enum unions, object/item streaming, and tool calling
- full live-provider workspace suite passes

Commands run:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --all-features
cargo test --doc --workspace --all-features
cargo check --no-default-features --features derive --lib
cargo check --no-default-features --features mock --lib
cargo test --no-default-features --features derive,mock --lib
cargo test --no-default-features --features derive,mock --test mock_client_tests --test mock_edge_tests
```
