### PR TITLE
[codex] Reject media on streaming request terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,27 @@ There is also `materialize_stream`, which streams a single object as progressive
 
 All are available on every provider (OpenAI, Anthropic, Grok, Gemini). See `examples/streaming_example.rs`.
 
+Streaming terminals are currently text-only. A fluent request with attached
+media returns one `Unsupported` stream error instead of silently dropping the
+attachments:
+
+```rust
+use futures_util::StreamExt;
+use rstructor::{MediaFile, RequestExt, RStructorError};
+
+let media = [MediaFile::new("https://example.com/chart.png", "image/png")];
+let mut stream = client.with_media(&media).generate_stream("Analyze this chart");
+
+assert!(matches!(
+    stream.next().await,
+    Some(Err(RStructorError::Unsupported(_)))
+));
+assert!(stream.next().await.is_none());
+```
+
+Use `generate_with_media` or `materialize_with_media` when attachments are
+required.
+
 ## Tool Calling
 
 Enable the `tools` feature to let the model call your typed Rust functions and feed the results back, looping until it produces a final answer. Tool argument types derive `Instructor`, so their JSON Schema is generated automatically.

--- a/src/backend/request.rs
+++ b/src/backend/request.rs
@@ -4,6 +4,9 @@
 //! `with_tools`, then choose a terminal: `materialize` (structured), `generate`
 //! (text), `run` (text, using tools if attached), or — with the `streaming`
 //! feature — `materialize_iter` / `materialize_stream` / `generate_stream`.
+//! Media-bearing requests must use a non-streaming terminal; streaming terminals
+//! yield [`RStructorError::Unsupported`](crate::RStructorError::Unsupported)
+//! instead of silently discarding attachments.
 //!
 //! ```no_run
 //! # use rstructor::{OpenAIClient, RequestExt, Instructor};
@@ -21,8 +24,14 @@
 use serde::de::DeserializeOwned;
 
 use crate::backend::{LLMClient, MediaFile};
+#[cfg(feature = "streaming")]
+use crate::error::RStructorError;
 use crate::error::Result;
 use crate::model::Instructor;
+
+#[cfg(feature = "streaming")]
+const STREAMING_MEDIA_UNSUPPORTED: &str = "streaming requests with media are not supported; \
+    remove the media attachment or use a non-streaming request terminal";
 
 /// A fluent request being built against a client. Created via [`RequestExt`].
 pub struct Request<'a, C: ?Sized> {
@@ -58,7 +67,8 @@ impl<'a, C: ?Sized> Request<'a, C> {
     }
 
     /// Attach media (images, or PDFs where the provider supports them) to the
-    /// request. Used by `materialize`, `generate`, and `run`.
+    /// request. Used by `materialize`, `generate`, and `run`. Streaming
+    /// terminals reject attached media because their client APIs are text-only.
     #[must_use]
     pub fn media(mut self, media: impl Into<Vec<MediaFile>>) -> Self {
         self.media = media.into();
@@ -123,11 +133,18 @@ impl<'a, C: LLMClient + Sync + ?Sized> Request<'a, C> {
     /// Stream a **list** of structured `T`, yielding each item as soon as it is
     /// fully generated and validated, with any attached system context prepended.
     ///
-    /// Attached media is ignored — the streaming APIs are text-only.
+    /// If media is attached, the stream yields one
+    /// [`RStructorError::Unsupported`](crate::RStructorError::Unsupported) and
+    /// ends without calling the client. Streaming APIs are currently text-only.
     pub fn materialize_iter<T>(self, prompt: &str) -> crate::backend::streaming::ItemStream<'a, T>
     where
         T: Instructor + DeserializeOwned + Send + 'static,
     {
+        if !self.media.is_empty() {
+            return crate::backend::streaming::error_stream(RStructorError::Unsupported(
+                STREAMING_MEDIA_UNSUPPORTED.to_string(),
+            ));
+        }
         use futures_util::StreamExt;
         let combined = self.combined(prompt);
         let client = self.client;
@@ -140,7 +157,16 @@ impl<'a, C: LLMClient + Sync + ?Sized> Request<'a, C> {
     }
 
     /// Stream raw text deltas, with any attached system context prepended.
+    ///
+    /// If media is attached, the stream yields one
+    /// [`RStructorError::Unsupported`](crate::RStructorError::Unsupported) and
+    /// ends without calling the client. Streaming APIs are currently text-only.
     pub fn generate_stream(self, prompt: &str) -> crate::backend::streaming::TextStream<'a> {
+        if !self.media.is_empty() {
+            return crate::backend::streaming::error_stream(RStructorError::Unsupported(
+                STREAMING_MEDIA_UNSUPPORTED.to_string(),
+            ));
+        }
         use futures_util::StreamExt;
         let combined = self.combined(prompt);
         let client = self.client;
@@ -153,7 +179,11 @@ impl<'a, C: LLMClient + Sync + ?Sized> Request<'a, C> {
     }
 
     /// Stream a single structured object as its JSON fills in, with any attached
-    /// system context prepended. Attached media is ignored.
+    /// system context prepended.
+    ///
+    /// If media is attached, the stream yields one
+    /// [`RStructorError::Unsupported`](crate::RStructorError::Unsupported) and
+    /// ends without calling the client. Streaming APIs are currently text-only.
     pub fn materialize_stream<T>(
         self,
         prompt: &str,
@@ -161,6 +191,11 @@ impl<'a, C: LLMClient + Sync + ?Sized> Request<'a, C> {
     where
         T: Instructor + DeserializeOwned + Send + 'static,
     {
+        if !self.media.is_empty() {
+            return crate::backend::streaming::error_stream(RStructorError::Unsupported(
+                STREAMING_MEDIA_UNSUPPORTED.to_string(),
+            ));
+        }
         use futures_util::StreamExt;
         let combined = self.combined(prompt);
         let client = self.client;

--- a/src/backend/streaming.rs
+++ b/src/backend/streaming.rs
@@ -38,9 +38,9 @@ pub type ObjectStream<'a, T> = Pin<Box<dyn Stream<Item = Result<StreamedObject<T
 
 /// Build a stream that yields one locally detected error and performs no I/O.
 ///
-/// Provider methods use this when synchronous request construction discovers an
-/// incompatible schema but their public streaming API cannot return `Result`
-/// directly.
+/// Provider and request-builder methods use this when synchronous request
+/// construction discovers an incompatible schema or unsupported input, but
+/// their public streaming API cannot return `Result` directly.
 pub(crate) fn error_stream<'a, T>(
     error: RStructorError,
 ) -> Pin<Box<dyn Stream<Item = Result<T>> + Send + 'a>>

--- a/tests/core_ergonomics_test.rs
+++ b/tests/core_ergonomics_test.rs
@@ -189,7 +189,7 @@ mod builder {
 
         let client = MockClient::new().with_response("must not be consumed");
         let media = real_world_media();
-        let mut stream = client.with_media(&media).generate_stream("analyze");
+        let mut stream = client.with_media(&media[..1]).generate_stream("analyze");
 
         assert_streaming_media_error(
             stream

--- a/tests/core_ergonomics_test.rs
+++ b/tests/core_ergonomics_test.rs
@@ -92,8 +92,36 @@ async fn media_default_errors_instead_of_silently_dropping() {
 /// hand-rolling an echo client. Requires the `mock` feature (CI runs all features).
 #[cfg(feature = "mock")]
 mod builder {
-    use super::{Dummy, MediaFile};
+    use super::{Dummy, MediaFile, RStructorError};
+    #[cfg(feature = "streaming")]
+    use rstructor::StreamedObject;
     use rstructor::{MockClient, RequestExt, RequestKind};
+
+    #[cfg(feature = "streaming")]
+    fn assert_streaming_media_error(error: RStructorError) {
+        let RStructorError::Unsupported(message) = error else {
+            panic!("expected Unsupported, got {error:?}");
+        };
+        assert_eq!(
+            message,
+            "streaming requests with media are not supported; remove the media attachment or use a non-streaming request terminal"
+        );
+        assert!(!message.contains("confidential"));
+        assert!(!message.contains("iVBOR"));
+    }
+
+    #[cfg(feature = "streaming")]
+    fn real_world_media() -> Vec<MediaFile> {
+        vec![
+            MediaFile::new(
+                "https://files.example.com/confidential-risk-chart.png",
+                "image/png",
+            ),
+            // Sanitized bytes from the header of a real PNG. The error must not
+            // expose their base64 representation.
+            MediaFile::from_bytes(b"\x89PNG\r\n\x1a\n", "image/png"),
+        ]
+    }
 
     #[tokio::test]
     async fn generate_has_no_system_by_default() {
@@ -152,6 +180,128 @@ mod builder {
             .await;
         // The streaming terminal also prepends the system context before dispatch.
         assert_eq!(client.last_request().unwrap().prompt, "CTX\n\nhi");
+    }
+
+    #[cfg(feature = "streaming")]
+    #[tokio::test]
+    async fn generate_stream_rejects_media_without_calling_client() {
+        use futures_util::StreamExt;
+
+        let client = MockClient::new().with_response("must not be consumed");
+        let media = real_world_media();
+        let mut stream = client.with_media(&media).generate_stream("analyze");
+
+        assert_streaming_media_error(
+            stream
+                .next()
+                .await
+                .expect("one error must be yielded")
+                .unwrap_err(),
+        );
+        assert!(stream.next().await.is_none());
+        assert_eq!(client.request_count(), 0);
+        assert!(!client.responses_exhausted());
+    }
+
+    #[cfg(feature = "streaming")]
+    #[tokio::test]
+    async fn materialize_stream_rejects_media_without_calling_client() {
+        use futures_util::StreamExt;
+
+        let client = MockClient::new().with_response(r#"{"value":"must not be consumed"}"#);
+        let media = real_world_media();
+        let mut stream = client
+            .with_media(&media)
+            .materialize_stream::<Dummy>("analyze");
+
+        assert_streaming_media_error(
+            stream
+                .next()
+                .await
+                .expect("one error must be yielded")
+                .unwrap_err(),
+        );
+        assert!(stream.next().await.is_none());
+        assert_eq!(client.request_count(), 0);
+        assert!(!client.responses_exhausted());
+    }
+
+    #[cfg(feature = "streaming")]
+    #[tokio::test]
+    async fn materialize_iter_rejects_media_without_calling_client() {
+        use futures_util::StreamExt;
+
+        let client =
+            MockClient::new().with_response(r#"{"items":[{"value":"must not be consumed"}]}"#);
+        let media = real_world_media();
+        let mut stream = client
+            .with_media(&media)
+            .materialize_iter::<Dummy>("analyze");
+
+        assert_streaming_media_error(
+            stream
+                .next()
+                .await
+                .expect("one error must be yielded")
+                .unwrap_err(),
+        );
+        assert!(stream.next().await.is_none());
+        assert_eq!(client.request_count(), 0);
+        assert!(!client.responses_exhausted());
+    }
+
+    #[cfg(feature = "streaming")]
+    #[tokio::test]
+    async fn empty_media_streams_delegate_with_system_context() {
+        use futures_util::StreamExt;
+
+        let text_client = MockClient::new().with_response("VaR is $2.1mm");
+        let text: Vec<_> = text_client
+            .with_system("Use the risk policy.")
+            .media(Vec::new())
+            .generate_stream("Summarize VaR")
+            .collect()
+            .await;
+        assert_eq!(
+            text.into_iter()
+                .collect::<rstructor::Result<Vec<_>>>()
+                .unwrap(),
+            vec!["VaR is $2.1mm"]
+        );
+        let request = text_client.last_request().unwrap();
+        assert_eq!(request.kind, RequestKind::GenerateStream);
+        assert_eq!(request.prompt, "Use the risk policy.\n\nSummarize VaR");
+
+        let object_client = MockClient::new().with_response(r#"{"value":"$2.1mm"}"#);
+        let objects: Vec<_> = object_client
+            .with_system("Use the risk policy.")
+            .media(Vec::new())
+            .materialize_stream::<Dummy>("Summarize VaR")
+            .collect()
+            .await;
+        assert!(matches!(
+            objects.last(),
+            Some(Ok(StreamedObject::Complete(Dummy { value }))) if value == "$2.1mm"
+        ));
+        let request = object_client.last_request().unwrap();
+        assert_eq!(request.kind, RequestKind::MaterializeStream);
+        assert_eq!(request.prompt, "Use the risk policy.\n\nSummarize VaR");
+
+        let item_client = MockClient::new().with_response(r#"{"items":[{"value":"$2.1mm"}]}"#);
+        let items: Vec<_> = item_client
+            .with_system("Use the risk policy.")
+            .media(Vec::new())
+            .materialize_iter::<Dummy>("Summarize VaR")
+            .collect()
+            .await;
+        assert_eq!(items.len(), 1);
+        assert!(matches!(
+            items.first(),
+            Some(Ok(Dummy { value })) if value == "$2.1mm"
+        ));
+        let request = item_client.last_request().unwrap();
+        assert_eq!(request.kind, RequestKind::MaterializeIter);
+        assert_eq!(request.prompt, "Use the risk policy.\n\nSummarize VaR");
     }
 }
 


### PR DESCRIPTION
## Summary

Streaming terminals on the fluent `Request` builder now reject attached media with one `RStructorError::Unsupported` item and then end. The provider client is never invoked, so attachments can no longer be silently discarded.

Normal text-only streaming is unchanged. Empty media still delegates to `generate_stream`, `materialize_stream`, or `materialize_iter` with the same system-context handling.

## Problem

`Request::generate_stream`, `Request::materialize_stream`, and `Request::materialize_iter` consumed a request containing `media` but only forwarded the combined text prompt to `LLMClient`. That made this code look valid while the chart was never sent:

```rust
let media = [MediaFile::new("https://example.com/chart.png", "image/png")];
let mut stream = client
    .with_media(&media)
    .generate_stream("Analyze this chart");

// Before this change, the provider received only "Analyze this chart".
```

For structured extraction, silently dropping part of the input can yield a plausible but semantically unrelated answer. The streaming traits do not currently expose media-bearing methods, so forwarding the attachments would require a larger public API design.

## Fix

Each streaming request terminal checks for attached media before constructing or polling the provider stream. A non-empty attachment list returns a local one-error stream:

```rust
use futures_util::StreamExt;
use rstructor::{MediaFile, RequestExt, RStructorError};

let media = [MediaFile::new("https://example.com/chart.png", "image/png")];
let mut stream = client
    .with_media(&media)
    .generate_stream("Analyze this chart");

assert!(matches!(
    stream.next().await,
    Some(Err(RStructorError::Unsupported(_)))
));
assert!(stream.next().await.is_none());
```

Callers that require attachments should use `generate_with_media` or `materialize_with_media` until streaming-media APIs are designed.

## Test coverage

The request-builder suite uses sanitized real-world media shapes: a remote PNG URI and actual PNG header bytes. For all three streaming terminals it verifies:

- exactly one `Unsupported` error is yielded, followed by EOF;
- the underlying client records zero requests;
- the scripted provider response remains unconsumed;
- neither the URI nor encoded bytes appear in the error;
- one and multiple attachments follow the same non-empty behavior;
- empty media continues to delegate;
- system context and request kind remain unchanged for empty-media streams.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --test core_ergonomics_test builder::`
- `cargo test --no-default-features --features 'openai,mock,streaming,derive' --test core_ergonomics_test`
- `cargo test --no-default-features --features derive --lib`
- `cargo check --no-default-features`
- `cargo check --no-default-features --features derive --lib`
- `cargo test --all-features --no-fail-fast`
- every example via `cargo run --all-features --example <name>`
- `cargo doc --all-features --no-deps`
