### PR TITLE
[codex] Enforce strict streaming integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,35 @@ while let Some(item) = stream.next().await {
 }
 ```
 
+Streaming uses strict integrity checks by default. A stream can yield validated
+items and later report malformed provider data or a truncated response, so the
+full collection is authoritative only after the stream drains to `None` without
+an error. OpenAI/Grok must send `[DONE]`, Anthropic must send `message_stop`, and
+Gemini must provide a non-empty `finishReason`.
+
+For irreversible side effects, stage items until clean completion and handle the
+machine-readable error kind:
+
+```rust
+use rstructor::{RStructorError, StreamErrorKind};
+
+let mut staged = Vec::new();
+while let Some(item) = stream.next().await {
+    match item {
+        Ok(invention) => staged.push(invention),
+        Err(RStructorError::StreamingError {
+            kind: StreamErrorKind::IncompleteEventStream,
+            ..
+        }) => {
+            staged.clear(); // do not commit a possibly truncated collection
+            return Err("provider stream ended without its terminal event".into());
+        }
+        Err(error) => return Err(error.into()),
+    }
+}
+commit_inventions(staged).await?;
+```
+
 `generate_stream` streams raw text deltas:
 
 ```rust

--- a/examples/streaming_example.rs
+++ b/examples/streaming_example.rs
@@ -30,16 +30,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut stream =
         client.materialize_iter::<Invention>("List 8 important inventions of the 20th century.");
 
-    let mut n = 0;
+    let mut inventions = Vec::new();
     while let Some(item) = stream.next().await {
+        // An integrity error can follow already-validated items if the provider
+        // truncates the response. Only commit irreversible side effects after
+        // this loop drains cleanly.
         let invention = item?; // each item is fully parsed and validated
-        n += 1;
         println!(
-            "  {n}. {} ({}) — {}",
-            invention.name, invention.year, invention.inventor
+            "  tentative {}. {} ({}) — {}",
+            inventions.len() + 1,
+            invention.name,
+            invention.year,
+            invention.inventor
         );
+        inventions.push(invention);
     }
 
-    println!("\nStreamed {n} items.");
+    println!(
+        "\nStream completed cleanly; {} items are authoritative.",
+        inventions.len()
+    );
     Ok(())
 }

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -872,7 +872,8 @@ impl LLMClient for AnthropicClient {
         let body = self.stream_body(prompt, None);
         crate::backend::streaming::sse_text_stream(
             self.send_stream(body),
-            crate::backend::streaming::anthropic_delta,
+            crate::backend::streaming::anthropic_stream_event,
+            crate::backend::streaming::TerminalMarker::AnthropicMessageStop,
         )
     }
 
@@ -900,7 +901,8 @@ impl LLMClient for AnthropicClient {
         let body = self.stream_body(prompt, Some(output_format));
         crate::backend::streaming::object_stream(
             self.send_stream(body),
-            crate::backend::streaming::anthropic_delta,
+            crate::backend::streaming::anthropic_stream_event,
+            crate::backend::streaming::TerminalMarker::AnthropicMessageStop,
         )
     }
 
@@ -926,7 +928,8 @@ impl LLMClient for AnthropicClient {
         let body = self.stream_body(prompt, Some(output_format));
         crate::backend::streaming::iter_stream(
             self.send_stream(body),
-            crate::backend::streaming::anthropic_delta,
+            crate::backend::streaming::anthropic_stream_event,
+            crate::backend::streaming::TerminalMarker::AnthropicMessageStop,
             crate::backend::streaming::finalize_item::<T>,
         )
     }

--- a/src/backend/client.rs
+++ b/src/backend/client.rs
@@ -363,6 +363,10 @@ pub trait LLMClient {
     /// back to a single chunk from [`generate`](Self::generate); the built-in
     /// providers override it with true server-sent-events streaming.
     ///
+    /// A provider or integrity error can follow earlier text chunks. The response
+    /// is authoritative only after the stream has been drained to `None` without
+    /// an error.
+    ///
     /// Requires the `streaming` feature.
     #[cfg(feature = "streaming")]
     fn generate_stream<'a>(&'a self, prompt: &'a str) -> crate::backend::streaming::TextStream<'a>
@@ -386,6 +390,9 @@ pub trait LLMClient {
     ///
     /// Note: unlike [`materialize`](Self::materialize), streaming is single-shot —
     /// a validation failure ends the stream with an error rather than re-asking.
+    /// Partial snapshots can precede a provider or integrity error;
+    /// [`StreamedObject::Complete`](crate::StreamedObject::Complete) is emitted
+    /// only after the provider's terminal event and complete JSON are verified.
     ///
     /// Requires the `streaming` feature.
     #[cfg(feature = "streaming")]
@@ -410,6 +417,10 @@ pub trait LLMClient {
     /// without buffering the whole response. The model is asked for a JSON object
     /// with an `items` array of `T`; elements are parsed and validated one at a
     /// time.
+    ///
+    /// Validated items can precede a later provider or integrity error. Treat the
+    /// collection as authoritative only after draining the stream to `None`
+    /// without an error. Malformed elements are never silently skipped.
     ///
     /// The default implementation has no streaming fallback (it errors); the
     /// built-in providers override it. Requires the `streaming` feature.

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -920,7 +920,8 @@ impl LLMClient for GeminiClient {
         let body = self.stream_body(prompt, None);
         crate::backend::streaming::sse_text_stream(
             self.send_stream(body),
-            crate::backend::streaming::gemini_delta,
+            crate::backend::streaming::gemini_stream_event,
+            crate::backend::streaming::TerminalMarker::GeminiFinishReason,
         )
     }
 
@@ -954,7 +955,8 @@ impl LLMClient for GeminiClient {
 
         crate::backend::streaming::object_stream_with(
             self.send_stream(body),
-            crate::backend::streaming::gemini_delta,
+            crate::backend::streaming::gemini_stream_event,
+            crate::backend::streaming::TerminalMarker::GeminiFinishReason,
             finalize,
         )
     }
@@ -988,7 +990,8 @@ impl LLMClient for GeminiClient {
 
         crate::backend::streaming::iter_stream(
             self.send_stream(body),
-            crate::backend::streaming::gemini_delta,
+            crate::backend::streaming::gemini_stream_event,
+            crate::backend::streaming::TerminalMarker::GeminiFinishReason,
             finalize,
         )
     }

--- a/src/backend/grok.rs
+++ b/src/backend/grok.rs
@@ -644,7 +644,8 @@ impl LLMClient for GrokClient {
         let body = self.stream_body(prompt, None);
         crate::backend::streaming::sse_text_stream(
             self.send_stream(body),
-            crate::backend::streaming::openai_delta,
+            crate::backend::streaming::openai_stream_event,
+            crate::backend::streaming::TerminalMarker::DoneSentinel,
         )
     }
 
@@ -671,7 +672,8 @@ impl LLMClient for GrokClient {
         let body = self.stream_body(prompt, Some(response_format));
         crate::backend::streaming::object_stream(
             self.send_stream(body),
-            crate::backend::streaming::openai_delta,
+            crate::backend::streaming::openai_stream_event,
+            crate::backend::streaming::TerminalMarker::DoneSentinel,
         )
     }
 
@@ -697,7 +699,8 @@ impl LLMClient for GrokClient {
         let body = self.stream_body(prompt, Some(response_format));
         crate::backend::streaming::iter_stream(
             self.send_stream(body),
-            crate::backend::streaming::openai_delta,
+            crate::backend::streaming::openai_stream_event,
+            crate::backend::streaming::TerminalMarker::DoneSentinel,
             crate::backend::streaming::finalize_item::<T>,
         )
     }

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -144,6 +144,10 @@ fn clone_error(e: &RStructorError) -> RStructorError {
                 message: message.clone(),
             }
         }
+        RStructorError::StreamingError { kind, message } => RStructorError::StreamingError {
+            kind: *kind,
+            message: message.clone(),
+        },
         RStructorError::Timeout => RStructorError::Timeout,
         RStructorError::Unsupported(s) => RStructorError::Unsupported(s.clone()),
         // Sources below don't implement Clone; preserve the message instead.

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -814,7 +814,8 @@ impl LLMClient for OpenAIClient {
         let body = self.stream_body(prompt, None);
         crate::backend::streaming::sse_text_stream(
             self.send_stream(body),
-            crate::backend::streaming::openai_delta,
+            crate::backend::streaming::openai_stream_event,
+            crate::backend::streaming::TerminalMarker::DoneSentinel,
         )
     }
 
@@ -845,7 +846,8 @@ impl LLMClient for OpenAIClient {
         let body = self.stream_body(prompt, Some(response_format));
         crate::backend::streaming::object_stream(
             self.send_stream(body),
-            crate::backend::streaming::openai_delta,
+            crate::backend::streaming::openai_stream_event,
+            crate::backend::streaming::TerminalMarker::DoneSentinel,
         )
     }
 
@@ -875,7 +877,8 @@ impl LLMClient for OpenAIClient {
         let body = self.stream_body(prompt, Some(response_format));
         crate::backend::streaming::iter_stream(
             self.send_stream(body),
-            crate::backend::streaming::openai_delta,
+            crate::backend::streaming::openai_stream_event,
+            crate::backend::streaming::TerminalMarker::DoneSentinel,
             crate::backend::streaming::finalize_item::<T>,
         )
     }

--- a/src/backend/streaming.rs
+++ b/src/backend/streaming.rs
@@ -26,7 +26,7 @@ use futures_util::{Stream, StreamExt};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 
-use crate::error::{RStructorError, Result};
+use crate::error::{RStructorError, Result, StreamErrorKind};
 use crate::model::Instructor;
 
 /// A boxed stream of text deltas. Each item is either an incremental piece of the
@@ -85,35 +85,167 @@ pub(crate) enum SseEvent {
 /// Bytes arrive in arbitrary HTTP chunks that do not respect line boundaries, so
 /// the decoder buffers a partial trailing line between [`push`](Self::push) calls
 /// and only emits events for lines it has seen in full.
-#[derive(Default)]
 pub(crate) struct SseDecoder {
     buf: Vec<u8>,
+    data_lines: Vec<String>,
+    first_line: bool,
+}
+
+impl Default for SseDecoder {
+    fn default() -> Self {
+        Self {
+            buf: Vec::new(),
+            data_lines: Vec::new(),
+            first_line: true,
+        }
+    }
 }
 
 impl SseDecoder {
     /// Feed a chunk of bytes, returning any complete `data:` events it completed.
-    pub(crate) fn push(&mut self, chunk: &[u8]) -> Vec<SseEvent> {
+    pub(crate) fn push(&mut self, chunk: &[u8]) -> Result<Vec<SseEvent>> {
         self.buf.extend_from_slice(chunk);
         let mut events = Vec::new();
 
-        while let Some(nl) = self.buf.iter().position(|&b| b == b'\n') {
-            let line_bytes: Vec<u8> = self.buf.drain(..=nl).collect();
-            let line = String::from_utf8_lossy(&line_bytes);
-            let line = line.trim_end_matches(['\r', '\n']);
-
-            // SSE: only `data:` fields carry content. Ignore `event:`, `id:`,
-            // `retry:`, comment lines (`:`...), and blank separators.
-            if let Some(rest) = line.strip_prefix("data:") {
-                let data = rest.trim();
-                if data == "[DONE]" {
-                    events.push(SseEvent::Done);
-                } else if !data.is_empty() {
-                    events.push(SseEvent::Data(data.to_string()));
-                }
+        while let Some(end) = self
+            .buf
+            .iter()
+            .position(|&byte| matches!(byte, b'\r' | b'\n'))
+        {
+            if self.buf[end] == b'\r' && end + 1 == self.buf.len() {
+                // Preserve a trailing CR until the next chunk tells us whether
+                // it is a CRLF pair or a standalone SSE line ending.
+                break;
             }
+            let delimiter_len =
+                usize::from(self.buf[end] == b'\r' && self.buf.get(end + 1) == Some(&b'\n')) + 1;
+            let line_bytes: Vec<u8> = self.buf.drain(..end).collect();
+            self.buf.drain(..delimiter_len);
+            self.process_line(&line_bytes, &mut events)?;
         }
 
-        events
+        Ok(events)
+    }
+
+    /// Finish decoding at HTTP EOF.
+    ///
+    /// SSE permits the final line/event to end at EOF without a trailing blank
+    /// line, so any buffered line is processed before the pending event is
+    /// dispatched.
+    pub(crate) fn finish(&mut self) -> Result<Vec<SseEvent>> {
+        let mut events = Vec::new();
+        if !self.buf.is_empty() {
+            let line_bytes = std::mem::take(&mut self.buf);
+            let line_bytes = line_bytes.strip_suffix(b"\r").unwrap_or(&line_bytes);
+            self.process_line(line_bytes, &mut events)?;
+        }
+        self.dispatch(&mut events);
+        Ok(events)
+    }
+
+    fn process_line(&mut self, line_bytes: &[u8], events: &mut Vec<SseEvent>) -> Result<()> {
+        let line = std::str::from_utf8(line_bytes).map_err(|error| {
+            streaming_error(
+                StreamErrorKind::InvalidEventEncoding,
+                format!("SSE data was not valid UTF-8: {error}"),
+            )
+        })?;
+        let line = if self.first_line {
+            self.first_line = false;
+            line.strip_prefix('\u{feff}').unwrap_or(line)
+        } else {
+            line
+        };
+
+        if line.is_empty() {
+            self.dispatch(events);
+            return Ok(());
+        }
+
+        // SSE: only `data` fields carry content. Ignore `event`, `id`, `retry`,
+        // comment lines, and unknown fields. Multiple `data` lines in one event
+        // are joined with newlines when the blank separator dispatches it.
+        let (field, value) = line.split_once(':').unwrap_or((line, ""));
+        if field == "data" {
+            self.data_lines
+                .push(value.strip_prefix(' ').unwrap_or(value).to_owned());
+        }
+        Ok(())
+    }
+
+    fn dispatch(&mut self, events: &mut Vec<SseEvent>) {
+        if self.data_lines.is_empty() {
+            return;
+        }
+        let data = self.data_lines.join("\n");
+        self.data_lines.clear();
+        if data == "[DONE]" {
+            events.push(SseEvent::Done);
+        } else {
+            events.push(SseEvent::Data(data));
+        }
+    }
+}
+
+fn streaming_error(kind: StreamErrorKind, message: impl Into<Box<str>>) -> RStructorError {
+    RStructorError::StreamingError {
+        kind,
+        message: message.into(),
+    }
+}
+
+fn parse_event_json(data: &str) -> Result<Value> {
+    serde_json::from_str(data).map_err(|error| {
+        streaming_error(
+            StreamErrorKind::InvalidEventJson,
+            format!(
+                "SSE data payload was not valid JSON at line {}, column {}: {}",
+                error.line(),
+                error.column(),
+                error
+            ),
+        )
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TerminalMarker {
+    DoneSentinel,
+    AnthropicMessageStop,
+    GeminiFinishReason,
+}
+
+impl TerminalMarker {
+    fn description(self) -> &'static str {
+        match self {
+            Self::DoneSentinel => "`[DONE]` sentinel",
+            Self::AnthropicMessageStop => "Anthropic `message_stop` event",
+            Self::GeminiFinishReason => "Gemini `finishReason`",
+        }
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct ProviderStreamEvent {
+    text: Option<String>,
+    terminal: bool,
+}
+
+fn invalid_provider_event(message: impl Into<Box<str>>) -> RStructorError {
+    streaming_error(StreamErrorKind::InvalidProviderEvent, message)
+}
+
+fn require_terminal(terminal: bool, marker: TerminalMarker) -> Result<()> {
+    if terminal {
+        Ok(())
+    } else {
+        Err(streaming_error(
+            StreamErrorKind::IncompleteEventStream,
+            format!(
+                "HTTP response ended before the required {}",
+                marker.description()
+            ),
+        ))
     }
 }
 
@@ -122,32 +254,61 @@ impl SseDecoder {
 /// `send` is the (async) request that yields the streaming response; deferring it
 /// lets this function return a `Stream` synchronously. `extract` pulls the
 /// incremental text out of each parsed `data:` JSON event.
-pub(crate) fn sse_text_stream<'a, Fut, F>(send: Fut, extract: F) -> TextStream<'a>
+pub(crate) fn sse_text_stream<'a, Fut, F>(
+    send: Fut,
+    extract: F,
+    marker: TerminalMarker,
+) -> TextStream<'a>
 where
     Fut: Future<Output = Result<reqwest::Response>> + Send + 'a,
-    F: Fn(&Value) -> Option<String> + Send + 'a,
+    F: Fn(&Value) -> Result<ProviderStreamEvent> + Send + 'a,
 {
     Box::pin(try_stream! {
         let response = send.await?;
         let mut bytes = response.bytes_stream();
         let mut decoder = SseDecoder::default();
 
-        'outer: while let Some(chunk) = bytes.next().await {
-            let chunk = chunk.map_err(RStructorError::from)?;
-            for event in decoder.push(chunk.as_ref()) {
+        let mut terminal = false;
+        loop {
+            let (events, eof) = match bytes.next().await {
+                Some(chunk) => {
+                    let chunk = chunk.map_err(RStructorError::from)?;
+                    (decoder.push(chunk.as_ref())?, false)
+                }
+                None => (decoder.finish()?, true),
+            };
+            for event in events {
                 match event {
-                    SseEvent::Done => break 'outer,
+                    SseEvent::Done => {
+                        if marker != TerminalMarker::DoneSentinel {
+                            Err(invalid_provider_event(format!(
+                                "received an unexpected `[DONE]` sentinel while waiting for {}",
+                                marker.description()
+                            )))?;
+                        }
+                        terminal = true;
+                        break;
+                    }
                     SseEvent::Data(data) => {
-                        if let Ok(json) = serde_json::from_str::<Value>(&data)
-                            && let Some(text) = extract(&json)
+                        let json = parse_event_json(&data)?;
+                        let event = extract(&json)?;
+                        if let Some(text) = event.text
                             && !text.is_empty()
                         {
                             yield text;
                         }
+                        if event.terminal {
+                            terminal = true;
+                            break;
+                        }
                     }
                 }
             }
+            if terminal || eof {
+                break;
+            }
         }
+        require_terminal(terminal, marker)?;
     })
 }
 
@@ -159,13 +320,17 @@ where
 /// changed, a [`StreamedObject::Partial`] is yielded. When the stream ends the full
 /// buffer is parsed and validated into `T` and yielded as
 /// [`StreamedObject::Complete`].
-pub(crate) fn object_stream<'a, T, Fut, F>(send: Fut, extract: F) -> ObjectStream<'a, T>
+pub(crate) fn object_stream<'a, T, Fut, F>(
+    send: Fut,
+    extract: F,
+    marker: TerminalMarker,
+) -> ObjectStream<'a, T>
 where
     T: Instructor + DeserializeOwned + Send + 'a,
     Fut: Future<Output = Result<reqwest::Response>> + Send + 'a,
-    F: Fn(&Value) -> Option<String> + Send + 'a,
+    F: Fn(&Value) -> Result<ProviderStreamEvent> + Send + 'a,
 {
-    object_stream_with(send, extract, |raw: &str| {
+    object_stream_with(send, extract, marker, |raw: &str| {
         super::utils::parse_and_validate_response::<T>(raw).map_err(|(err, _ctx)| err)
     })
 }
@@ -176,40 +341,27 @@ where
 pub(crate) fn object_stream_with<'a, T, Fut, F, Fin>(
     send: Fut,
     extract: F,
+    marker: TerminalMarker,
     finalize: Fin,
 ) -> ObjectStream<'a, T>
 where
     T: Send + 'a,
     Fut: Future<Output = Result<reqwest::Response>> + Send + 'a,
-    F: Fn(&Value) -> Option<String> + Send + 'a,
+    F: Fn(&Value) -> Result<ProviderStreamEvent> + Send + 'a,
     Fin: FnOnce(&str) -> Result<T> + Send + 'a,
 {
     Box::pin(try_stream! {
-        let response = send.await?;
-        let mut bytes = response.bytes_stream();
-        let mut decoder = SseDecoder::default();
         let mut buf = String::new();
         let mut last_partial: Option<Value> = None;
+        let mut deltas = sse_text_stream(send, extract, marker);
 
-        'outer: while let Some(chunk) = bytes.next().await {
-            let chunk = chunk.map_err(RStructorError::from)?;
-            for event in decoder.push(chunk.as_ref()) {
-                match event {
-                    SseEvent::Done => break 'outer,
-                    SseEvent::Data(data) => {
-                        if let Ok(json) = serde_json::from_str::<Value>(&data)
-                            && let Some(text) = extract(&json)
-                        {
-                            buf.push_str(&text);
-                            if let Some(partial) = complete_json(&buf)
-                                && last_partial.as_ref() != Some(&partial)
-                            {
-                                last_partial = Some(partial.clone());
-                                yield StreamedObject::Partial(partial);
-                            }
-                        }
-                    }
-                }
+        while let Some(delta) = deltas.next().await {
+            buf.push_str(&delta?);
+            if let Some(partial) = complete_json(&buf)
+                && last_partial.as_ref() != Some(&partial)
+            {
+                last_partial = Some(partial.clone());
+                yield StreamedObject::Partial(partial);
             }
         }
 
@@ -220,48 +372,156 @@ where
 
 /// Extract the text delta from an OpenAI/Grok streaming chunk
 /// (`{"choices":[{"delta":{"content":"..."}}]}`).
-pub(crate) fn openai_delta(event: &Value) -> Option<String> {
-    event
-        .get("choices")?
-        .get(0)?
-        .get("delta")?
-        .get("content")?
-        .as_str()
-        .map(str::to_owned)
+pub(crate) fn openai_stream_event(event: &Value) -> Result<ProviderStreamEvent> {
+    if let Some(error) = event.get("error") {
+        let error_type = error
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown_error");
+        return Err(streaming_error(
+            StreamErrorKind::ProviderStreamError,
+            format!("OpenAI-compatible provider emitted an in-stream `{error_type}` event"),
+        ));
+    }
+    let choices = event
+        .get("choices")
+        .ok_or_else(|| invalid_provider_event("OpenAI stream event was missing `choices`"))?
+        .as_array()
+        .ok_or_else(|| invalid_provider_event("OpenAI stream event `choices` was not an array"))?;
+    let Some(choice) = choices.first() else {
+        // OpenAI may emit a final usage-only chunk with an empty choices array.
+        return Ok(ProviderStreamEvent::default());
+    };
+    let delta = choice
+        .get("delta")
+        .ok_or_else(|| invalid_provider_event("OpenAI stream choice was missing `delta`"))?
+        .as_object()
+        .ok_or_else(|| invalid_provider_event("OpenAI stream choice `delta` was not an object"))?;
+    let text = match delta.get("content") {
+        None | Some(Value::Null) => None,
+        Some(Value::String(text)) => Some(text.clone()),
+        Some(_) => {
+            return Err(invalid_provider_event(
+                "OpenAI stream delta `content` was not a string",
+            ));
+        }
+    };
+    Ok(ProviderStreamEvent {
+        text,
+        terminal: false,
+    })
 }
 
 /// Extract the text delta from an Anthropic streaming event
 /// (`{"type":"content_block_delta","delta":{"text":"..."}}`). Also accepts
 /// `input_json_delta.partial_json`, used when streaming structured output.
-pub(crate) fn anthropic_delta(event: &Value) -> Option<String> {
-    if event.get("type")?.as_str()? != "content_block_delta" {
-        return None;
+pub(crate) fn anthropic_stream_event(event: &Value) -> Result<ProviderStreamEvent> {
+    let event_type = event.get("type").and_then(Value::as_str).ok_or_else(|| {
+        invalid_provider_event("Anthropic stream event was missing string `type`")
+    })?;
+
+    match event_type {
+        "message_stop" => Ok(ProviderStreamEvent {
+            text: None,
+            terminal: true,
+        }),
+        "content_block_delta" => {
+            let delta = event
+                .get("delta")
+                .and_then(Value::as_object)
+                .ok_or_else(|| {
+                    invalid_provider_event("Anthropic content delta was missing object `delta`")
+                })?;
+            let delta_type = delta.get("type").and_then(Value::as_str).ok_or_else(|| {
+                invalid_provider_event("Anthropic content delta was missing string `type`")
+            })?;
+            let field = match delta_type {
+                "text_delta" => "text",
+                "input_json_delta" => "partial_json",
+                // Anthropic asks clients to ignore unknown future event types.
+                _ => return Ok(ProviderStreamEvent::default()),
+            };
+            let text = delta.get(field).and_then(Value::as_str).ok_or_else(|| {
+                invalid_provider_event(format!(
+                    "Anthropic `{delta_type}` was missing string `{field}`"
+                ))
+            })?;
+            Ok(ProviderStreamEvent {
+                text: Some(text.to_owned()),
+                terminal: false,
+            })
+        }
+        "error" => {
+            let error_type = event
+                .get("error")
+                .and_then(|error| error.get("type"))
+                .and_then(Value::as_str)
+                .unwrap_or("unknown_error");
+            Err(streaming_error(
+                StreamErrorKind::ProviderStreamError,
+                format!("Anthropic emitted an in-stream `{error_type}` event"),
+            ))
+        }
+        _ => Ok(ProviderStreamEvent::default()),
     }
-    let delta = event.get("delta")?;
-    delta
-        .get("text")
-        .and_then(Value::as_str)
-        .or_else(|| delta.get("partial_json").and_then(Value::as_str))
-        .map(str::to_owned)
 }
 
 /// Extract the text delta from a Gemini streaming chunk
 /// (`{"candidates":[{"content":{"parts":[{"text":"..."}]}}]}`). Concatenates the
 /// text of every part in the chunk.
-pub(crate) fn gemini_delta(event: &Value) -> Option<String> {
-    let parts = event
-        .get("candidates")?
-        .get(0)?
-        .get("content")?
-        .get("parts")?
-        .as_array()?;
+pub(crate) fn gemini_stream_event(event: &Value) -> Result<ProviderStreamEvent> {
+    if let Some(error) = event.get("error") {
+        let status = error
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("UNKNOWN");
+        return Err(streaming_error(
+            StreamErrorKind::ProviderStreamError,
+            format!("Gemini emitted an in-stream `{status}` error"),
+        ));
+    }
+    let candidates = event
+        .get("candidates")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            invalid_provider_event("Gemini stream event was missing array `candidates`")
+        })?;
+    let candidate = candidates
+        .first()
+        .ok_or_else(|| invalid_provider_event("Gemini stream event had no candidates"))?;
 
-    let text: String = parts
-        .iter()
-        .filter_map(|p| p.get("text").and_then(Value::as_str))
-        .collect();
+    let terminal = match candidate.get("finishReason") {
+        None | Some(Value::Null) => false,
+        Some(Value::String(reason)) => !reason.is_empty(),
+        Some(_) => {
+            return Err(invalid_provider_event(
+                "Gemini candidate `finishReason` was not a string",
+            ));
+        }
+    };
 
-    if text.is_empty() { None } else { Some(text) }
+    let mut text = String::new();
+    if let Some(content) = candidate.get("content") {
+        let parts = content
+            .get("parts")
+            .and_then(Value::as_array)
+            .ok_or_else(|| {
+                invalid_provider_event("Gemini candidate content was missing array `parts`")
+            })?;
+        for part in parts {
+            if let Some(value) = part.get("text") {
+                let value = value.as_str().ok_or_else(|| {
+                    invalid_provider_event("Gemini content part `text` was not a string")
+                })?;
+                text.push_str(value);
+            }
+        }
+    }
+
+    Ok(ProviderStreamEvent {
+        text: (!text.is_empty()).then_some(text),
+        terminal,
+    })
 }
 
 /// Repair a possibly-truncated JSON prefix into a parseable JSON value.
@@ -375,7 +635,7 @@ mod tests {
     fn decoder_emits_complete_data_event() {
         let mut d = SseDecoder::default();
         assert_eq!(
-            d.push(b"data: {\"a\":1}\n\n"),
+            d.push(b"data: {\"a\":1}\n\n").unwrap(),
             vec![SseEvent::Data("{\"a\":1}".to_string())]
         );
     }
@@ -383,10 +643,10 @@ mod tests {
     #[test]
     fn decoder_buffers_across_chunk_boundary() {
         let mut d = SseDecoder::default();
-        assert_eq!(d.push(b"data: {\"hel"), vec![]);
-        assert_eq!(d.push(b"lo\":1"), vec![]);
+        assert_eq!(d.push(b"data: {\"hel").unwrap(), vec![]);
+        assert_eq!(d.push(b"lo\":1").unwrap(), vec![]);
         assert_eq!(
-            d.push(b"}\n"),
+            d.push(b"}\n\n").unwrap(),
             vec![SseEvent::Data("{\"hello\":1}".to_string())]
         );
     }
@@ -395,7 +655,8 @@ mod tests {
     fn decoder_handles_crlf_and_ignores_non_data_lines() {
         let mut d = SseDecoder::default();
         assert_eq!(
-            d.push(b"event: message\r\ndata: {\"x\":1}\r\n\r\n: keep-alive\r\n"),
+            d.push(b"event: message\r\ndata: {\"x\":1}\r\n\r\n: keep-alive\r\n")
+                .unwrap(),
             vec![SseEvent::Data("{\"x\":1}".to_string())]
         );
     }
@@ -403,46 +664,152 @@ mod tests {
     #[test]
     fn decoder_recognizes_done_sentinel() {
         let mut d = SseDecoder::default();
-        assert_eq!(d.push(b"data: [DONE]\n\n"), vec![SseEvent::Done]);
+        assert_eq!(d.push(b"data: [DONE]\n\n").unwrap(), vec![SseEvent::Done]);
     }
 
     #[test]
     fn openai_delta_extracts_content() {
         assert_eq!(
-            openai_delta(&json!({"choices":[{"delta":{"content":"Hi"}}]})),
-            Some("Hi".to_string())
+            openai_stream_event(&json!({"choices":[{"delta":{"content":"Hi"}}]})).unwrap(),
+            ProviderStreamEvent {
+                text: Some("Hi".to_string()),
+                terminal: false,
+            }
         );
         assert_eq!(
-            openai_delta(&json!({"choices":[{"delta":{"role":"assistant"}}]})),
-            None
+            openai_stream_event(&json!({"choices":[{"delta":{"role":"assistant"}}]})).unwrap(),
+            ProviderStreamEvent::default()
         );
     }
 
     #[test]
     fn anthropic_delta_extracts_text_and_partial_json() {
         assert_eq!(
-            anthropic_delta(
+            anthropic_stream_event(
                 &json!({"type":"content_block_delta","delta":{"type":"text_delta","text":"Hi"}})
-            ),
-            Some("Hi".to_string())
+            )
+            .unwrap(),
+            ProviderStreamEvent {
+                text: Some("Hi".to_string()),
+                terminal: false,
+            }
         );
         assert_eq!(
-            anthropic_delta(
+            anthropic_stream_event(
                 &json!({"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{\"a\":"}})
-            ),
-            Some("{\"a\":".to_string())
+            )
+            .unwrap(),
+            ProviderStreamEvent {
+                text: Some("{\"a\":".to_string()),
+                terminal: false,
+            }
         );
-        assert_eq!(anthropic_delta(&json!({"type":"message_start"})), None);
+        assert_eq!(
+            anthropic_stream_event(&json!({"type":"message_start"})).unwrap(),
+            ProviderStreamEvent::default()
+        );
+        assert_eq!(
+            anthropic_stream_event(&json!({"type":"message_stop"})).unwrap(),
+            ProviderStreamEvent {
+                text: None,
+                terminal: true,
+            }
+        );
     }
 
     #[test]
     fn gemini_delta_concatenates_parts() {
         assert_eq!(
-            gemini_delta(
+            gemini_stream_event(
                 &json!({"candidates":[{"content":{"parts":[{"text":"a"},{"text":"b"}]}}]})
-            ),
-            Some("ab".to_string())
+            )
+            .unwrap(),
+            ProviderStreamEvent {
+                text: Some("ab".to_string()),
+                terminal: false,
+            }
         );
+        assert_eq!(
+            gemini_stream_event(
+                &json!({"candidates":[{"content":{"parts":[{"text":"c"}]},"finishReason":"STOP"}]})
+            )
+            .unwrap(),
+            ProviderStreamEvent {
+                text: Some("c".to_string()),
+                terminal: true,
+            }
+        );
+    }
+
+    #[test]
+    fn provider_adapters_reject_malformed_known_events_and_in_band_errors() {
+        assert!(matches!(
+            openai_stream_event(&json!({"choices":[{"delta":{"content":42}}]})),
+            Err(RStructorError::StreamingError {
+                kind: StreamErrorKind::InvalidProviderEvent,
+                ..
+            })
+        ));
+        assert!(matches!(
+            anthropic_stream_event(
+                &json!({"type":"content_block_delta","delta":{"type":"text_delta","text":42}})
+            ),
+            Err(RStructorError::StreamingError {
+                kind: StreamErrorKind::InvalidProviderEvent,
+                ..
+            })
+        ));
+        assert!(matches!(
+            anthropic_stream_event(
+                &json!({"type":"error","error":{"type":"overloaded_error","message":"overloaded"}})
+            ),
+            Err(RStructorError::StreamingError {
+                kind: StreamErrorKind::ProviderStreamError,
+                ..
+            })
+        ));
+        assert!(matches!(
+            openai_stream_event(
+                &json!({"error":{"type":"server_error","message":"internal details"}})
+            ),
+            Err(RStructorError::StreamingError {
+                kind: StreamErrorKind::ProviderStreamError,
+                ..
+            })
+        ));
+        assert!(matches!(
+            gemini_stream_event(&json!({"candidates":[{"finishReason":42}]})),
+            Err(RStructorError::StreamingError {
+                kind: StreamErrorKind::InvalidProviderEvent,
+                ..
+            })
+        ));
+        assert!(matches!(
+            gemini_stream_event(
+                &json!({"error":{"code":503,"status":"UNAVAILABLE","message":"details"}})
+            ),
+            Err(RStructorError::StreamingError {
+                kind: StreamErrorKind::ProviderStreamError,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn stream_errors_do_not_echo_provider_or_model_content() {
+        let provider_secret = "sensitive upstream details";
+        let error = anthropic_stream_event(
+            &json!({"type":"error","error":{"type":"api_error","message":provider_secret}}),
+        )
+        .unwrap_err();
+        assert!(!error.to_string().contains(provider_secret));
+
+        let model_content = "sensitive-position-token";
+        let mut streamer = JsonArrayStreamer::default();
+        let error = streamer
+            .push_str(&format!(r#"{{"items":[{model_content},0]}}"#))
+            .expect_err("invalid item should fail");
+        assert!(!error.to_string().contains(model_content));
     }
 
     #[test]
@@ -514,15 +881,18 @@ mod tests {
         // separator) only in the next: the data line must not be emitted until
         // its terminating newline is seen.
         let mut d = SseDecoder::default();
-        assert_eq!(d.push(b"data:{a}\r"), vec![]);
-        assert_eq!(d.push(b"\n\r\n"), vec![SseEvent::Data("{a}".to_string())]);
+        assert_eq!(d.push(b"data:{a}\r").unwrap(), vec![]);
+        assert_eq!(
+            d.push(b"\n\r\n").unwrap(),
+            vec![SseEvent::Data("{a}".to_string())]
+        );
     }
 
     #[test]
-    fn decoder_emits_multiple_data_lines_in_one_chunk_in_order() {
+    fn decoder_emits_multiple_events_in_one_chunk_in_order() {
         let mut d = SseDecoder::default();
         assert_eq!(
-            d.push(b"data:{a}\ndata:{b}\n"),
+            d.push(b"data:{a}\n\ndata:{b}\n\n").unwrap(),
             vec![
                 SseEvent::Data("{a}".to_string()),
                 SseEvent::Data("{b}".to_string()),
@@ -535,8 +905,8 @@ mod tests {
         // The euro sign U+20AC is the three bytes E2 82 AC; split it across two
         // chunks and confirm the decoder reassembles a single intact code point.
         let mut d = SseDecoder::default();
-        assert_eq!(d.push(b"data:\xe2\x82"), vec![]);
-        let events = d.push(b"\xac\n");
+        assert_eq!(d.push(b"data:\xe2\x82").unwrap(), vec![]);
+        let events = d.push(b"\xac\n\n").unwrap();
         assert_eq!(events, vec![SseEvent::Data("\u{20AC}".to_string())]);
         if let SseEvent::Data(s) = &events[0] {
             assert_eq!(s.chars().next(), Some('\u{20AC}'));
@@ -547,17 +917,23 @@ mod tests {
     fn decoder_handles_done_and_data_in_same_push() {
         let mut d = SseDecoder::default();
         assert_eq!(
-            d.push(b"data:[DONE]\ndata:{a}\n"),
+            d.push(b"data:[DONE]\n\ndata:{a}\n\n").unwrap(),
             vec![SseEvent::Done, SseEvent::Data("{a}".to_string())]
         );
     }
 
     #[test]
-    fn decoder_ignores_empty_and_whitespace_data_lines() {
+    fn decoder_preserves_empty_and_whitespace_data_events() {
         let mut d = SseDecoder::default();
-        assert_eq!(d.push(b"data:\n"), vec![]);
+        assert_eq!(
+            d.push(b"data:\n\n").unwrap(),
+            vec![SseEvent::Data(String::new())]
+        );
         let mut d = SseDecoder::default();
-        assert_eq!(d.push(b"data:   \n"), vec![]);
+        assert_eq!(
+            d.push(b"data:   \n\n").unwrap(),
+            vec![SseEvent::Data("  ".to_string())]
+        );
     }
 
     #[test]
@@ -565,9 +941,84 @@ mod tests {
         // Only the exact `[DONE]` sentinel ends the stream; lowercase is data.
         let mut d = SseDecoder::default();
         assert_eq!(
-            d.push(b"data:[done]\n"),
+            d.push(b"data:[done]\n\n").unwrap(),
             vec![SseEvent::Data("[done]".to_string())]
         );
+    }
+
+    #[test]
+    fn decoder_joins_multiline_data_fields_per_sse_spec() {
+        let mut d = SseDecoder::default();
+        assert_eq!(
+            d.push(b"data: {\"a\":\ndata: 1}\n\n").unwrap(),
+            vec![SseEvent::Data("{\"a\":\n1}".to_string())]
+        );
+    }
+
+    #[test]
+    fn decoder_accepts_cr_only_line_endings() {
+        let mut d = SseDecoder::default();
+        let mut events = d.push(b"data: {\"a\":1}\r\rdata: [DONE]\r\r").unwrap();
+        events.extend(d.finish().unwrap());
+        assert_eq!(
+            events,
+            vec![SseEvent::Data("{\"a\":1}".to_string()), SseEvent::Done,]
+        );
+    }
+
+    #[test]
+    fn decoder_dispatches_a_final_event_at_eof_without_newline() {
+        let mut d = SseDecoder::default();
+        assert!(d.push(b"data: {\"a\":1}").unwrap().is_empty());
+        assert_eq!(
+            d.finish().unwrap(),
+            vec![SseEvent::Data("{\"a\":1}".to_string())]
+        );
+    }
+
+    #[test]
+    fn decoder_rejects_invalid_utf8_without_lossy_replacement() {
+        let mut d = SseDecoder::default();
+        let error = d
+            .push(b"data: \xff\n\n")
+            .expect_err("invalid UTF-8 must fail the stream");
+        assert!(matches!(
+            error,
+            RStructorError::StreamingError {
+                kind: StreamErrorKind::InvalidEventEncoding,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn decoder_is_invariant_across_every_byte_split() {
+        let fixture = b"\xef\xbb\xbfdata: {\"symbol\":\"EUR/USD\"}\r\n\r\ndata: [DONE]\n\n";
+        let expected = vec![
+            SseEvent::Data("{\"symbol\":\"EUR/USD\"}".to_string()),
+            SseEvent::Done,
+        ];
+
+        for split in 0..=fixture.len() {
+            let mut decoder = SseDecoder::default();
+            let mut events = decoder.push(&fixture[..split]).unwrap();
+            events.extend(decoder.push(&fixture[split..]).unwrap());
+            events.extend(decoder.finish().unwrap());
+            assert_eq!(events, expected, "failed at byte split {split}");
+        }
+    }
+
+    #[test]
+    fn malformed_event_json_has_a_machine_readable_error_kind() {
+        let error = parse_event_json(r#"{"choices":["#).unwrap_err();
+        assert!(matches!(
+            error,
+            RStructorError::StreamingError {
+                kind: StreamErrorKind::InvalidEventJson,
+                ..
+            }
+        ));
+        assert!(!error.to_string().contains(r#"{"choices":["#));
     }
 
     // --- complete_json edge cases ---
@@ -647,82 +1098,270 @@ pub type ItemStream<'a, T> = Pin<Box<dyn Stream<Item = Result<T>> + Send + 'a>>;
 /// wrapper object `{"items": [ ... ]}`; the streamer skips to the first `[` (the
 /// `items` array) and then emits each complete element (object or scalar) as a
 /// `serde_json::Value`.
+#[derive(Debug, Default, PartialEq, Eq)]
+enum ArrayState {
+    #[default]
+    Seeking,
+    Streaming,
+    ClosingEnvelope,
+    Complete,
+}
+
 #[derive(Default)]
 pub(crate) struct JsonArrayStreamer {
-    in_array: bool,
-    depth: i32,
+    state: ArrayState,
+    prefix_in_string: bool,
+    prefix_escaped: bool,
+    envelope: Vec<char>,
+    containers: Vec<char>,
     in_string: bool,
     escaped: bool,
     started_element: bool,
+    just_saw_comma: bool,
+    next_index: usize,
     current: String,
 }
 
-impl JsonArrayStreamer {
-    pub(crate) fn push_str(&mut self, s: &str) -> Vec<Value> {
-        let mut out = Vec::new();
-        for c in s.chars() {
-            if !self.in_array {
-                if c == '[' {
-                    self.in_array = true;
-                }
-                continue;
-            }
-            if self.in_string {
-                self.current.push(c);
-                if self.escaped {
-                    self.escaped = false;
-                } else if c == '\\' {
-                    self.escaped = true;
-                } else if c == '"' {
-                    self.in_string = false;
-                }
-                continue;
-            }
-            match c {
-                '"' => {
-                    self.started_element = true;
-                    self.in_string = true;
-                    self.current.push(c);
-                }
-                '{' | '[' => {
-                    self.started_element = true;
-                    self.depth += 1;
-                    self.current.push(c);
-                }
-                '}' | ']' if self.depth > 0 => {
-                    self.depth -= 1;
-                    self.current.push(c);
-                }
-                ']' => {
-                    // End of the items array.
-                    if let Some(v) = self.finish_element() {
-                        out.push(v);
-                    }
-                    self.in_array = false;
-                }
-                ',' if self.depth == 0 => {
-                    if let Some(v) = self.finish_element() {
-                        out.push(v);
-                    }
-                }
-                c if c.is_whitespace() && !self.started_element => {}
-                _ => {
-                    self.started_element = true;
-                    self.current.push(c);
-                }
-            }
+struct ArrayPush {
+    values: Vec<Value>,
+    error: Option<RStructorError>,
+}
+
+#[cfg(test)]
+impl ArrayPush {
+    fn unwrap(self) -> Vec<Value> {
+        if let Some(error) = self.error {
+            panic!("called ArrayPush::unwrap() on an error: {error}");
         }
-        out
+        self.values
     }
 
-    fn finish_element(&mut self) -> Option<Value> {
+    fn expect_err(self, message: &str) -> RStructorError {
+        self.error.unwrap_or_else(|| panic!("{message}"))
+    }
+}
+
+impl JsonArrayStreamer {
+    fn push_str(&mut self, s: &str) -> ArrayPush {
+        let mut values = Vec::new();
+        for c in s.chars() {
+            if let Err(error) = self.push_char(c, &mut values) {
+                return ArrayPush {
+                    values,
+                    error: Some(error),
+                };
+            }
+        }
+        ArrayPush {
+            values,
+            error: None,
+        }
+    }
+
+    fn push_char(&mut self, c: char, out: &mut Vec<Value>) -> Result<()> {
+        match self.state {
+            ArrayState::Seeking => {
+                self.seek_array(c);
+                return Ok(());
+            }
+            ArrayState::ClosingEnvelope => {
+                return self.close_envelope(c);
+            }
+            ArrayState::Complete => {
+                if !c.is_whitespace() {
+                    return Err(streaming_error(
+                        StreamErrorKind::InvalidArrayEnvelope,
+                        "unexpected data followed the completed streamed array envelope",
+                    ));
+                }
+                return Ok(());
+            }
+            ArrayState::Streaming => {}
+        }
+
+        if self.in_string {
+            self.current.push(c);
+            if self.escaped {
+                self.escaped = false;
+            } else if c == '\\' {
+                self.escaped = true;
+            } else if c == '"' {
+                self.in_string = false;
+            }
+            return Ok(());
+        }
+        match c {
+            '"' => {
+                self.start_element();
+                self.in_string = true;
+                self.current.push(c);
+            }
+            '{' => {
+                self.start_element();
+                self.containers.push('}');
+                self.current.push(c);
+            }
+            '[' => {
+                self.start_element();
+                self.containers.push(']');
+                self.current.push(c);
+            }
+            ']' => {
+                if let Some(expected) = self.containers.last().copied() {
+                    if expected != ']' {
+                        return Err(self.invalid_element(format!(
+                            "mismatched closing delimiter `]`; expected `{expected}`"
+                        )));
+                    }
+                    self.containers.pop();
+                    self.current.push(c);
+                } else {
+                    if self.just_saw_comma {
+                        return Err(
+                            self.invalid_element("trailing commas are not valid JSON array syntax")
+                        );
+                    }
+                    if let Some(value) = self.finish_element()? {
+                        out.push(value);
+                    }
+                    self.state = if self.envelope.is_empty() {
+                        ArrayState::Complete
+                    } else {
+                        ArrayState::ClosingEnvelope
+                    };
+                }
+            }
+            '}' => {
+                let Some(expected) = self.containers.last().copied() else {
+                    return Err(
+                        self.invalid_element("unexpected `}` before the streamed array was closed")
+                    );
+                };
+                if expected != '}' {
+                    return Err(self.invalid_element(format!(
+                        "mismatched closing delimiter `}}`; expected `{expected}`"
+                    )));
+                }
+                self.containers.pop();
+                self.current.push(c);
+            }
+            ',' if self.containers.is_empty() => {
+                let Some(value) = self.finish_element()? else {
+                    return Err(self.invalid_element("expected an array element before `,`"));
+                };
+                out.push(value);
+                self.just_saw_comma = true;
+            }
+            c if c.is_whitespace() && !self.started_element => {}
+            _ => {
+                self.start_element();
+                self.current.push(c);
+            }
+        }
+        Ok(())
+    }
+
+    /// Verify that HTTP EOF or `[DONE]` arrived after a complete array.
+    pub(crate) fn finish(&self) -> Result<()> {
+        match self.state {
+            ArrayState::Seeking => Err(streaming_error(
+                StreamErrorKind::MissingArray,
+                "structured stream ended before an `items` array was received",
+            )),
+            ArrayState::Streaming => Err(streaming_error(
+                StreamErrorKind::IncompleteArray {
+                    next_index: self.next_index,
+                },
+                format!(
+                    "structured stream ended before the array and element {} were complete",
+                    self.next_index
+                ),
+            )),
+            ArrayState::ClosingEnvelope => Err(streaming_error(
+                StreamErrorKind::IncompleteArrayEnvelope,
+                "streamed items array closed, but its surrounding JSON object did not",
+            )),
+            ArrayState::Complete => Ok(()),
+        }
+    }
+
+    fn seek_array(&mut self, c: char) {
+        if self.prefix_in_string {
+            if self.prefix_escaped {
+                self.prefix_escaped = false;
+            } else if c == '\\' {
+                self.prefix_escaped = true;
+            } else if c == '"' {
+                self.prefix_in_string = false;
+            }
+        } else if c == '"' {
+            self.prefix_in_string = true;
+        } else if c == '{' {
+            self.envelope.push('}');
+        } else if c == '}' {
+            if self.envelope.last() == Some(&'}') {
+                self.envelope.pop();
+            }
+        } else if c == '[' {
+            self.state = ArrayState::Streaming;
+        }
+    }
+
+    fn close_envelope(&mut self, c: char) -> Result<()> {
+        if c.is_whitespace() {
+            return Ok(());
+        }
+        let Some(expected) = self.envelope.last().copied() else {
+            return Err(streaming_error(
+                StreamErrorKind::InvalidArrayEnvelope,
+                "unexpected data followed the streamed items array",
+            ));
+        };
+        if c != expected {
+            return Err(streaming_error(
+                StreamErrorKind::InvalidArrayEnvelope,
+                format!("unexpected `{c}` after streamed items array; expected `{expected}`"),
+            ));
+        }
+        self.envelope.pop();
+        if self.envelope.is_empty() {
+            self.state = ArrayState::Complete;
+        }
+        Ok(())
+    }
+
+    fn start_element(&mut self) {
+        self.started_element = true;
+        self.just_saw_comma = false;
+    }
+
+    fn finish_element(&mut self) -> Result<Option<Value>> {
         let text = std::mem::take(&mut self.current);
         self.started_element = false;
         let trimmed = text.trim();
         if trimmed.is_empty() {
-            return None;
+            return Ok(None);
         }
-        serde_json::from_str(trimmed).ok()
+        let value = serde_json::from_str(trimmed).map_err(|error| {
+            self.invalid_element(format!(
+                "element {} was not valid JSON at line {}, column {}: {}",
+                self.next_index,
+                error.line(),
+                error.column(),
+                error
+            ))
+        })?;
+        self.next_index += 1;
+        Ok(Some(value))
+    }
+
+    fn invalid_element(&self, message: impl Into<Box<str>>) -> RStructorError {
+        streaming_error(
+            StreamErrorKind::InvalidArrayElement {
+                index: self.next_index,
+            },
+            message,
+        )
     }
 }
 
@@ -734,37 +1373,29 @@ impl JsonArrayStreamer {
 pub(crate) fn iter_stream<'a, T, Fut, F, Fin>(
     send: Fut,
     extract: F,
+    marker: TerminalMarker,
     finalize_item: Fin,
 ) -> ItemStream<'a, T>
 where
     T: Send + 'a,
     Fut: Future<Output = Result<reqwest::Response>> + Send + 'a,
-    F: Fn(&Value) -> Option<String> + Send + 'a,
+    F: Fn(&Value) -> Result<ProviderStreamEvent> + Send + 'a,
     Fin: Fn(Value) -> Result<T> + Send + 'a,
 {
     Box::pin(try_stream! {
-        let response = send.await?;
-        let mut bytes = response.bytes_stream();
-        let mut decoder = SseDecoder::default();
         let mut array = JsonArrayStreamer::default();
+        let mut deltas = sse_text_stream(send, extract, marker);
 
-        'outer: while let Some(chunk) = bytes.next().await {
-            let chunk = chunk.map_err(RStructorError::from)?;
-            for event in decoder.push(chunk.as_ref()) {
-                match event {
-                    SseEvent::Done => break 'outer,
-                    SseEvent::Data(data) => {
-                        if let Ok(json) = serde_json::from_str::<Value>(&data)
-                            && let Some(text) = extract(&json)
-                        {
-                            for element in array.push_str(&text) {
-                                yield finalize_item(element)?;
-                            }
-                        }
-                    }
-                }
+        while let Some(delta) = deltas.next().await {
+            let pushed = array.push_str(&delta?);
+            for element in pushed.values {
+                yield finalize_item(element)?;
+            }
+            if let Some(error) = pushed.error {
+                Err(error)?;
             }
         }
+        array.finish()?;
     })
 }
 
@@ -800,18 +1431,24 @@ mod array_tests {
     fn streams_object_elements_as_they_complete() {
         let mut s = JsonArrayStreamer::default();
         // Wrapper prefix + first complete element, split across pushes.
-        assert_eq!(s.push_str(r#"{"items":["#), Vec::<Value>::new());
-        assert_eq!(s.push_str(r#"{"n":1},{"n":2}"#), vec![json!({"n":1})]);
+        assert_eq!(s.push_str(r#"{"items":["#).unwrap(), Vec::<Value>::new());
         assert_eq!(
-            s.push_str(r#",{"n":3}]}"#),
+            s.push_str(r#"{"n":1},{"n":2}"#).unwrap(),
+            vec![json!({"n":1})]
+        );
+        assert_eq!(
+            s.push_str(r#",{"n":3}]}"#).unwrap(),
             vec![json!({"n":2}), json!({"n":3})]
         );
+        s.finish().unwrap();
     }
 
     #[test]
     fn handles_scalars_strings_and_nesting() {
         let mut s = JsonArrayStreamer::default();
-        let got = s.push_str(r#"{"items":[1, "a,b", {"x":[1,2]}, true]}"#);
+        let got = s
+            .push_str(r#"{"items":[1, "a,b", {"x":[1,2]}, true]}"#)
+            .unwrap();
         assert_eq!(
             got,
             vec![json!(1), json!("a,b"), json!({"x":[1,2]}), json!(true)]
@@ -822,7 +1459,10 @@ mod array_tests {
     fn ignores_strings_containing_brackets_before_array() {
         let mut s = JsonArrayStreamer::default();
         // The first '[' is the items array; nothing emitted until an element completes.
-        assert_eq!(s.push_str(r#"{"items":[{"v":"#), Vec::<Value>::new());
+        assert_eq!(
+            s.push_str(r#"{"items":[{"v":"#).unwrap(),
+            Vec::<Value>::new()
+        );
     }
 
     // --- JsonArrayStreamer edge cases ---
@@ -831,7 +1471,7 @@ mod array_tests {
     fn handles_escaped_quotes_in_string_element() {
         let mut s = JsonArrayStreamer::default();
         assert_eq!(
-            s.push_str(r#"{"items":["he said \"hi\"","x"]}"#),
+            s.push_str(r#"{"items":["he said \"hi\"","x"]}"#).unwrap(),
             vec![json!("he said \"hi\""), json!("x")]
         );
     }
@@ -841,7 +1481,7 @@ mod array_tests {
         let mut s = JsonArrayStreamer::default();
         // The `]` inside the string must not be treated as the array terminator.
         assert_eq!(
-            s.push_str(r#"{"items":["a]b","c"]}"#),
+            s.push_str(r#"{"items":["a]b","c"]}"#).unwrap(),
             vec![json!("a]b"), json!("c")]
         );
     }
@@ -850,7 +1490,7 @@ mod array_tests {
     fn handles_array_of_arrays_elements() {
         let mut s = JsonArrayStreamer::default();
         assert_eq!(
-            s.push_str(r#"{"items":[[1,2],[3,4]]}"#),
+            s.push_str(r#"{"items":[[1,2],[3,4]]}"#).unwrap(),
             vec![json!([1, 2]), json!([3, 4])]
         );
     }
@@ -859,43 +1499,78 @@ mod array_tests {
     fn handles_null_and_bare_top_level_array() {
         let mut s = JsonArrayStreamer::default();
         assert_eq!(
-            s.push_str(r#"{"items":[null,1]}"#),
+            s.push_str(r#"{"items":[null,1]}"#).unwrap(),
             vec![json!(null), json!(1)]
         );
         // A bare top-level array (no `{"items": ...}` wrapper): the first `[` is
         // still taken as the array start.
         let mut s = JsonArrayStreamer::default();
-        assert_eq!(s.push_str(r#"[1,2,3]"#), vec![json!(1), json!(2), json!(3)]);
+        assert_eq!(
+            s.push_str(r#"[1,2,3]"#).unwrap(),
+            vec![json!(1), json!(2), json!(3)]
+        );
     }
 
     #[test]
-    fn drops_invalid_element_and_recovers() {
-        // An element that is not valid JSON is silently dropped; subsequent valid
-        // elements still come through.
+    fn rejects_invalid_and_missing_elements() {
         let mut s = JsonArrayStreamer::default();
-        assert_eq!(s.push_str(r#"{"items":[1abc,2]}"#), vec![json!(2)]);
-        // A leading empty element (`[,1]`) finishes an empty segment (dropped) and
-        // then yields the real element.
+        let error = s
+            .push_str(r#"{"items":[1abc,2]}"#)
+            .expect_err("malformed elements must not be dropped");
+        assert!(matches!(
+            error,
+            RStructorError::StreamingError {
+                kind: StreamErrorKind::InvalidArrayElement { index: 0 },
+                ..
+            }
+        ));
+
         let mut s = JsonArrayStreamer::default();
-        assert_eq!(s.push_str(r#"{"items":[,1]}"#), vec![json!(1)]);
-        // A trailing comma (`[1,]`) yields the element then an empty segment that
-        // is dropped at the closing `]`.
+        assert!(matches!(
+            s.push_str(r#"{"items":[,1]}"#).error,
+            Some(RStructorError::StreamingError {
+                kind: StreamErrorKind::InvalidArrayElement { index: 0 },
+                ..
+            })
+        ));
+
         let mut s = JsonArrayStreamer::default();
-        assert_eq!(s.push_str(r#"{"items":[1,]}"#), vec![json!(1)]);
+        assert!(matches!(
+            s.push_str(r#"{"items":[1,]}"#).error,
+            Some(RStructorError::StreamingError {
+                kind: StreamErrorKind::InvalidArrayElement { index: 1 },
+                ..
+            })
+        ));
+
+        let mut s = JsonArrayStreamer::default();
+        let pushed = s.push_str(r#"{"items":[1,not-json,2]}"#);
+        assert_eq!(pushed.values, vec![json!(1)]);
+        assert!(matches!(
+            pushed.error,
+            Some(RStructorError::StreamingError {
+                kind: StreamErrorKind::InvalidArrayElement { index: 1 },
+                ..
+            })
+        ));
     }
 
     #[test]
     fn empty_items_array_yields_nothing() {
         let mut s = JsonArrayStreamer::default();
-        assert_eq!(s.push_str(r#"{"items":[]}"#), Vec::<Value>::new());
+        assert_eq!(s.push_str(r#"{"items":[]}"#).unwrap(), Vec::<Value>::new());
+        s.finish().unwrap();
     }
 
     #[test]
     fn element_split_across_push_str_calls() {
         // Scalar split mid-number: the two halves concatenate into one element.
         let mut s = JsonArrayStreamer::default();
-        assert_eq!(s.push_str(r#"{"items":[12"#), Vec::<Value>::new());
-        assert_eq!(s.push_str(r#"34,5]}"#), vec![json!(1234), json!(5)]);
+        assert_eq!(s.push_str(r#"{"items":[12"#).unwrap(), Vec::<Value>::new());
+        assert_eq!(
+            s.push_str(r#"34,5]}"#).unwrap(),
+            vec![json!(1234), json!(5)]
+        );
     }
 
     #[test]
@@ -904,17 +1579,93 @@ mod array_tests {
         // must persist so the following `\b` decodes to a single literal backslash
         // + `b`, not a control escape, and the element parses correctly.
         let mut s = JsonArrayStreamer::default();
-        assert_eq!(s.push_str(r#"{"items":["a\"#), Vec::<Value>::new());
-        assert_eq!(s.push_str(r#"\b","c"]}"#), vec![json!("a\\b"), json!("c")]);
+        assert_eq!(s.push_str(r#"{"items":["a\"#).unwrap(), Vec::<Value>::new());
+        assert_eq!(
+            s.push_str(r#"\b","c"]}"#).unwrap(),
+            vec![json!("a\\b"), json!("c")]
+        );
     }
 
     #[test]
-    fn re_entry_after_array_close() {
-        // After the items array closes, feeding a second array re-enters and
-        // streams its elements too (documents the re-entry behavior).
+    fn does_not_reenter_after_array_close() {
         let mut s = JsonArrayStreamer::default();
-        assert_eq!(s.push_str(r#"{"items":[1]}"#), vec![json!(1)]);
-        assert_eq!(s.push_str(r#"[9,9]"#), vec![json!(9), json!(9)]);
+        assert_eq!(s.push_str(r#"{"items":[1]}"#).unwrap(), vec![json!(1)]);
+        assert!(matches!(
+            s.push_str(r#"[9,9]"#).error,
+            Some(RStructorError::StreamingError {
+                kind: StreamErrorKind::InvalidArrayEnvelope,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn ignores_brackets_inside_wrapper_strings_while_seeking() {
+        let mut s = JsonArrayStreamer::default();
+        assert_eq!(
+            s.push_str(r#"{"note":"risk [gross]","items":[1,2]}"#)
+                .unwrap(),
+            vec![json!(1), json!(2)]
+        );
+        s.finish().unwrap();
+    }
+
+    #[test]
+    fn finish_distinguishes_missing_and_incomplete_arrays() {
+        let mut missing = JsonArrayStreamer::default();
+        missing.push_str(r#"{"items":"not an array"}"#).unwrap();
+        assert!(matches!(
+            missing.finish(),
+            Err(RStructorError::StreamingError {
+                kind: StreamErrorKind::MissingArray,
+                ..
+            })
+        ));
+
+        let mut incomplete = JsonArrayStreamer::default();
+        incomplete
+            .push_str(r#"{"items":[{"symbol":"AAPL"},"#)
+            .unwrap();
+        assert!(matches!(
+            incomplete.finish(),
+            Err(RStructorError::StreamingError {
+                kind: StreamErrorKind::IncompleteArray { next_index: 1 },
+                ..
+            })
+        ));
+
+        let mut incomplete_envelope = JsonArrayStreamer::default();
+        incomplete_envelope
+            .push_str(r#"{"items":[{"symbol":"AAPL"}]"#)
+            .unwrap();
+        assert!(matches!(
+            incomplete_envelope.finish(),
+            Err(RStructorError::StreamingError {
+                kind: StreamErrorKind::IncompleteArrayEnvelope,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn array_streamer_is_invariant_across_every_utf8_byte_split() {
+        let fixture =
+            r#"{"items":[{"symbol":"AAPL","quantity":125000},{"symbol":"ES","quantity":-240}]}"#;
+        let expected = vec![
+            json!({"symbol":"AAPL","quantity":125000}),
+            json!({"symbol":"ES","quantity":-240}),
+        ];
+
+        for split in 0..=fixture.len() {
+            if !fixture.is_char_boundary(split) {
+                continue;
+            }
+            let mut streamer = JsonArrayStreamer::default();
+            let mut values = streamer.push_str(&fixture[..split]).unwrap();
+            values.extend(streamer.push_str(&fixture[split..]).unwrap());
+            streamer.finish().unwrap();
+            assert_eq!(values, expected, "failed at byte split {split}");
+        }
     }
 
     // --- array_wrapper_schema ---

--- a/src/backend/streaming.rs
+++ b/src/backend/streaming.rs
@@ -502,18 +502,20 @@ pub(crate) fn gemini_stream_event(event: &Value) -> Result<ProviderStreamEvent> 
 
     let mut text = String::new();
     if let Some(content) = candidate.get("content") {
-        let parts = content
-            .get("parts")
-            .and_then(Value::as_array)
-            .ok_or_else(|| {
-                invalid_provider_event("Gemini candidate content was missing array `parts`")
+        let content = content.as_object().ok_or_else(|| {
+            invalid_provider_event("Gemini candidate `content` was not an object")
+        })?;
+        if let Some(parts) = content.get("parts") {
+            let parts = parts.as_array().ok_or_else(|| {
+                invalid_provider_event("Gemini candidate content `parts` was not an array")
             })?;
-        for part in parts {
-            if let Some(value) = part.get("text") {
-                let value = value.as_str().ok_or_else(|| {
-                    invalid_provider_event("Gemini content part `text` was not a string")
-                })?;
-                text.push_str(value);
+            for part in parts {
+                if let Some(value) = part.get("text") {
+                    let value = value.as_str().ok_or_else(|| {
+                        invalid_provider_event("Gemini content part `text` was not a string")
+                    })?;
+                    text.push_str(value);
+                }
             }
         }
     }
@@ -739,6 +741,16 @@ mod tests {
                 terminal: true,
             }
         );
+        assert_eq!(
+            gemini_stream_event(
+                &json!({"candidates":[{"content":{"role":"model"},"finishReason":"STOP"}]})
+            )
+            .unwrap(),
+            ProviderStreamEvent {
+                text: None,
+                terminal: true,
+            }
+        );
     }
 
     #[test]
@@ -779,6 +791,20 @@ mod tests {
         ));
         assert!(matches!(
             gemini_stream_event(&json!({"candidates":[{"finishReason":42}]})),
+            Err(RStructorError::StreamingError {
+                kind: StreamErrorKind::InvalidProviderEvent,
+                ..
+            })
+        ));
+        assert!(matches!(
+            gemini_stream_event(&json!({"candidates":[{"content":{"parts":42}}]})),
+            Err(RStructorError::StreamingError {
+                kind: StreamErrorKind::InvalidProviderEvent,
+                ..
+            })
+        ));
+        assert!(matches!(
+            gemini_stream_event(&json!({"candidates":[{"content":"invalid"}]})),
             Err(RStructorError::StreamingError {
                 kind: StreamErrorKind::InvalidProviderEvent,
                 ..

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{fmt, time::Duration};
 use thiserror::Error;
 
 /// Classification of API errors for better handling and retry logic.
@@ -116,6 +116,69 @@ pub enum ApiErrorKind {
         /// Description of what was expected vs received
         details: String,
     },
+}
+
+/// Machine-readable classification for integrity failures in a streamed response.
+///
+/// Streaming methods can yield successful items before discovering that the
+/// provider's remaining response is malformed or truncated. Callers should stop
+/// consuming the stream when a [`RStructorError::StreamingError`] is yielded and
+/// decide whether to retain or roll back any earlier items.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum StreamErrorKind {
+    /// An SSE event contained bytes that were not valid UTF-8.
+    InvalidEventEncoding,
+    /// An SSE `data:` payload was not valid JSON.
+    InvalidEventJson,
+    /// A recognized provider event had an invalid shape.
+    InvalidProviderEvent,
+    /// The provider sent an explicit error inside an otherwise successful stream.
+    ProviderStreamError,
+    /// HTTP EOF arrived before the provider's required terminal event.
+    IncompleteEventStream,
+    /// A streamed array element was not valid JSON.
+    InvalidArrayElement {
+        /// Zero-based index of the malformed element.
+        index: usize,
+    },
+    /// The structured response never contained the expected array.
+    MissingArray,
+    /// The response ended before the streamed array was closed.
+    IncompleteArray {
+        /// Zero-based index of the element that would have been yielded next.
+        next_index: usize,
+    },
+    /// The JSON surrounding a complete streamed array was malformed.
+    InvalidArrayEnvelope,
+    /// The array closed, but its surrounding JSON object did not.
+    IncompleteArrayEnvelope,
+}
+
+impl fmt::Display for StreamErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidEventEncoding => f.write_str("invalid SSE event encoding"),
+            Self::InvalidEventJson => f.write_str("invalid SSE event JSON"),
+            Self::InvalidProviderEvent => f.write_str("invalid provider stream event"),
+            Self::ProviderStreamError => f.write_str("provider stream error"),
+            Self::IncompleteEventStream => {
+                f.write_str("incomplete stream without a provider terminal event")
+            }
+            Self::InvalidArrayElement { index } => {
+                write!(f, "invalid streamed array element at index {index}")
+            }
+            Self::MissingArray => f.write_str("missing streamed array"),
+            Self::IncompleteArray { next_index } => {
+                write!(
+                    f,
+                    "incomplete streamed array before element index {next_index}"
+                )
+            }
+            Self::InvalidArrayEnvelope => f.write_str("invalid streamed array envelope"),
+            Self::IncompleteArrayEnvelope => f.write_str("incomplete streamed array envelope"),
+        }
+    }
 }
 
 impl ApiErrorKind {
@@ -372,6 +435,19 @@ pub enum RStructorError {
         message: String,
     },
 
+    /// A streamed response was malformed or ended before its framing completed.
+    ///
+    /// This error is deliberately non-retryable: a stream may already have
+    /// yielded text or validated objects, so automatically replaying it could
+    /// duplicate caller-visible side effects.
+    #[error("Streaming error ({kind}): {message}")]
+    StreamingError {
+        /// Machine-readable failure category.
+        kind: StreamErrorKind,
+        /// Safe diagnostic context. Provider response contents are not included.
+        message: Box<str>,
+    },
+
     /// Operation timed out
     #[error("Timeout error")]
     Timeout,
@@ -535,6 +611,16 @@ impl PartialEq for RStructorError {
                     message: message_b,
                 },
             ) => path_a == path_b && message_a == message_b,
+            (
+                Self::StreamingError {
+                    kind: kind_a,
+                    message: message_a,
+                },
+                Self::StreamingError {
+                    kind: kind_b,
+                    message: message_b,
+                },
+            ) => kind_a == kind_b && message_a == message_b,
             (Self::Unsupported(a), Self::Unsupported(b)) => a == b,
             (Self::Timeout, Self::Timeout) => true,
             // HttpError and JsonError don't implement PartialEq, so we always return false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub mod model;
 pub mod schema;
 
 // Re-exports for convenience
-pub use error::{ApiErrorKind, RStructorError, Result};
+pub use error::{ApiErrorKind, RStructorError, Result, StreamErrorKind};
 pub use model::Instructor;
 pub use schema::{CustomTypeSchema, Schema, SchemaBuilder, SchemaType};
 

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod error_tests {
-    use rstructor::{ApiErrorKind, RStructorError, Result};
+    use rstructor::{ApiErrorKind, RStructorError, Result, StreamErrorKind};
     use serde_json::json;
     use std::time::Duration;
 
@@ -303,6 +303,13 @@ mod error_tests {
             }
             .is_retryable()
         );
+        assert!(
+            !RStructorError::StreamingError {
+                kind: StreamErrorKind::IncompleteEventStream,
+                message: "missing [DONE]".into(),
+            }
+            .is_retryable()
+        );
     }
 
     #[test]
@@ -389,6 +396,33 @@ mod error_tests {
             RStructorError::ToolArgumentDecodeError {
                 path: "$.order.quantity".to_string(),
                 message: "invalid type: string, expected i64".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_stream_error_display_equality_and_index_context() {
+        let error = RStructorError::StreamingError {
+            kind: StreamErrorKind::InvalidArrayElement { index: 7 },
+            message: "element was not valid JSON".into(),
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Streaming error (invalid streamed array element at index 7): element was not valid JSON"
+        );
+        assert_eq!(
+            error,
+            RStructorError::StreamingError {
+                kind: StreamErrorKind::InvalidArrayElement { index: 7 },
+                message: "element was not valid JSON".into(),
+            }
+        );
+        assert_ne!(
+            error,
+            RStructorError::StreamingError {
+                kind: StreamErrorKind::InvalidArrayElement { index: 8 },
+                message: "element was not valid JSON".into(),
             }
         );
     }

--- a/tests/fixtures/streaming/anthropic_in_band_error.sse
+++ b/tests/fixtures/streaming/anthropic_in_band_error.sse
@@ -1,0 +1,5 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_risk_003","type":"message","role":"assistant","model":"claude-sonnet-4-5-20250929","content":[],"stop_reason":null}}
+
+event: error
+data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}

--- a/tests/fixtures/streaming/anthropic_text_complete.sse
+++ b/tests/fixtures/streaming/anthropic_text_complete.sse
@@ -1,0 +1,11 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_risk_001","type":"message","role":"assistant","model":"claude-sonnet-4-5-20250929","content":[],"stop_reason":null}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Net delta: $18.4mm"}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":8}}
+
+event: message_stop
+data: {"type":"message_stop"}

--- a/tests/fixtures/streaming/anthropic_text_missing_stop.sse
+++ b/tests/fixtures/streaming/anthropic_text_missing_stop.sse
@@ -1,0 +1,8 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_risk_002","type":"message","role":"assistant","model":"claude-sonnet-4-5-20250929","content":[],"stop_reason":null}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Net delta: $18.4mm"}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":8}}

--- a/tests/fixtures/streaming/gemini_finish_only_content.sse
+++ b/tests/fixtures/streaming/gemini_finish_only_content.sse
@@ -1,0 +1,3 @@
+data: {"candidates":[{"content":{"parts":[{"text":"VaR: $2.1mm"}],"role":"model"},"index":0}],"modelVersion":"gemini-2.5-flash"}
+
+data: {"candidates":[{"content":{"role":"model"},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":6,"totalTokenCount":14},"modelVersion":"gemini-2.5-flash"}

--- a/tests/fixtures/streaming/gemini_text_complete.sse
+++ b/tests/fixtures/streaming/gemini_text_complete.sse
@@ -1,0 +1,1 @@
+data: {"candidates":[{"content":{"parts":[{"text":"VaR: "},{"text":"$2.1mm"}],"role":"model"},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":6,"totalTokenCount":14},"modelVersion":"gemini-2.5-flash"}

--- a/tests/fixtures/streaming/gemini_text_missing_finish.sse
+++ b/tests/fixtures/streaming/gemini_text_missing_finish.sse
@@ -1,0 +1,1 @@
+data: {"candidates":[{"content":{"parts":[{"text":"VaR: $2.1mm"}],"role":"model"},"index":0}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":6,"totalTokenCount":14},"modelVersion":"gemini-2.5-flash"}

--- a/tests/fixtures/streaming/grok_text_missing_done.sse
+++ b/tests/fixtures/streaming/grok_text_missing_done.sse
@@ -1,0 +1,1 @@
+data: {"id":"7f0e9c9a-risk","object":"chat.completion.chunk","created":1785254400,"model":"grok-4-1-fast-reasoning","choices":[{"index":0,"delta":{"role":"assistant","content":"Beta: 0.84"},"finish_reason":"stop"}]}

--- a/tests/fixtures/streaming/openai_items_complete.sse
+++ b/tests/fixtures/streaming/openai_items_complete.sse
@@ -1,0 +1,5 @@
+data: {"id":"chatcmpl-risk-006","object":"chat.completion.chunk","created":1785254400,"model":"gpt-5-mini","choices":[{"index":0,"delta":{"content":"{\"items\":[{\"symbol\":\"AAPL\",\"quantity\":125000},"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-risk-006","object":"chat.completion.chunk","created":1785254400,"model":"gpt-5-mini","choices":[{"index":0,"delta":{"content":"{\"symbol\":\"ESU6\",\"quantity\":-240}]}"},"finish_reason":"stop"}]}
+
+data: [DONE]

--- a/tests/fixtures/streaming/openai_items_complete_without_done.sse
+++ b/tests/fixtures/streaming/openai_items_complete_without_done.sse
@@ -1,0 +1,3 @@
+data: {"id":"chatcmpl-risk-005","object":"chat.completion.chunk","created":1785254400,"model":"gpt-5-mini","choices":[{"index":0,"delta":{"content":"{\"items\":[{\"symbol\":\"AAPL\",\"quantity\":125000},"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-risk-005","object":"chat.completion.chunk","created":1785254400,"model":"gpt-5-mini","choices":[{"index":0,"delta":{"content":"{\"symbol\":\"ESU6\",\"quantity\":-240}]}"},"finish_reason":"stop"}]}

--- a/tests/fixtures/streaming/openai_items_invalid_element.sse
+++ b/tests/fixtures/streaming/openai_items_invalid_element.sse
@@ -1,0 +1,5 @@
+data: {"id":"chatcmpl-risk-003","object":"chat.completion.chunk","created":1785254400,"model":"gpt-5-mini","choices":[{"index":0,"delta":{"content":"{\"items\":[{\"symbol\":\"AAPL\",\"quantity\":125000},not-json,"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-risk-003","object":"chat.completion.chunk","created":1785254400,"model":"gpt-5-mini","choices":[{"index":0,"delta":{"content":"{\"symbol\":\"ESU6\",\"quantity\":-240}]}"},"finish_reason":"stop"}]}
+
+data: [DONE]

--- a/tests/fixtures/streaming/openai_items_truncated.sse
+++ b/tests/fixtures/streaming/openai_items_truncated.sse
@@ -1,0 +1,5 @@
+data: {"id":"chatcmpl-risk-004","object":"chat.completion.chunk","created":1785254400,"model":"gpt-5-mini","choices":[{"index":0,"delta":{"content":"{\"items\":[{\"symbol\":\"AAPL\",\"quantity\":125000},"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-risk-004","object":"chat.completion.chunk","created":1785254400,"model":"gpt-5-mini","choices":[{"index":0,"delta":{"content":"{\"symbol\":\"ESU6\",\"quantity\":-240"},"finish_reason":"stop"}]}
+
+data: [DONE]

--- a/tests/fixtures/streaming/openai_object_valid_then_malformed.sse
+++ b/tests/fixtures/streaming/openai_object_valid_then_malformed.sse
@@ -1,0 +1,3 @@
+data: {"id":"chatcmpl-risk-002","object":"chat.completion.chunk","created":1785254400,"model":"gpt-5-mini","choices":[{"index":0,"delta":{"content":"{\"portfolio_id\":\"HF-ALPHA-001\",\"gross_exposure\":1.42}"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-risk-002","object":"chat.completion.chunk","choices":[

--- a/tests/fixtures/streaming/openai_text_malformed_event.sse
+++ b/tests/fixtures/streaming/openai_text_malformed_event.sse
@@ -1,0 +1,5 @@
+data: {"id":"chatcmpl-risk-001","object":"chat.completion.chunk","created":1785254400,"model":"gpt-5-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"Gross exposure: "},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-risk-001","object":"chat.completion.chunk","created":1785254400,"model":"gpt-5-mini","choices":[{"index":0,"delta":{"content":"1.42x"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-risk-001","object":"chat.completion.chunk","choices":[

--- a/tests/map_fidelity_tests.rs
+++ b/tests/map_fidelity_tests.rs
@@ -498,7 +498,8 @@ async fn gemini_object_stream_sends_and_decodes_a_native_typed_map() {
                 "candidates": [{
                     "content": {
                         "parts": [{ "text": response }]
-                    }
+                    },
+                    "finishReason": "STOP"
                 }]
             })
         ))
@@ -567,7 +568,8 @@ async fn gemini_item_stream_sends_and_decodes_native_typed_maps() {
                 "candidates": [{
                     "content": {
                         "parts": [{ "text": stream_payload }]
-                    }
+                    },
+                    "finishReason": "STOP"
                 }]
             })
         ))

--- a/tests/mock_edge_tests.rs
+++ b/tests/mock_edge_tests.rs
@@ -8,7 +8,9 @@
 
 #![cfg(feature = "mock")]
 
-use rstructor::{Instructor, LLMClient, MockClient, MockResponse, RStructorError, RequestKind};
+use rstructor::{
+    Instructor, LLMClient, MockClient, MockResponse, RStructorError, RequestKind, StreamErrorKind,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
@@ -213,6 +215,10 @@ async fn path_aware_errors_are_preserved_when_mock_defaults_are_cloned() {
             context: "structured output".into(),
             path: "$.properties.positions".into(),
             message: "dynamic maps are unsupported".into(),
+        },
+        RStructorError::StreamingError {
+            kind: StreamErrorKind::IncompleteArray { next_index: 2 },
+            message: "stream ended early".into(),
         },
     ] {
         let client = MockClient::new().with_default_response(MockResponse::error(error));

--- a/tests/stream_integrity_tests.rs
+++ b/tests/stream_integrity_tests.rs
@@ -181,6 +181,30 @@ async fn gemini_final_text_and_finish_reason_complete_together() {
 
 #[cfg(feature = "gemini")]
 #[tokio::test]
+async fn gemini_finish_only_content_may_omit_parts() {
+    let fixture = include_str!("fixtures/streaming/gemini_finish_only_content.sse");
+    let (server, response) = serve_gemini_fixture(fixture).await;
+    let client = rstructor::GeminiClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("test-model");
+    let chunks = client
+        .generate_stream("summarize value at risk")
+        .collect::<Vec<_>>()
+        .await;
+
+    assert_eq!(
+        chunks
+            .into_iter()
+            .collect::<rstructor::Result<Vec<_>>>()
+            .unwrap(),
+        vec!["VaR: $2.1mm"]
+    );
+    response.assert_async().await;
+}
+
+#[cfg(feature = "gemini")]
+#[tokio::test]
 async fn gemini_requires_a_nonempty_finish_reason() {
     let fixture = include_str!("fixtures/streaming/gemini_text_missing_finish.sse");
     let (server, response) = serve_gemini_fixture(fixture).await;

--- a/tests/stream_integrity_tests.rs
+++ b/tests/stream_integrity_tests.rs
@@ -1,0 +1,325 @@
+//! Offline HTTP tests for strict streaming integrity.
+//!
+//! The fixtures use sanitized OpenAI Chat Completions event shapes captured from
+//! realistic portfolio workflows. They drive the real HTTP/SSE/provider pipeline,
+//! which `MockClient` intentionally bypasses.
+
+#![cfg(all(feature = "openai", feature = "streaming"))]
+
+use futures_util::StreamExt;
+use rstructor::{
+    Instructor, LLMClient, OpenAIClient, RStructorError, StreamErrorKind, StreamedObject,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
+struct Position {
+    symbol: String,
+    quantity: i64,
+}
+
+#[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
+struct PortfolioSummary {
+    portfolio_id: String,
+    gross_exposure: f64,
+}
+
+fn client(server: &mockito::Server) -> OpenAIClient {
+    OpenAIClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("gpt-5-mini")
+}
+
+async fn serve_fixture(body: &str) -> (mockito::ServerGuard, mockito::Mock) {
+    serve_fixture_at("/chat/completions", body).await
+}
+
+async fn serve_fixture_at(path: &str, body: &str) -> (mockito::ServerGuard, mockito::Mock) {
+    let mut server = mockito::Server::new_async().await;
+    let response = server
+        .mock("POST", path)
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(body)
+        .expect(1)
+        .create_async()
+        .await;
+    (server, response)
+}
+
+async fn serve_gemini_fixture(body: &str) -> (mockito::ServerGuard, mockito::Mock) {
+    let mut server = mockito::Server::new_async().await;
+    let response = server
+        .mock("POST", "/models/test-model:streamGenerateContent")
+        .match_query(mockito::Matcher::AllOf(vec![
+            mockito::Matcher::UrlEncoded("alt".to_string(), "sse".to_string()),
+            mockito::Matcher::UrlEncoded("key".to_string(), "test-key".to_string()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(body)
+        .expect(1)
+        .create_async()
+        .await;
+    (server, response)
+}
+
+fn assert_stream_error(error: RStructorError, expected: StreamErrorKind) {
+    match error {
+        RStructorError::StreamingError { kind, message } => {
+            assert_eq!(kind, expected);
+            assert!(!message.is_empty());
+        }
+        other => panic!("expected StreamingError, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn malformed_sse_json_is_terminal_after_prior_text_deltas() {
+    let fixture = include_str!("fixtures/streaming/openai_text_malformed_event.sse");
+    let (server, response) = serve_fixture(fixture).await;
+    let client = client(&server);
+    let mut stream = client.generate_stream("summarize gross exposure");
+
+    assert_eq!(stream.next().await.unwrap().unwrap(), "Gross exposure: ");
+    assert_eq!(stream.next().await.unwrap().unwrap(), "1.42x");
+    assert_stream_error(
+        stream.next().await.unwrap().unwrap_err(),
+        StreamErrorKind::InvalidEventJson,
+    );
+    assert!(stream.next().await.is_none(), "nothing may follow an error");
+    response.assert_async().await;
+}
+
+#[cfg(feature = "anthropic")]
+#[tokio::test]
+async fn anthropic_requires_message_stop_after_content() {
+    let fixture = include_str!("fixtures/streaming/anthropic_text_missing_stop.sse");
+    let (server, response) = serve_fixture_at("/messages", fixture).await;
+    let client = rstructor::AnthropicClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("claude-sonnet-4-5-20250929");
+    let mut stream = client.generate_stream("summarize net delta");
+
+    assert_eq!(stream.next().await.unwrap().unwrap(), "Net delta: $18.4mm");
+    assert_stream_error(
+        stream.next().await.unwrap().unwrap_err(),
+        StreamErrorKind::IncompleteEventStream,
+    );
+    assert!(stream.next().await.is_none());
+    response.assert_async().await;
+}
+
+#[cfg(feature = "anthropic")]
+#[tokio::test]
+async fn anthropic_message_stop_completes_cleanly() {
+    let fixture = include_str!("fixtures/streaming/anthropic_text_complete.sse");
+    let (server, response) = serve_fixture_at("/messages", fixture).await;
+    let client = rstructor::AnthropicClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("claude-sonnet-4-5-20250929");
+    let chunks = client
+        .generate_stream("summarize net delta")
+        .collect::<Vec<_>>()
+        .await;
+
+    assert_eq!(
+        chunks
+            .into_iter()
+            .collect::<rstructor::Result<Vec<_>>>()
+            .unwrap(),
+        vec!["Net delta: $18.4mm"]
+    );
+    response.assert_async().await;
+}
+
+#[cfg(feature = "anthropic")]
+#[tokio::test]
+async fn anthropic_in_band_error_is_terminal_and_typed() {
+    let fixture = include_str!("fixtures/streaming/anthropic_in_band_error.sse");
+    let (server, response) = serve_fixture_at("/messages", fixture).await;
+    let client = rstructor::AnthropicClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("claude-sonnet-4-5-20250929");
+    let mut stream = client.generate_stream("summarize net delta");
+
+    assert_stream_error(
+        stream.next().await.unwrap().unwrap_err(),
+        StreamErrorKind::ProviderStreamError,
+    );
+    assert!(stream.next().await.is_none());
+    response.assert_async().await;
+}
+
+#[cfg(feature = "gemini")]
+#[tokio::test]
+async fn gemini_final_text_and_finish_reason_complete_together() {
+    let fixture = include_str!("fixtures/streaming/gemini_text_complete.sse");
+    let (server, response) = serve_gemini_fixture(fixture).await;
+    let client = rstructor::GeminiClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("test-model");
+    let chunks = client
+        .generate_stream("summarize value at risk")
+        .collect::<Vec<_>>()
+        .await;
+
+    assert_eq!(
+        chunks
+            .into_iter()
+            .collect::<rstructor::Result<Vec<_>>>()
+            .unwrap(),
+        vec!["VaR: $2.1mm"]
+    );
+    response.assert_async().await;
+}
+
+#[cfg(feature = "gemini")]
+#[tokio::test]
+async fn gemini_requires_a_nonempty_finish_reason() {
+    let fixture = include_str!("fixtures/streaming/gemini_text_missing_finish.sse");
+    let (server, response) = serve_gemini_fixture(fixture).await;
+    let client = rstructor::GeminiClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("test-model");
+    let mut stream = client.generate_stream("summarize value at risk");
+
+    assert_eq!(stream.next().await.unwrap().unwrap(), "VaR: $2.1mm");
+    assert_stream_error(
+        stream.next().await.unwrap().unwrap_err(),
+        StreamErrorKind::IncompleteEventStream,
+    );
+    assert!(stream.next().await.is_none());
+    response.assert_async().await;
+}
+
+#[cfg(feature = "grok")]
+#[tokio::test]
+async fn grok_requires_done_after_its_finish_reason_chunk() {
+    let fixture = include_str!("fixtures/streaming/grok_text_missing_done.sse");
+    let (server, response) = serve_fixture(fixture).await;
+    let client = rstructor::GrokClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("grok-4-1-fast-reasoning");
+    let mut stream = client.generate_stream("estimate market beta");
+
+    assert_eq!(stream.next().await.unwrap().unwrap(), "Beta: 0.84");
+    assert_stream_error(
+        stream.next().await.unwrap().unwrap_err(),
+        StreamErrorKind::IncompleteEventStream,
+    );
+    assert!(stream.next().await.is_none());
+    response.assert_async().await;
+}
+
+#[tokio::test]
+async fn object_stream_never_completes_after_a_malformed_event() {
+    let fixture = include_str!("fixtures/streaming/openai_object_valid_then_malformed.sse");
+    let (server, response) = serve_fixture(fixture).await;
+    let client = client(&server);
+    let mut stream = client.materialize_stream::<PortfolioSummary>("summarize the portfolio");
+
+    let first = stream.next().await.unwrap().unwrap();
+    assert!(matches!(first, StreamedObject::Partial(_)));
+    assert_stream_error(
+        stream.next().await.unwrap().unwrap_err(),
+        StreamErrorKind::InvalidEventJson,
+    );
+    assert!(
+        stream.next().await.is_none(),
+        "Complete must not follow an integrity error"
+    );
+    response.assert_async().await;
+}
+
+#[tokio::test]
+async fn invalid_array_element_is_not_dropped_or_renumbered() {
+    let fixture = include_str!("fixtures/streaming/openai_items_invalid_element.sse");
+    let (server, response) = serve_fixture(fixture).await;
+    let client = client(&server);
+    let mut stream = client.materialize_iter::<Position>("reconcile positions");
+
+    assert_eq!(
+        stream.next().await.unwrap().unwrap(),
+        Position {
+            symbol: "AAPL".to_string(),
+            quantity: 125_000,
+        }
+    );
+    assert_stream_error(
+        stream.next().await.unwrap().unwrap_err(),
+        StreamErrorKind::InvalidArrayElement { index: 1 },
+    );
+    assert!(stream.next().await.is_none(), "nothing may follow an error");
+    response.assert_async().await;
+}
+
+#[tokio::test]
+async fn done_sentinel_does_not_hide_a_truncated_array_tail() {
+    let fixture = include_str!("fixtures/streaming/openai_items_truncated.sse");
+    let (server, response) = serve_fixture(fixture).await;
+    let client = client(&server);
+    let mut stream = client.materialize_iter::<Position>("reconcile positions");
+
+    assert_eq!(stream.next().await.unwrap().unwrap().symbol, "AAPL");
+    assert_stream_error(
+        stream.next().await.unwrap().unwrap_err(),
+        StreamErrorKind::IncompleteArray { next_index: 1 },
+    );
+    assert!(stream.next().await.is_none(), "nothing may follow an error");
+    response.assert_async().await;
+}
+
+#[tokio::test]
+async fn valid_json_at_eof_is_not_authoritative_without_done() {
+    let fixture = include_str!("fixtures/streaming/openai_items_complete_without_done.sse");
+    let (server, response) = serve_fixture(fixture).await;
+    let client = client(&server);
+    let mut stream = client.materialize_iter::<Position>("reconcile positions");
+
+    assert_eq!(stream.next().await.unwrap().unwrap().symbol, "AAPL");
+    assert_eq!(stream.next().await.unwrap().unwrap().symbol, "ESU6");
+    assert_stream_error(
+        stream.next().await.unwrap().unwrap_err(),
+        StreamErrorKind::IncompleteEventStream,
+    );
+    assert!(stream.next().await.is_none(), "nothing may follow an error");
+    response.assert_async().await;
+}
+
+#[tokio::test]
+async fn complete_array_and_terminal_marker_end_cleanly() {
+    let fixture = include_str!("fixtures/streaming/openai_items_complete.sse");
+    let (server, response) = serve_fixture(fixture).await;
+    let client = client(&server);
+    let results = client
+        .materialize_iter::<Position>("reconcile positions")
+        .collect::<Vec<_>>()
+        .await;
+
+    let positions = results
+        .into_iter()
+        .collect::<rstructor::Result<Vec<_>>>()
+        .unwrap();
+    assert_eq!(
+        positions,
+        vec![
+            Position {
+                symbol: "AAPL".to_string(),
+                quantity: 125_000,
+            },
+            Position {
+                symbol: "ESU6".to_string(),
+                quantity: -240,
+            },
+        ]
+    );
+    response.assert_async().await;
+}


### PR DESCRIPTION
## Summary

Make every built-in streaming path fail closed when provider data is malformed or truncated. Text and validated items may still be yielded before a later integrity error, but a stream is authoritative only when it drains cleanly, and `materialize_stream` now emits `Complete(T)` only after verified provider termination.

## Problem

The shared streaming layer treated several forms of data loss as success:

- malformed SSE JSON events were silently discarded;
- invalid `materialize_iter` elements were dropped and later elements were renumbered;
- invalid UTF-8 was replacement-decoded;
- an EOF-terminated SSE line was discarded;
- a truncated array could end after yielding a valid prefix;
- a syntactically complete prefix could be finalized even when the provider never sent its terminal event.

That creates a dangerous false-success mode: dropping one delta can still leave valid JSON with different semantics, so schema validation alone cannot detect the corruption.

## Fix

- Parse SSE events according to framing rules, including CR/LF/CRLF, UTF-8 BOMs, repeated `data:` fields, arbitrary byte boundaries, and EOF-terminated final events.
- Stop after one typed `RStructorError::StreamingError`; error messages contain structural context without echoing provider or model payloads.
- Require the provider-specific terminal contract:
  - OpenAI and Grok: `[DONE]`
  - Anthropic: `message_stop`
  - Gemini: a non-empty `finishReason`
- Surface malformed known provider events and in-band provider errors.
- Make streamed-array parsing indexed and fallible, reject bad commas/delimiters, validate closure of the array and its wrapper, and prevent second-array re-entry.
- Preserve completed values before a later malformed value, including when both occur in the same provider delta.

This intentionally changes the default behavior for proxies that omit required terminal markers: valid-looking content followed by bare EOF now ends with `StreamErrorKind::IncompleteEventStream`.

## Usage examples

Stage streamed items until clean completion before committing irreversible side effects:

```rust
use futures_util::StreamExt;
use rstructor::{LLMClient, RStructorError, StreamErrorKind};

let mut staged = Vec::new();
let mut stream = client.materialize_iter::<Position>("Reconcile positions");

while let Some(item) = stream.next().await {
    match item {
        Ok(position) => staged.push(position),
        Err(RStructorError::StreamingError {
            kind: StreamErrorKind::IncompleteEventStream,
            ..
        }) => {
            staged.clear();
            return Err("provider stream was truncated".into());
        }
        Err(error) => return Err(error.into()),
    }
}

commit_positions(staged).await?;
```

Malformed list elements are no longer invisible:

```rust
match stream.next().await {
    Some(Err(RStructorError::StreamingError {
        kind: StreamErrorKind::InvalidArrayElement { index },
        ..
    })) => eprintln!("provider emitted invalid JSON at $.items[{index}]"),
    other => { /* handle item, completion, or another error */ }
}
```

For a provider payload shaped like:

```text
{"items":[{"symbol":"AAPL","quantity":125000},not-json,{"symbol":"ESU6","quantity":-240}]}
```

the stream now yields the valid AAPL item, then `InvalidArrayElement { index: 1 }`, then ends. It never silently skips to ESU6.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --no-fail-fast`
- `cargo build --all-features --examples`
- `cargo build --no-default-features --features derive`
- `cargo build --no-default-features --features "derive,mock"`

The test suite includes sanitized provider-shaped fixtures for OpenAI, Anthropic, Gemini, and Grok; every-byte-split state-machine tests; malformed UTF-8/JSON/provider events; in-band errors; same-delta valid-prefix preservation; missing terminal markers; incomplete arrays and wrappers; and clean completion.
