### PR TITLE
[codex] Make derive diagnostics strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,44 @@ let client = OpenAIClient::from_env()?.max_retries(5);
 let client = OpenAIClient::from_env()?.no_retries();
 ```
 
+### Derive attributes
+
+The `llm` attribute accepts a small, checked API:
+
+- Structs and enums: `description`, `title`, `examples`, `validate`
+- Fields: `description`, `example`, `examples`
+- Enum variants: `description`
+
+Examples use native Rust expressions. Use `serde_json::json!` for object values
+instead of embedding serialized JSON strings. Multi-value examples accept both
+`examples = [one, two]` and `examples(one, two)`.
+
+Optionality comes from the Rust type itself:
+
+```rust
+#[derive(Instructor, Serialize, Deserialize)]
+#[llm(
+    description = "A portfolio allocation",
+    examples = [::serde_json::json!({
+        "name": "Long quality",
+        "benchmark": null
+    })]
+)]
+struct Allocation {
+    #[llm(description = "Strategy name", example = "Long quality")]
+    name: String,
+
+    // No `#[llm(optional)]` marker is needed.
+    #[llm(description = "Optional benchmark ticker")]
+    benchmark: Option<String>,
+}
+```
+
+Unknown `llm` keys, malformed values, invalid validation paths, and unsupported
+tuple or unit structs are compile errors at the relevant attribute or item.
+Serde attributes outside the schema subset remain owned by Serde and are not
+rejected by `Instructor`.
+
 ## Complex Types
 
 ### Dynamic Maps

--- a/examples/enum_example.rs
+++ b/examples/enum_example.rs
@@ -23,7 +23,7 @@ struct TextAnalysis {
     #[llm(description = "The detected sentiment of the text")]
     sentiment: Sentiment,
 
-    #[llm(description = "Confidence score from 0.0 to 1.0", example = "0.92")]
+    #[llm(description = "Confidence score from 0.0 to 1.0", example = 0.92)]
     confidence: f32,
 }
 

--- a/examples/medical_example.rs
+++ b/examples/medical_example.rs
@@ -124,14 +124,14 @@ struct PatientData {
 
     #[llm(description = "List of possible diagnoses with probabilities", 
           example = [
-              {
+              ::serde_json::json!({
                   "disease_name": "Myocardial infarction",
                   "probability": 0.85
-              },
-              {
+              }),
+              ::serde_json::json!({
                   "disease_name": "Angina pectoris",
                   "probability": 0.35
-              }
+              })
           ])]
     differential_diagnosis: Vec<DifferentialDiagnosis>,
 }

--- a/examples/movie_example.rs
+++ b/examples/movie_example.rs
@@ -6,7 +6,7 @@ struct Person {
     #[llm(description = "Full name of the person")]
     name: String,
 
-    #[llm(description = "Role of the person in the production", optional)]
+    #[llm(description = "Role of the person in the production")]
     role: Option<String>,
 }
 

--- a/rstructor_derive/Cargo.toml
+++ b/rstructor_derive/Cargo.toml
@@ -34,3 +34,4 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 chrono = { version = "0.4.44", features = ["serde"] }
 uuid = { version = "1.23.1", features = ["serde"] }
+trybuild = "1"

--- a/rstructor_derive/src/container_attrs.rs
+++ b/rstructor_derive/src/container_attrs.rs
@@ -1,5 +1,5 @@
 /// Container-level attributes for structs and enums
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ContainerAttributes {
     /// Description of the struct or enum
     pub description: Option<String>,
@@ -14,7 +14,7 @@ pub struct ContainerAttributes {
     pub serde_rename_all: Option<String>,
 
     /// Custom validation function path (e.g., "validate_product" or "my_module::validate")
-    pub validate: Option<String>,
+    pub validate: Option<syn::Path>,
 
     /// Serde tag field name for internally/adjacently tagged enums
     pub serde_tag: Option<String>,
@@ -33,7 +33,7 @@ pub struct ContainerAttributesBuilder {
     title: Option<String>,
     examples: Vec<proc_macro2::TokenStream>,
     serde_rename_all: Option<String>,
-    validate: Option<String>,
+    validate: Option<syn::Path>,
     serde_tag: Option<String>,
     serde_content: Option<String>,
     serde_untagged: bool,
@@ -60,7 +60,7 @@ impl ContainerAttributesBuilder {
         self
     }
 
-    pub fn validate(mut self, validate: Option<String>) -> Self {
+    pub fn validate(mut self, validate: Option<syn::Path>) -> Self {
         self.validate = validate;
         self
     }

--- a/rstructor_derive/src/generators/enum_schema.rs
+++ b/rstructor_derive/src/generators/enum_schema.rs
@@ -18,7 +18,7 @@ pub fn generate_enum_schema(
     data_enum: &DataEnum,
     container_attrs: &ContainerAttributes,
     generics: &syn::Generics,
-) -> TokenStream {
+) -> syn::Result<TokenStream> {
     // Check if it's a simple enum (no data)
     let all_simple = data_enum.variants.iter().all(|v| v.fields.is_empty());
     let has_tag = container_attrs.serde_tag.is_some();
@@ -49,24 +49,24 @@ fn generate_simple_enum_schema(
     data_enum: &DataEnum,
     container_attrs: &ContainerAttributes,
     generics: &syn::Generics,
-) -> TokenStream {
+) -> syn::Result<TokenStream> {
     // Generate implementation for simple enum with serde rename support
     let variant_values: Vec<_> = data_enum
         .variants
         .iter()
         .map(|v| {
-            let attrs = parse_variant_attributes(v);
+            let attrs = parse_variant_attributes(v)?;
             let original_name = v.ident.to_string();
             // Priority: 1) variant #[serde(rename)], 2) container #[serde(rename_all)], 3) original name
-            if let Some(ref rename) = attrs.serde_rename {
+            Ok(if let Some(ref rename) = attrs.serde_rename {
                 rename.clone()
             } else if let Some(ref rename_all) = container_attrs.serde_rename_all {
                 apply_rename_all(&original_name, rename_all)
             } else {
                 original_name
-            }
+            })
         })
-        .collect();
+        .collect::<syn::Result<_>>()?;
 
     // Handle container attributes
     let mut container_setters = Vec::new();
@@ -108,7 +108,7 @@ fn generate_simple_enum_schema(
     let schema_generics = schema_bounded_generics(generics);
     let (impl_generics, ty_generics, where_clause) = schema_generics.split_for_impl();
 
-    quote! {
+    Ok(quote! {
         impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
             fn schema() -> ::rstructor::schema::Schema {
                 // Create array of enum values
@@ -132,7 +132,7 @@ fn generate_simple_enum_schema(
                 Some(stringify!(#name).to_string())
             }
         }
-    }
+    })
 }
 
 /// Generate schema for a complex enum (with associated data)
@@ -141,7 +141,7 @@ fn generate_complex_enum_schema(
     data_enum: &DataEnum,
     container_attrs: &ContainerAttributes,
     generics: &syn::Generics,
-) -> TokenStream {
+) -> syn::Result<TokenStream> {
     // Dispatch to appropriate generator based on serde tagging mode
     if container_attrs.serde_untagged {
         return generate_untagged_enum_schema(name, data_enum, container_attrs, generics);
@@ -179,14 +179,14 @@ fn generate_externally_tagged_enum_schema(
     data_enum: &DataEnum,
     container_attrs: &ContainerAttributes,
     generics: &syn::Generics,
-) -> TokenStream {
+) -> syn::Result<TokenStream> {
     // Create variants for oneOf schema
     let mut variant_schemas = Vec::new();
 
     // Process each variant
     for variant in &data_enum.variants {
         // Get description and rename from variant attributes
-        let attrs = parse_variant_attributes(variant);
+        let attrs = parse_variant_attributes(variant)?;
 
         let original_variant_name = variant.ident.to_string();
         // Priority: 1) variant #[serde(rename)], 2) container #[serde(rename_all)], 3) original name
@@ -223,7 +223,12 @@ fn generate_externally_tagged_enum_schema(
 
                 if has_single_field {
                     // Handle single unnamed field specially (more natural JSON)
-                    let field = fields.unnamed.first().unwrap();
+                    let field = fields.unnamed.first().ok_or_else(|| {
+                        syn::Error::new_spanned(
+                            fields,
+                            "expected one field in a single-field enum variant",
+                        )
+                    })?;
 
                     // Extract field schema based on its type
                     let field_schema = generate_field_schema(&field.ty, &None);
@@ -303,7 +308,7 @@ fn generate_externally_tagged_enum_schema(
                 for field in &fields.named {
                     if let Some(field_ident) = &field.ident {
                         let original_field_name = field_ident.to_string();
-                        let field_attrs = parse_field_attributes(field);
+                        let field_attrs = parse_field_attributes(field)?;
 
                         // Apply serde rename if present
                         let field_name_str = if let Some(ref rename) = field_attrs.serde_rename {
@@ -420,7 +425,7 @@ fn generate_externally_tagged_enum_schema(
     let schema_generics = schema_bounded_generics(generics);
     let (impl_generics, ty_generics, where_clause) = schema_generics.split_for_impl();
 
-    quote! {
+    Ok(quote! {
         impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
             fn schema() -> ::rstructor::schema::Schema {
                 // Create oneOf schema for enum variants
@@ -443,7 +448,7 @@ fn generate_externally_tagged_enum_schema(
                 Some(stringify!(#name).to_string())
             }
         }
-    }
+    })
 }
 
 /// Generate schema for a field based on its type
@@ -728,11 +733,11 @@ fn generate_internally_tagged_enum_schema(
     container_attrs: &ContainerAttributes,
     generics: &syn::Generics,
     tag_name: &str,
-) -> TokenStream {
+) -> syn::Result<TokenStream> {
     let mut variant_schemas = Vec::new();
 
     for variant in &data_enum.variants {
-        let attrs = parse_variant_attributes(variant);
+        let attrs = parse_variant_attributes(variant)?;
         let original_variant_name = variant.ident.to_string();
         let variant_name = if let Some(ref rename) = attrs.serde_rename {
             rename.clone()
@@ -783,7 +788,7 @@ fn generate_internally_tagged_enum_schema(
                 for field in &fields.named {
                     if let Some(field_ident) = &field.ident {
                         let original_field_name = field_ident.to_string();
-                        let field_attrs = parse_field_attributes(field);
+                        let field_attrs = parse_field_attributes(field)?;
 
                         let field_name_str = if let Some(ref rename) = field_attrs.serde_rename {
                             rename.clone()
@@ -851,7 +856,12 @@ fn generate_internally_tagged_enum_schema(
                 if fields.unnamed.len() == 1 {
                     // Newtype variant (e.g. Present(InnerStruct)):
                     // serde flattens the inner struct's fields alongside the tag.
-                    let field = fields.unnamed.first().unwrap();
+                    let field = fields.unnamed.first().ok_or_else(|| {
+                        syn::Error::new_spanned(
+                            fields,
+                            "expected one field in a single-field enum variant",
+                        )
+                    })?;
                     let inner_ty = &field.ty;
 
                     // Unwrap Box<T> if present — Box<T> doesn't implement SchemaType
@@ -953,7 +963,7 @@ fn generate_internally_tagged_enum_schema(
     let schema_generics = schema_bounded_generics(generics);
     let (impl_generics, ty_generics, where_clause) = schema_generics.split_for_impl();
 
-    quote! {
+    Ok(quote! {
         impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
             fn schema() -> ::rstructor::schema::Schema {
                 let variant_schemas = vec![
@@ -974,7 +984,7 @@ fn generate_internally_tagged_enum_schema(
                 Some(stringify!(#name).to_string())
             }
         }
-    }
+    })
 }
 
 /// Generate schema for adjacently tagged enums
@@ -986,11 +996,11 @@ fn generate_adjacently_tagged_enum_schema(
     generics: &syn::Generics,
     tag_name: &str,
     content_name: &str,
-) -> TokenStream {
+) -> syn::Result<TokenStream> {
     let mut variant_schemas = Vec::new();
 
     for variant in &data_enum.variants {
-        let attrs = parse_variant_attributes(variant);
+        let attrs = parse_variant_attributes(variant)?;
         let original_variant_name = variant.ident.to_string();
         let variant_name = if let Some(ref rename) = attrs.serde_rename {
             rename.clone()
@@ -1039,7 +1049,12 @@ fn generate_adjacently_tagged_enum_schema(
 
                 if fields.unnamed.len() == 1 {
                     // Single field: {"tag": "Variant", "content": value}
-                    let field = fields.unnamed.first().unwrap();
+                    let field = fields.unnamed.first().ok_or_else(|| {
+                        syn::Error::new_spanned(
+                            fields,
+                            "expected one field in a single-field enum variant",
+                        )
+                    })?;
                     let field_schema = generate_field_schema(&field.ty, &None);
 
                     // Create an explicit description for single unnamed field
@@ -1137,7 +1152,7 @@ fn generate_adjacently_tagged_enum_schema(
                 for field in &fields.named {
                     if let Some(field_ident) = &field.ident {
                         let original_field_name = field_ident.to_string();
-                        let field_attrs = parse_field_attributes(field);
+                        let field_attrs = parse_field_attributes(field)?;
 
                         let field_name_str = if let Some(ref rename) = field_attrs.serde_rename {
                             rename.clone()
@@ -1248,7 +1263,7 @@ fn generate_adjacently_tagged_enum_schema(
     let schema_generics = schema_bounded_generics(generics);
     let (impl_generics, ty_generics, where_clause) = schema_generics.split_for_impl();
 
-    quote! {
+    Ok(quote! {
         impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
             fn schema() -> ::rstructor::schema::Schema {
                 let variant_schemas = vec![
@@ -1269,7 +1284,7 @@ fn generate_adjacently_tagged_enum_schema(
                 Some(stringify!(#name).to_string())
             }
         }
-    }
+    })
 }
 
 /// Generate schema for untagged enums
@@ -1279,11 +1294,11 @@ fn generate_untagged_enum_schema(
     data_enum: &DataEnum,
     container_attrs: &ContainerAttributes,
     generics: &syn::Generics,
-) -> TokenStream {
+) -> syn::Result<TokenStream> {
     let mut variant_schemas = Vec::new();
 
     for variant in &data_enum.variants {
-        let attrs = parse_variant_attributes(variant);
+        let attrs = parse_variant_attributes(variant)?;
         let variant_name = variant.ident.to_string();
         let description = attrs
             .description
@@ -1304,7 +1319,12 @@ fn generate_untagged_enum_schema(
             Fields::Unnamed(fields) => {
                 if fields.unnamed.len() == 1 {
                     // Single field - just the value
-                    let field = fields.unnamed.first().unwrap();
+                    let field = fields.unnamed.first().ok_or_else(|| {
+                        syn::Error::new_spanned(
+                            fields,
+                            "expected one field in a single-field enum variant",
+                        )
+                    })?;
                     let field_schema = generate_field_schema(&field.ty, &Some(description.clone()));
                     variant_schemas.push(quote! { #field_schema });
                 } else {
@@ -1342,7 +1362,7 @@ fn generate_untagged_enum_schema(
                 for field in &fields.named {
                     if let Some(field_ident) = &field.ident {
                         let original_field_name = field_ident.to_string();
-                        let field_attrs = parse_field_attributes(field);
+                        let field_attrs = parse_field_attributes(field)?;
 
                         let field_name_str = if let Some(ref rename) = field_attrs.serde_rename {
                             rename.clone()
@@ -1409,7 +1429,7 @@ fn generate_untagged_enum_schema(
     let schema_generics = schema_bounded_generics(generics);
     let (impl_generics, ty_generics, where_clause) = schema_generics.split_for_impl();
 
-    quote! {
+    Ok(quote! {
         impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
             fn schema() -> ::rstructor::schema::Schema {
                 let variant_schemas = vec![
@@ -1430,7 +1450,7 @@ fn generate_untagged_enum_schema(
                 Some(stringify!(#name).to_string())
             }
         }
-    }
+    })
 }
 
 /// Generate container attribute setters (shared helper)

--- a/rstructor_derive/src/generators/struct_schema.rs
+++ b/rstructor_derive/src/generators/struct_schema.rs
@@ -17,7 +17,7 @@ pub fn generate_struct_schema(
     data_struct: &DataStruct,
     container_attrs: &ContainerAttributes,
     generics: &syn::Generics,
-) -> TokenStream {
+) -> syn::Result<TokenStream> {
     let mut property_setters = Vec::new();
     let mut required_setters = Vec::new();
     let mut has_self_reference = false;
@@ -35,9 +35,15 @@ pub fn generate_struct_schema(
 
             for field in &fields.named {
                 // Parse field attributes first to check for serde rename
-                let attrs = parse_field_attributes(field);
+                let attrs = parse_field_attributes(field)?;
 
-                let original_field_name = field.ident.as_ref().unwrap().to_string();
+                let original_field_name = field
+                    .ident
+                    .as_ref()
+                    .ok_or_else(|| {
+                        syn::Error::new_spanned(field, "Instructor requires named struct fields")
+                    })?
+                    .to_string();
                 // Priority: 1) field-level #[serde(rename)], 2) container #[serde(rename_all)], 3) original name
                 let field_name = if let Some(ref rename) = attrs.serde_rename {
                     rename.clone()
@@ -383,7 +389,16 @@ pub fn generate_struct_schema(
                 }
             }
         }
-        _ => panic!("Instructor can only be derived for structs with named fields"),
+        _ => {
+            let span = match &data_struct.fields {
+                Fields::Unit => name.span(),
+                fields => syn::spanned::Spanned::span(fields),
+            };
+            return Err(syn::Error::new(
+                span,
+                "Instructor requires a struct with named fields",
+            ));
+        }
     }
 
     // Handle container attributes
@@ -434,7 +449,7 @@ pub fn generate_struct_schema(
 
     // Generate implementation with $defs support for recursive types
     if has_self_reference {
-        quote! {
+        Ok(quote! {
             impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
                 fn schema() -> ::rstructor::schema::Schema {
                     // Create base schema object (properties will be added to $defs)
@@ -471,9 +486,9 @@ pub fn generate_struct_schema(
                     Some(stringify!(#name).to_string())
                 }
             }
-        }
+        })
     } else {
-        quote! {
+        Ok(quote! {
             impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
                 fn schema() -> ::rstructor::schema::Schema {
                     // Create base schema object
@@ -501,7 +516,7 @@ pub fn generate_struct_schema(
                     Some(stringify!(#name).to_string())
                 }
             }
-        }
+        })
     }
 }
 

--- a/rstructor_derive/src/lib.rs
+++ b/rstructor_derive/src/lib.rs
@@ -12,6 +12,7 @@ mod type_utils;
 
 use container_attrs::ContainerAttributes;
 use proc_macro::TokenStream;
+use syn::spanned::Spanned;
 use syn::{Data, DeriveInput, Fields, parse_macro_input};
 
 /// Derive macro for implementing Instructor and SchemaType
@@ -140,6 +141,17 @@ use syn::{Data, DeriveInput, Fields, parse_macro_input};
 /// - `description`: A description of the struct or enum
 /// - `title`: A custom title for the JSON Schema (defaults to the type name)
 /// - `examples`: Example instances of the struct or enum
+/// - `validate`: A quoted Rust path to a custom validation function
+///
+/// ### Field and Variant Attributes
+///
+/// Fields accept `description`, `example`, and `examples`. Enum variants accept
+/// `description`. Field optionality is inferred from `Option<T>`; there is no
+/// `optional` attribute.
+///
+/// The `llm` namespace is checked strictly. Unknown attributes, malformed
+/// values, invalid validation paths, and unsupported tuple/unit structs produce
+/// errors at the relevant source span instead of being ignored.
 ///
 /// ### Serde Integration
 ///
@@ -148,22 +160,35 @@ use syn::{Data, DeriveInput, Fields, parse_macro_input};
 ///   - Example: With `#[serde(rename_all = "camelCase")]`, a field `user_id` becomes `userId` in the schema
 #[proc_macro_derive(Instructor, attributes(llm))]
 pub fn derive_instructor(input: TokenStream) -> TokenStream {
-    // Parse the input tokens into a syntax tree
     let input = parse_macro_input!(input as DeriveInput);
-    let name = &input.ident;
+    expand(input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
 
-    // First, extract container-level attributes
-    let container_attrs = extract_container_attributes(&input.attrs);
+fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+    validate_derive_input(&input)?;
+
+    let name = &input.ident;
+    let container_attrs = extract_container_attributes(&input.attrs)?;
 
     // Generate the schema implementation
     let schema_impl = match &input.data {
-        Data::Struct(data_struct) => {
-            generators::generate_struct_schema(name, data_struct, &container_attrs, &input.generics)
-        }
+        Data::Struct(data_struct) => generators::generate_struct_schema(
+            name,
+            data_struct,
+            &container_attrs,
+            &input.generics,
+        )?,
         Data::Enum(data_enum) => {
-            generators::generate_enum_schema(name, data_enum, &container_attrs, &input.generics)
+            generators::generate_enum_schema(name, data_enum, &container_attrs, &input.generics)?
         }
-        _ => panic!("Instructor can only be derived for structs and enums"),
+        Data::Union(_) => {
+            return Err(syn::Error::new_spanned(
+                &input,
+                "Instructor can only be derived for structs with named fields and enums",
+            ));
+        }
     };
 
     // Generate the Instructor trait implementation.
@@ -173,9 +198,7 @@ pub fn derive_instructor(input: TokenStream) -> TokenStream {
     // `Vec`, `Box`, and string-keyed maps), then runs this type's own
     // `#[llm(validate = "...")]` function, if any.
     let field_validation = generate_field_validation(&input.data);
-    let container_validate = if let Some(validate_fn) = &container_attrs.validate {
-        let validate_path: syn::Path =
-            syn::parse_str(validate_fn).expect("validate attribute must be a valid function path");
+    let container_validate = if let Some(validate_path) = &container_attrs.validate {
         quote::quote! { #validate_path(self)?; }
     } else {
         quote::quote! {}
@@ -212,7 +235,66 @@ pub fn derive_instructor(input: TokenStream) -> TokenStream {
         #instructor_impl
     };
 
-    combined.into()
+    Ok(combined)
+}
+
+fn validate_derive_input(input: &DeriveInput) -> syn::Result<()> {
+    let mut errors = None;
+
+    if let Err(error) = extract_container_attributes(&input.attrs) {
+        combine_error(&mut errors, error);
+    }
+
+    match &input.data {
+        Data::Struct(data) => {
+            if !matches!(data.fields, Fields::Named(_)) {
+                let span = match &data.fields {
+                    Fields::Unit => input.ident.span(),
+                    fields => fields.span(),
+                };
+                combine_error(
+                    &mut errors,
+                    syn::Error::new(span, "Instructor requires a struct with named fields"),
+                );
+            }
+            for field in &data.fields {
+                if let Err(error) = parsers::field_parser::parse_field_attributes(field) {
+                    combine_error(&mut errors, error);
+                }
+            }
+        }
+        Data::Enum(data) => {
+            for variant in &data.variants {
+                if let Err(error) = parsers::variant_parser::parse_variant_attributes(variant) {
+                    combine_error(&mut errors, error);
+                }
+                for field in &variant.fields {
+                    if let Err(error) = parsers::field_parser::parse_field_attributes(field) {
+                        combine_error(&mut errors, error);
+                    }
+                }
+            }
+        }
+        Data::Union(_) => combine_error(
+            &mut errors,
+            syn::Error::new_spanned(
+                input,
+                "Instructor can only be derived for structs with named fields and enums",
+            ),
+        ),
+    }
+
+    match errors {
+        Some(errors) => Err(errors),
+        None => Ok(()),
+    }
+}
+
+fn combine_error(errors: &mut Option<syn::Error>, error: syn::Error) {
+    match errors {
+        Some(errors) => errors.combine(error),
+        None => *errors = Some(error),
+    }
 }
 
 /// Generate statements that recursively validate every field of a struct or the
@@ -224,27 +306,28 @@ pub fn derive_instructor(input: TokenStream) -> TokenStream {
 /// fields cost nothing while nested `Instructor` values are validated.
 fn generate_field_validation(data: &Data) -> proc_macro2::TokenStream {
     match data {
-        Data::Struct(data_struct) => match &data_struct.fields {
-            Fields::Named(named) => {
-                let probes = named.named.iter().map(|f| {
-                    let ident = f.ident.as_ref().unwrap();
+        Data::Struct(data_struct) => {
+            match &data_struct.fields {
+                Fields::Named(named) => {
+                    let probes = named.named.iter().filter_map(|f| f.ident.as_ref()).map(|ident| {
                     quote::quote! {
                         ::rstructor::model::__private::Probe(&self.#ident).rstructor_probe()?;
                     }
                 });
-                quote::quote! { #(#probes)* }
+                    quote::quote! { #(#probes)* }
+                }
+                Fields::Unnamed(unnamed) => {
+                    let probes = unnamed.unnamed.iter().enumerate().map(|(i, _)| {
+                        let index = syn::Index::from(i);
+                        quote::quote! {
+                            ::rstructor::model::__private::Probe(&self.#index).rstructor_probe()?;
+                        }
+                    });
+                    quote::quote! { #(#probes)* }
+                }
+                Fields::Unit => quote::quote! {},
             }
-            Fields::Unnamed(unnamed) => {
-                let probes = unnamed.unnamed.iter().enumerate().map(|(i, _)| {
-                    let index = syn::Index::from(i);
-                    quote::quote! {
-                        ::rstructor::model::__private::Probe(&self.#index).rstructor_probe()?;
-                    }
-                });
-                quote::quote! { #(#probes)* }
-            }
-            Fields::Unit => quote::quote! {},
-        },
+        }
         Data::Enum(data_enum) => {
             let arms = data_enum.variants.iter().map(|variant| {
                 let vname = &variant.ident;
@@ -253,7 +336,7 @@ fn generate_field_validation(data: &Data) -> proc_macro2::TokenStream {
                         let binds: Vec<_> = named
                             .named
                             .iter()
-                            .map(|f| f.ident.clone().unwrap())
+                            .filter_map(|f| f.ident.clone())
                             .collect();
                         quote::quote! {
                             Self::#vname { #(#binds),* } => {
@@ -284,22 +367,15 @@ fn generate_field_validation(data: &Data) -> proc_macro2::TokenStream {
     }
 }
 
-use quote::ToTokens;
-
-fn extract_container_attributes(attrs: &[syn::Attribute]) -> ContainerAttributes {
+fn extract_container_attributes(attrs: &[syn::Attribute]) -> syn::Result<ContainerAttributes> {
     let mut description = None;
     let mut title = None;
     let mut examples = Vec::new();
-    let mut serde_rename_all = None;
     let mut validate = None;
-    let mut serde_tag = None;
-    let mut serde_content = None;
-    let mut serde_untagged = false;
+    let mut errors = None;
 
-    // First, check for llm-specific attributes
-    for attr in attrs {
-        if attr.path().is_ident("llm") {
-            let _ = attr.parse_nested_meta(|meta| {
+    for attr in attrs.iter().filter(|attr| attr.path().is_ident("llm")) {
+        if let Err(error) = attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("description") {
                     let value = meta.value()?;
                     let content: syn::LitStr = value.parse()?;
@@ -311,71 +387,41 @@ fn extract_container_attributes(attrs: &[syn::Attribute]) -> ContainerAttributes
                 } else if meta.path.is_ident("validate") {
                     let value = meta.value()?;
                     let content: syn::LitStr = value.parse()?;
-                    validate = Some(content.value());
+                    validate = Some(content.parse::<syn::Path>().map_err(|error| {
+                        syn::Error::new(
+                            content.span(),
+                            format!("invalid validation function path: {error}"),
+                        )
+                    })?);
                 } else if meta.path.is_ident("examples") {
-                    // Handle array syntax like examples = ["one", "two"]
-                    let value = meta.value()?;
-
-                    // Try to parse as array expression
-                    if let Ok(syn::Expr::Array(array)) = value.parse::<syn::Expr>() {
-                        // For each element in the array, convert to TokenStream
-                        for elem in array.elems.iter() {
-                            // For string literals, wrap them in serde_json::Value::String constructors
-                            if let syn::Expr::Lit(lit_expr) = elem {
-                                if let syn::Lit::Str(lit_str) = &lit_expr.lit {
-                                    let str_val = lit_str.value();
-                                    let json_str = quote::quote! {
-                                        ::serde_json::Value::String(#str_val.to_string())
-                                    };
-                                    examples.push(json_str);
-                                } else {
-                                    // For other literals, pass them through
-                                    examples.push(elem.to_token_stream());
-                                }
-                            } else {
-                                // For non-literals (like objects), pass them through
-                                examples.push(elem.to_token_stream());
-                            }
-                        }
-                    }
+                    let expressions =
+                        parsers::array_parser::parse_expression_list(&meta, "examples")?;
+                    examples.extend(parsers::array_parser::expression_tokens(&expressions));
+                } else {
+                    return Err(meta.error(
+                        "unsupported container `llm` attribute; expected one of: `description`, `title`, `examples`, `validate`",
+                    ));
                 }
                 Ok(())
-            });
+            })
+        {
+            combine_error(&mut errors, error);
         }
     }
 
-    // Then, check for serde attributes
-    for attr in attrs {
-        if attr.path().is_ident("serde") {
-            let _ = attr.parse_nested_meta(|meta| {
-                if meta.path.is_ident("rename_all") {
-                    let value = meta.value()?;
-                    let content: syn::LitStr = value.parse()?;
-                    serde_rename_all = Some(content.value());
-                } else if meta.path.is_ident("tag") {
-                    let value = meta.value()?;
-                    let content: syn::LitStr = value.parse()?;
-                    serde_tag = Some(content.value());
-                } else if meta.path.is_ident("content") {
-                    let value = meta.value()?;
-                    let content: syn::LitStr = value.parse()?;
-                    serde_content = Some(content.value());
-                } else if meta.path.is_ident("untagged") {
-                    serde_untagged = true;
-                }
-                Ok(())
-            });
-        }
+    if let Some(errors) = errors {
+        return Err(errors);
     }
 
-    ContainerAttributes::builder()
+    let serde = parsers::serde_parser::parse_serde_attributes(attrs);
+    Ok(ContainerAttributes::builder()
         .description(description)
         .title(title)
         .examples(examples)
-        .serde_rename_all(serde_rename_all)
+        .serde_rename_all(serde.rename_all)
         .validate(validate)
-        .serde_tag(serde_tag)
-        .serde_content(serde_content)
-        .serde_untagged(serde_untagged)
-        .build()
+        .serde_tag(serde.tag)
+        .serde_content(serde.content)
+        .serde_untagged(serde.untagged)
+        .build())
 }

--- a/rstructor_derive/src/parsers/array_parser.rs
+++ b/rstructor_derive/src/parsers/array_parser.rs
@@ -1,99 +1,104 @@
 use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
-use syn::{Expr, ExprArray, Lit, Token, bracketed, parse::Parse};
+use syn::meta::ParseNestedMeta;
+use syn::punctuated::Punctuated;
+use syn::{Expr, ExprArray, Lit, Token, parenthesized};
 
-/// Utility struct to parse array literal expressions
-/// Handles array literals like [1, 2, 3] or ["a", "b", "c"]
-pub struct ArrayAttr {
-    pub expr_array: ExprArray,
-}
-
-impl Parse for ArrayAttr {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        let content;
-        bracketed!(content in input);
-        let mut elements = Vec::new();
-
-        // Parse comma-separated expressions inside brackets
-        while !content.is_empty() {
-            let elem: Expr = content.parse()?;
-            elements.push(elem);
-
-            if content.is_empty() {
-                break;
-            }
-
-            content.parse::<Token![,]>()?;
-        }
-
-        Ok(ArrayAttr {
-            expr_array: ExprArray {
-                attrs: Vec::new(),
-                bracket_token: syn::token::Bracket::default(),
-                elems: elements.into_iter().collect(),
-            },
-        })
+/// Parse a multi-value attribute in either native supported form:
+/// `examples = [one, two]` or `examples(one, two)`.
+pub fn parse_expression_list(
+    meta: &ParseNestedMeta<'_>,
+    attribute_name: &str,
+) -> syn::Result<Vec<Expr>> {
+    if meta.input.peek(Token![=]) {
+        let value = meta.value()?;
+        let expression: Expr = value.parse()?;
+        let Expr::Array(array) = expression else {
+            return Err(syn::Error::new_spanned(
+                expression,
+                format!("`{attribute_name}` must be an array expression"),
+            ));
+        };
+        return Ok(array.elems.into_iter().collect());
     }
+
+    if meta.input.peek(syn::token::Paren) {
+        let content;
+        parenthesized!(content in meta.input);
+        return Ok(Punctuated::<Expr, Token![,]>::parse_terminated(&content)?
+            .into_iter()
+            .collect());
+    }
+
+    Err(meta.error(format!("`{attribute_name}` must use `= [...]` or `(...)`")))
 }
 
-/// Parse an array literal from an attribute value
-/// Returns a vector of TokenStreams representing JSON values for each array element
-pub fn parse_array_literal(value: &syn::parse::ParseBuffer) -> Option<Vec<TokenStream>> {
-    // Try to parse as a bracketed array
-    if let Ok(array_attr) = value.parse::<ArrayAttr>() {
-        // Process each element of the array
-        let mut tokens = Vec::new();
+/// Convert an already-parsed Rust array expression into generated
+/// `serde_json::Value` expressions.
+pub fn array_expression_tokens(array: &ExprArray) -> Vec<TokenStream> {
+    expression_tokens(array.elems.iter())
+}
 
-        for elem in &array_attr.expr_array.elems {
-            match elem {
-                Expr::Lit(lit) => {
-                    match &lit.lit {
-                        Lit::Str(lit_str) => {
-                            let s = lit_str.value();
-                            tokens.push(quote! {
-                                ::serde_json::Value::String(#s.to_string())
-                            });
-                        }
-                        Lit::Int(lit_int) => {
-                            tokens.push(quote! {
-                                ::serde_json::Value::Number(::serde_json::Number::from(#lit_int))
-                            });
-                        }
-                        Lit::Float(lit_float) => {
-                            let s = lit_float.to_string();
-                            tokens.push(quote! {
-                                ::serde_json::json!(#s.parse::<f64>().unwrap())
-                            });
-                        }
-                        Lit::Bool(lit_bool) => {
-                            let b = lit_bool.value;
-                            tokens.push(quote! {
-                                ::serde_json::Value::Bool(#b)
-                            });
-                        }
-                        _ => {
-                            // For other literals, convert to string
-                            let elem_tokens = elem.to_token_stream();
-                            tokens.push(quote! {
-                                ::serde_json::Value::String(#elem_tokens.to_string())
-                            });
-                        }
-                    }
-                }
-                _ => {
-                    // For non-literals, convert to string
-                    let elem_tokens = elem.to_token_stream();
+/// Convert parsed Rust expressions into generated `serde_json::Value`
+/// expressions.
+pub fn expression_tokens<'a>(expressions: impl IntoIterator<Item = &'a Expr>) -> Vec<TokenStream> {
+    let mut tokens = Vec::new();
+
+    for elem in expressions {
+        match elem {
+            Expr::Macro(expr_macro)
+                if expr_macro
+                    .mac
+                    .path
+                    .segments
+                    .last()
+                    .is_some_and(|segment| segment.ident == "json") =>
+            {
+                let elem_tokens = elem.to_token_stream();
+                tokens.push(quote! {
+                    #elem_tokens
+                });
+            }
+            Expr::Lit(lit) => match &lit.lit {
+                Lit::Str(lit_str) => {
+                    let s = lit_str.value();
                     tokens.push(quote! {
-                        ::serde_json::Value::String(format!("{}", #elem_tokens))
+                        ::serde_json::Value::String(#s.to_string())
                     });
                 }
+                Lit::Int(lit_int) => {
+                    tokens.push(quote! {
+                        ::serde_json::Value::Number(::serde_json::Number::from(#lit_int))
+                    });
+                }
+                Lit::Float(lit_float) => {
+                    tokens.push(quote! {
+                        ::serde_json::json!(#lit_float)
+                    });
+                }
+                Lit::Bool(lit_bool) => {
+                    let b = lit_bool.value;
+                    tokens.push(quote! {
+                        ::serde_json::Value::Bool(#b)
+                    });
+                }
+                _ => {
+                    let elem_tokens = elem.to_token_stream();
+                    tokens.push(quote! {
+                        ::serde_json::Value::String(#elem_tokens.to_string())
+                    });
+                }
+            },
+            _ => {
+                let elem_tokens = elem.to_token_stream();
+                tokens.push(quote! {
+                    ::serde_json::Value::String(format!("{}", #elem_tokens))
+                });
             }
         }
-
-        Some(tokens)
-    } else {
-        None
     }
+
+    tokens
 }
 
 #[cfg(test)]
@@ -102,20 +107,11 @@ mod tests {
     use quote::quote;
     use syn::parse_str;
 
-    // Test the ArrayAttr structure directly
     #[test]
-    fn test_array_attr_parse() {
-        // Create a string array
+    fn test_array_expression_tokens() {
         let input = "[\"apple\", \"banana\", \"cherry\"]";
         let array_expr: syn::ExprArray = parse_str(input).unwrap();
-
-        // Create an ArrayAttr
-        let array_attr = ArrayAttr {
-            expr_array: array_expr,
-        };
-
-        // Check the array elements
-        assert_eq!(array_attr.expr_array.elems.len(), 3);
+        assert_eq!(array_expression_tokens(&array_expr).len(), 3);
     }
 
     #[test]
@@ -152,5 +148,36 @@ mod tests {
 
         // The tokenized string should include quotes
         assert!(token_string.contains("apple"));
+    }
+
+    #[test]
+    fn preserves_json_macro_array_elements_as_values() {
+        let array_expr: syn::ExprArray =
+            parse_str(r#"[::serde_json::json!({"symbol": "AAPL", "weight": 0.5})]"#).unwrap();
+
+        let tokens = array_expression_tokens(&array_expr);
+        assert_eq!(tokens.len(), 1);
+
+        let token_string = tokens[0].to_string();
+        assert!(token_string.contains("serde_json"));
+        assert!(token_string.contains("json"));
+        assert!(!token_string.contains("Value :: String"));
+    }
+
+    #[test]
+    fn parses_both_multi_value_attribute_forms() {
+        let array_form: syn::Attribute = syn::parse_quote!(#[llm(examples = ["SPY", "QQQ"])]);
+        let parenthesized_form: syn::Attribute = syn::parse_quote!(#[llm(examples("SPY", "QQQ"))]);
+
+        for attribute in [array_form, parenthesized_form] {
+            let mut values = None;
+            attribute
+                .parse_nested_meta(|meta| {
+                    values = Some(parse_expression_list(&meta, "examples")?);
+                    Ok(())
+                })
+                .unwrap();
+            assert_eq!(values.unwrap().len(), 2);
+        }
     }
 }

--- a/rstructor_derive/src/parsers/field_parser.rs
+++ b/rstructor_derive/src/parsers/field_parser.rs
@@ -1,277 +1,222 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::Field;
+use syn::{Expr, ExprLit, Field, Lit};
 
-use crate::parsers::array_parser::parse_array_literal;
+use crate::parsers::array_parser::{
+    array_expression_tokens, expression_tokens, parse_expression_list,
+};
+use crate::parsers::serde_parser::parse_serde_attributes;
 use crate::type_utils::{TypeCategory, get_option_inner_type, get_type_category, is_option_type};
 
-/// Represents parsed field attributes
+/// Represents parsed field attributes.
 pub struct FieldAttributes {
     pub description: Option<String>,
     pub example_value: Option<TokenStream>,
     pub examples_array: Vec<TokenStream>,
-    /// Field rename from #[serde(rename = "...")]
+    /// Field rename from `#[serde(rename = "...")]`.
     pub serde_rename: Option<String>,
 }
 
-/// Parse a single field's llm and serde attributes
-pub fn parse_field_attributes(field: &Field) -> FieldAttributes {
+/// Parse a single field's `llm` attributes and the schema-relevant subset of
+/// Serde metadata.
+pub fn parse_field_attributes(field: &Field) -> syn::Result<FieldAttributes> {
     let mut description = None;
     let mut example_value = None;
     let mut examples_array = Vec::new();
-    let mut serde_rename = None;
 
-    // Get the base type (unwrapping Option if present)
-    let is_optional = is_option_type(&field.ty);
-    let base_type = if is_optional {
+    let base_type = if is_option_type(&field.ty) {
         get_option_inner_type(&field.ty)
     } else {
         &field.ty
     };
+    let category = get_type_category(base_type);
 
-    // Extract attributes
-    for attr in &field.attrs {
-        // Parse serde attributes for rename
-        if attr.path().is_ident("serde") {
-            let _ = attr.parse_nested_meta(|meta| {
-                if meta.path.is_ident("rename") {
-                    let value = meta.value()?;
-                    let content: syn::LitStr = value.parse()?;
-                    serde_rename = Some(content.value());
-                }
-                Ok(())
-            });
-        }
-
-        if attr.path().is_ident("llm") {
-            // Parse attribute arguments
-            let _result = attr.parse_nested_meta(|meta| {
-                if meta.path.is_ident("description") {
-                    let value = meta.value()?;
-                    let content: syn::LitStr = value.parse()?;
-                    description = Some(content.value());
-                } else if meta.path.is_ident("example") {
-                    let value = meta.value()?;
-
-                    // First, try to parse as an array literal for array types
-                    if let TypeCategory::Array = get_type_category(base_type) {
-                        // Try to parse as an array literal
-                        if let Some(array_tokens) = parse_array_literal(value) {
-                            example_value = Some(quote! {
-                                ::serde_json::Value::Array(vec![#(#array_tokens),*])
-                            });
-                            return Ok(());
-                        }
-                    }
-
-                    // If not an array literal or not an array type, parse based on field type
-                    match get_type_category(base_type) {
-                        TypeCategory::String => {
-                            let content: syn::LitStr = value.parse()?;
-                            example_value = Some(quote! {
-                                ::serde_json::Value::String(#content.to_string())
-                            });
-                        },
-                        TypeCategory::Integer => {
-                            if let Ok(content) = value.parse::<syn::LitInt>() {
-                                example_value = Some(quote! {
-                                    ::serde_json::Value::Number(::serde_json::Number::from(#content))
-                                });
-                            } else if let Ok(content) = value.parse::<syn::LitStr>() {
-                                // Allow string for integer too
-                                let int_str = content.value();
-                                example_value = Some(quote! {
-                                    match #int_str.parse::<i64>() {
-                                        Ok(num) => ::serde_json::Value::Number(::serde_json::Number::from(num)),
-                                        Err(_) => ::serde_json::Value::String(#int_str.to_string())
-                                    }
-                                });
-                            }
-                        },
-                        TypeCategory::Float => {
-                            if let Ok(content) = value.parse::<syn::LitFloat>() {
-                                let float_str = content.to_string();
-                                example_value = Some(quote! {
-                                    match #float_str.parse::<f64>() {
-                                        Ok(num) => ::serde_json::json!(num),
-                                        Err(_) => ::serde_json::Value::String(#float_str.to_string())
-                                    }
-                                });
-                            } else if let Ok(content) = value.parse::<syn::LitStr>() {
-                                // Allow string for float too
-                                let float_str = content.value();
-                                example_value = Some(quote! {
-                                    match #float_str.parse::<f64>() {
-                                        Ok(num) => ::serde_json::json!(num),
-                                        Err(_) => ::serde_json::Value::String(#float_str.to_string())
-                                    }
-                                });
-                            }
-                        },
-                        TypeCategory::Boolean => {
-                            if let Ok(content) = value.parse::<syn::LitBool>() {
-                                let bool_val = content.value;
-                                example_value = Some(quote! {
-                                    ::serde_json::Value::Bool(#bool_val)
-                                });
-                            } else if let Ok(content) = value.parse::<syn::LitStr>() {
-                                // Allow string for boolean too
-                                let bool_str = content.value();
-                                example_value = Some(quote! {
-                                    match #bool_str.parse::<bool>() {
-                                        Ok(val) => ::serde_json::Value::Bool(val),
-                                        Err(_) => ::serde_json::Value::String(#bool_str.to_string())
-                                    }
-                                });
-                            }
-                        },
-                        TypeCategory::Array => {
-                            // For array types, we need to handle the special array syntax
-                            // Parse the attribute value as a string first
-                            if let Ok(content) = value.parse::<syn::LitStr>() {
-                                let array_str = content.value();
-
-                                // Check if it's a bracketed array like ["a", "b", "c"]
-                                if array_str.starts_with('[') && array_str.ends_with(']') {
-                                    // Parse as JSON array, but convert single quotes to double quotes
-                                    let json_array = array_str.replace('\'', "\"");
-                                    example_value = Some(quote! {
-                                        match ::serde_json::from_str(#json_array) {
-                                            Ok(val) => val,
-                                            Err(_) => ::serde_json::Value::String(#array_str.to_string())
-                                        }
-                                    });
-                                } else {
-                                    // Treat as a single string
-                                    example_value = Some(quote! {
-                                        ::serde_json::Value::Array(vec![::serde_json::Value::String(#array_str.to_string())])
-                                    });
-                                }
-                            }
-                        },
-                        TypeCategory::Object => {
-                            // For object types, parse as JSON string
-                            if let Ok(content) = value.parse::<syn::LitStr>() {
-                                let json_str = content.value();
-                                example_value = Some(quote! {
-                                    match ::serde_json::from_str(#json_str) {
-                                        Ok(val) => val,
-                                        Err(_) => ::serde_json::Value::String(#json_str.to_string())
-                                    }
-                                });
-                            }
-                        }
-                    }
-                } else if meta.path.is_ident("examples") {
-                    // First, try to parse as an array literal
-                    let value = meta.value()?;
-
-                    if let Some(array_tokens) = parse_array_literal(value) {
-                        // Use the parsed array tokens directly
-                        examples_array = array_tokens;
-                        return Ok(());
-                    }
-
-                    // If not an array literal, handle examples based on type
-                    match get_type_category(base_type) {
-                        TypeCategory::String => {
-                            // Parse array of string literals for string types
-                            meta.parse_nested_meta(|nested_meta| {
-                                if let Ok(lit_str) = nested_meta.value()?.parse::<syn::LitStr>() {
-                                    let value = lit_str.value();
-                                    examples_array.push(quote! {
-                                        ::serde_json::Value::String(#value.to_string())
-                                    });
-                                }
-                                Ok(())
-                            })?;
-                        },
-                        TypeCategory::Integer => {
-                            // Parse array of integer literals
-                            meta.parse_nested_meta(|nested_meta| {
-                                if let Ok(lit_int) = nested_meta.value()?.parse::<syn::LitInt>() {
-                                    examples_array.push(quote! {
-                                        ::serde_json::Value::Number(::serde_json::Number::from(#lit_int))
-                                    });
-                                } else if let Ok(lit_str) = nested_meta.value()?.parse::<syn::LitStr>() {
-                                    let value = lit_str.value();
-                                    examples_array.push(quote! {
-                                        match #value.parse::<i64>() {
-                                            Ok(num) => ::serde_json::Value::Number(::serde_json::Number::from(num)),
-                                            Err(_) => ::serde_json::Value::String(#value.to_string())
-                                        }
-                                    });
-                                }
-                                Ok(())
-                            })?;
-                        },
-                        TypeCategory::Float => {
-                            // Parse array of float literals
-                            meta.parse_nested_meta(|nested_meta| {
-                                if let Ok(lit_float) = nested_meta.value()?.parse::<syn::LitFloat>() {
-                                    let value = lit_float.to_string();
-                                    examples_array.push(quote! {
-                                        match #value.parse::<f64>() {
-                                            Ok(num) => ::serde_json::json!(num),
-                                            Err(_) => ::serde_json::Value::String(#value.to_string())
-                                        }
-                                    });
-                                } else if let Ok(lit_str) = nested_meta.value()?.parse::<syn::LitStr>() {
-                                    let value = lit_str.value();
-                                    examples_array.push(quote! {
-                                        match #value.parse::<f64>() {
-                                            Ok(num) => ::serde_json::json!(num),
-                                            Err(_) => ::serde_json::Value::String(#value.to_string())
-                                        }
-                                    });
-                                }
-                                Ok(())
-                            })?;
-                        },
-                        TypeCategory::Boolean => {
-                            // Parse array of boolean literals
-                            meta.parse_nested_meta(|nested_meta| {
-                                if let Ok(lit_bool) = nested_meta.value()?.parse::<syn::LitBool>() {
-                                    let value = lit_bool.value;
-                                    examples_array.push(quote! {
-                                        ::serde_json::Value::Bool(#value)
-                                    });
-                                } else if let Ok(lit_str) = nested_meta.value()?.parse::<syn::LitStr>() {
-                                    let value = lit_str.value();
-                                    examples_array.push(quote! {
-                                        match #value.parse::<bool>() {
-                                            Ok(val) => ::serde_json::Value::Bool(val),
-                                            Err(_) => ::serde_json::Value::String(#value.to_string())
-                                        }
-                                    });
-                                }
-                                Ok(())
-                            })?;
-                        },
-                        TypeCategory::Array | TypeCategory::Object => {
-                            // For arrays and objects, accept a JSON string
-                            let value = meta.value()?;
-                            let content: syn::LitStr = value.parse()?;
-                            let json_str = content.value();
-
-                            examples_array.push(quote! {
-                                match ::serde_json::from_str::<::serde_json::Value>(#json_str) {
-                                    Ok(val) => val,
-                                    Err(_) => ::serde_json::Value::String(#json_str.to_string())
-                                }
-                            });
-                        }
-                    }
-                }
-                Ok(())
-            });
-        }
+    for attr in field
+        .attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("llm"))
+    {
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("description") {
+                let value = meta.value()?;
+                let content: syn::LitStr = value.parse()?;
+                description = Some(content.value());
+            } else if meta.path.is_ident("example") {
+                let value = meta.value()?;
+                let expression: Expr = value.parse()?;
+                example_value = Some(example_tokens(expression, category)?);
+            } else if meta.path.is_ident("examples") {
+                let expressions = parse_expression_list(&meta, "examples")?;
+                examples_array = expression_tokens(&expressions);
+            } else {
+                return Err(meta.error(
+                    "unsupported field `llm` attribute; expected one of: `description`, `example`, `examples`",
+                ));
+            }
+            Ok(())
+        })?;
     }
 
-    FieldAttributes {
+    Ok(FieldAttributes {
         description,
         example_value,
         examples_array,
-        serde_rename,
+        serde_rename: parse_serde_attributes(&field.attrs).rename,
+    })
+}
+
+fn example_tokens(expression: Expr, category: TypeCategory) -> syn::Result<TokenStream> {
+    match category {
+        TypeCategory::String => {
+            let value = string_literal(expression, "a string literal")?;
+            Ok(quote! {
+                ::serde_json::Value::String(#value.to_string())
+            })
+        }
+        TypeCategory::Integer => match expression {
+            Expr::Lit(ExprLit {
+                lit: Lit::Int(value),
+                ..
+            }) => Ok(quote! {
+                ::serde_json::Value::Number(::serde_json::Number::from(#value))
+            }),
+            expression if is_negative_integer(&expression) => Ok(quote! {
+                ::serde_json::Value::Number(::serde_json::Number::from(#expression))
+            }),
+            expression => Err(expected_example(expression, "an integer literal")),
+        },
+        TypeCategory::Float => match expression {
+            Expr::Lit(ExprLit {
+                lit: Lit::Float(value),
+                ..
+            }) => Ok(quote! {
+                ::serde_json::json!(#value)
+            }),
+            Expr::Lit(ExprLit {
+                lit: Lit::Int(value),
+                ..
+            }) => Ok(quote! {
+                ::serde_json::json!(#value)
+            }),
+            expression if is_negative_number(&expression) => Ok(quote! {
+                ::serde_json::json!(#expression)
+            }),
+            expression => Err(expected_example(expression, "a numeric literal")),
+        },
+        TypeCategory::Boolean => match expression {
+            Expr::Lit(ExprLit {
+                lit: Lit::Bool(value),
+                ..
+            }) => {
+                let value = value.value;
+                Ok(quote! {
+                    ::serde_json::Value::Bool(#value)
+                })
+            }
+            expression => Err(expected_example(expression, "a boolean literal")),
+        },
+        TypeCategory::Array => match expression {
+            Expr::Array(array) => {
+                let values = array_expression_tokens(&array);
+                Ok(quote! {
+                    ::serde_json::Value::Array(vec![#(#values),*])
+                })
+            }
+            Expr::Lit(ExprLit {
+                lit: Lit::Str(value),
+                ..
+            }) => {
+                let value = value.value();
+                if value.starts_with('[') && value.ends_with(']') {
+                    let json = value.replace('\'', "\"");
+                    Ok(quote! {
+                        match ::serde_json::from_str(#json) {
+                            Ok(value) => value,
+                            Err(_) => ::serde_json::Value::String(#value.to_string()),
+                        }
+                    })
+                } else {
+                    Ok(quote! {
+                        ::serde_json::Value::Array(vec![
+                            ::serde_json::Value::String(#value.to_string())
+                        ])
+                    })
+                }
+            }
+            expression => Err(expected_example(
+                expression,
+                "an array expression or string literal",
+            )),
+        },
+        TypeCategory::Object => match expression {
+            Expr::Macro(expression)
+                if expression
+                    .mac
+                    .path
+                    .segments
+                    .last()
+                    .is_some_and(|segment| segment.ident == "json") =>
+            {
+                Ok(quote! { #expression })
+            }
+            expression => {
+                let value = string_literal(expression, "a JSON string literal or `json!` macro")?;
+                Ok(quote! {
+                    match ::serde_json::from_str(#value) {
+                        Ok(value) => value,
+                        Err(_) => ::serde_json::Value::String(#value.to_string()),
+                    }
+                })
+            }
+        },
     }
+}
+
+fn is_negative_integer(expression: &Expr) -> bool {
+    let Expr::Unary(unary) = expression else {
+        return false;
+    };
+    if !matches!(unary.op, syn::UnOp::Neg(_)) {
+        return false;
+    }
+    matches!(
+        unary.expr.as_ref(),
+        Expr::Lit(ExprLit {
+            lit: Lit::Int(_),
+            ..
+        })
+    )
+}
+
+fn is_negative_number(expression: &Expr) -> bool {
+    let Expr::Unary(unary) = expression else {
+        return false;
+    };
+    if !matches!(unary.op, syn::UnOp::Neg(_)) {
+        return false;
+    }
+    matches!(
+        unary.expr.as_ref(),
+        Expr::Lit(ExprLit {
+            lit: Lit::Int(_) | Lit::Float(_),
+            ..
+        })
+    )
+}
+
+fn string_literal(expression: Expr, expected: &str) -> syn::Result<String> {
+    match expression {
+        Expr::Lit(ExprLit {
+            lit: Lit::Str(value),
+            ..
+        }) => Ok(value.value()),
+        expression => Err(expected_example(expression, expected)),
+    }
+}
+
+fn expected_example(expression: Expr, expected: &str) -> syn::Error {
+    syn::Error::new_spanned(
+        expression,
+        format!("invalid `example` value: expected {expected}"),
+    )
 }

--- a/rstructor_derive/src/parsers/mod.rs
+++ b/rstructor_derive/src/parsers/mod.rs
@@ -1,3 +1,4 @@
 pub mod array_parser;
 pub mod field_parser;
+pub mod serde_parser;
 pub mod variant_parser;

--- a/rstructor_derive/src/parsers/serde_parser.rs
+++ b/rstructor_derive/src/parsers/serde_parser.rs
@@ -1,0 +1,94 @@
+use syn::punctuated::Punctuated;
+use syn::{Attribute, Expr, Lit, Meta, Token};
+
+/// The subset of Serde metadata that currently affects generated schemas.
+///
+/// Parsing is deliberately permissive: Serde owns this namespace, so
+/// `#[derive(Instructor)]` must ignore metadata it does not understand instead
+/// of rejecting valid Serde options such as `default`, `flatten`, or `with`.
+#[derive(Default)]
+pub struct SerdeAttributes {
+    pub rename: Option<String>,
+    pub rename_all: Option<String>,
+    pub tag: Option<String>,
+    pub content: Option<String>,
+    pub untagged: bool,
+}
+
+pub fn parse_serde_attributes(attrs: &[Attribute]) -> SerdeAttributes {
+    let mut parsed = SerdeAttributes::default();
+
+    for attr in attrs.iter().filter(|attr| attr.path().is_ident("serde")) {
+        let Ok(items) = attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+        else {
+            // Serde's own derive reports malformed Serde metadata. Ignoring it
+            // here prevents this macro from claiming ownership of that syntax.
+            continue;
+        };
+
+        for item in items {
+            match item {
+                Meta::NameValue(meta) if meta.path.is_ident("rename") => {
+                    parsed.rename = string_value(&meta.value);
+                }
+                Meta::NameValue(meta) if meta.path.is_ident("rename_all") => {
+                    parsed.rename_all = string_value(&meta.value);
+                }
+                Meta::NameValue(meta) if meta.path.is_ident("tag") => {
+                    parsed.tag = string_value(&meta.value);
+                }
+                Meta::NameValue(meta) if meta.path.is_ident("content") => {
+                    parsed.content = string_value(&meta.value);
+                }
+                Meta::Path(path) if path.is_ident("untagged") => {
+                    parsed.untagged = true;
+                }
+                _ => {
+                    // All other Serde metadata is intentionally left to Serde.
+                }
+            }
+        }
+    }
+
+    parsed
+}
+
+fn string_value(value: &Expr) -> Option<String> {
+    let Expr::Lit(value) = value else {
+        return None;
+    };
+    let Lit::Str(value) = &value.lit else {
+        return None;
+    };
+    Some(value.value())
+}
+
+#[cfg(test)]
+mod tests {
+    use syn::parse_quote;
+
+    use super::parse_serde_attributes;
+
+    #[test]
+    fn extracts_supported_values_and_ignores_other_valid_serde_metadata() {
+        let input: syn::DeriveInput = parse_quote! {
+            #[serde(
+                rename = "renamed",
+                rename_all = "camelCase",
+                tag = "kind",
+                content = "payload",
+                untagged,
+                default,
+                alias = "legacy"
+            )]
+            struct Example;
+        };
+
+        let attrs = parse_serde_attributes(&input.attrs);
+        assert_eq!(attrs.rename.as_deref(), Some("renamed"));
+        assert_eq!(attrs.rename_all.as_deref(), Some("camelCase"));
+        assert_eq!(attrs.tag.as_deref(), Some("kind"));
+        assert_eq!(attrs.content.as_deref(), Some("payload"));
+        assert!(attrs.untagged);
+    }
+}

--- a/rstructor_derive/src/parsers/variant_parser.rs
+++ b/rstructor_derive/src/parsers/variant_parser.rs
@@ -1,5 +1,7 @@
 use syn::Variant;
 
+use crate::parsers::serde_parser::parse_serde_attributes;
+
 /// Represents parsed variant attributes
 pub struct VariantAttributes {
     pub description: Option<String>,
@@ -8,39 +10,30 @@ pub struct VariantAttributes {
 }
 
 /// Parse a single enum variant's llm and serde attributes
-pub fn parse_variant_attributes(variant: &Variant) -> VariantAttributes {
+pub fn parse_variant_attributes(variant: &Variant) -> syn::Result<VariantAttributes> {
     let mut description = None;
-    let mut serde_rename = None;
 
-    // Extract attributes
-    for attr in &variant.attrs {
-        // Parse serde attributes for rename
-        if attr.path().is_ident("serde") {
-            let _ = attr.parse_nested_meta(|meta| {
-                if meta.path.is_ident("rename") {
-                    let value = meta.value()?;
-                    let content: syn::LitStr = value.parse()?;
-                    serde_rename = Some(content.value());
-                }
-                Ok(())
-            });
-        }
-
-        if attr.path().is_ident("llm") {
-            // Parse attribute arguments
-            let _result = attr.parse_nested_meta(|meta| {
-                if meta.path.is_ident("description") {
-                    let value = meta.value()?;
-                    let content: syn::LitStr = value.parse()?;
-                    description = Some(content.value());
-                }
-                Ok(())
-            });
-        }
+    for attr in variant
+        .attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("llm"))
+    {
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("description") {
+                let value = meta.value()?;
+                let content: syn::LitStr = value.parse()?;
+                description = Some(content.value());
+            } else {
+                return Err(
+                    meta.error("unsupported variant `llm` attribute; expected `description`")
+                );
+            }
+            Ok(())
+        })?;
     }
 
-    VariantAttributes {
+    Ok(VariantAttributes {
         description,
-        serde_rename,
-    }
+        serde_rename: parse_serde_attributes(&variant.attrs).rename,
+    })
 }

--- a/rstructor_derive/tests/diagnostic_schema_stability_tests.rs
+++ b/rstructor_derive/tests/diagnostic_schema_stability_tests.rs
@@ -1,0 +1,72 @@
+use rstructor::{Instructor, SchemaType};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(Instructor, Serialize, Deserialize)]
+#[llm(description = "A compact risk snapshot", title = "RiskSnapshot")]
+#[serde(rename_all = "camelCase")]
+struct RiskSnapshot {
+    #[llm(description = "Gross market value", example = 1250000.0)]
+    gross_value: f64,
+    #[llm(description = "Optional desk note")]
+    desk_note: Option<String>,
+}
+
+#[derive(Instructor, Serialize, Deserialize)]
+struct AllocationLeg {
+    symbol: String,
+    weight: f64,
+}
+
+#[derive(Instructor, Serialize, Deserialize)]
+struct AllocationExamples {
+    #[llm(example = ::serde_json::json!({"symbol": "AAPL", "weight": 0.6}))]
+    primary: AllocationLeg,
+
+    #[llm(example = [
+        ::serde_json::json!({"symbol": "AAPL", "weight": 0.6}),
+        ::serde_json::json!({"symbol": "MSFT", "weight": 0.4})
+    ])]
+    legs: Vec<AllocationLeg>,
+}
+
+#[test]
+fn valid_attributes_keep_the_existing_schema_shape() {
+    assert_eq!(
+        RiskSnapshot::schema().to_json(),
+        json!({
+            "type": "object",
+            "title": "RiskSnapshot",
+            "description": "A compact risk snapshot",
+            "properties": {
+                "grossValue": {
+                    "type": "number",
+                    "description": "Gross market value",
+                    "example": 1250000.0
+                },
+                "deskNote": {
+                    "type": "string",
+                    "description": "Optional desk note"
+                }
+            },
+            "required": ["grossValue"]
+        })
+    );
+}
+
+#[test]
+fn native_object_examples_remain_json_values() {
+    let schema = AllocationExamples::schema().to_json();
+
+    assert_eq!(
+        schema["properties"]["primary"]["example"],
+        json!({"symbol": "AAPL", "weight": 0.6})
+    );
+    assert_eq!(
+        schema["properties"]["legs"]["example"],
+        json!([
+            {"symbol": "AAPL", "weight": 0.6},
+            {"symbol": "MSFT", "weight": 0.4}
+        ])
+    );
+}

--- a/rstructor_derive/tests/ui.rs
+++ b/rstructor_derive/tests/ui.rs
@@ -1,0 +1,6 @@
+#[test]
+fn derive_diagnostics_are_spanned_and_stable() {
+    let cases = trybuild::TestCases::new();
+    cases.pass("tests/ui/pass/*.rs");
+    cases.compile_fail("tests/ui/fail/*.rs");
+}

--- a/rstructor_derive/tests/ui/fail/invalid_validation_path.rs
+++ b/rstructor_derive/tests/ui/fail/invalid_validation_path.rs
@@ -1,0 +1,9 @@
+use rstructor::Instructor;
+
+#[derive(Instructor)]
+#[llm(validate = "risk::")]
+struct InvalidValidationPath {
+    value: String,
+}
+
+fn main() {}

--- a/rstructor_derive/tests/ui/fail/invalid_validation_path.stderr
+++ b/rstructor_derive/tests/ui/fail/invalid_validation_path.stderr
@@ -1,0 +1,5 @@
+error: invalid validation function path: unexpected end of input, expected identifier
+ --> tests/ui/fail/invalid_validation_path.rs:4:18
+  |
+4 | #[llm(validate = "risk::")]
+  |                  ^^^^^^^^

--- a/rstructor_derive/tests/ui/fail/malformed_examples.rs
+++ b/rstructor_derive/tests/ui/fail/malformed_examples.rs
@@ -1,0 +1,15 @@
+use rstructor::Instructor;
+
+#[derive(Instructor)]
+#[llm(examples = "not an array")]
+struct InvalidContainerExamples {
+    value: String,
+}
+
+#[derive(Instructor)]
+struct InvalidFieldExamples {
+    #[llm(examples = 42)]
+    value: String,
+}
+
+fn main() {}

--- a/rstructor_derive/tests/ui/fail/malformed_examples.stderr
+++ b/rstructor_derive/tests/ui/fail/malformed_examples.stderr
@@ -1,0 +1,11 @@
+error: `examples` must be an array expression
+ --> tests/ui/fail/malformed_examples.rs:4:18
+  |
+4 | #[llm(examples = "not an array")]
+  |                  ^^^^^^^^^^^^^^
+
+error: `examples` must be an array expression
+  --> tests/ui/fail/malformed_examples.rs:11:22
+   |
+11 |     #[llm(examples = 42)]
+   |                      ^^

--- a/rstructor_derive/tests/ui/fail/malformed_values.rs
+++ b/rstructor_derive/tests/ui/fail/malformed_values.rs
@@ -1,0 +1,25 @@
+use rstructor::Instructor;
+
+#[derive(Instructor)]
+#[llm(description = 42)]
+#[llm(title)]
+struct InvalidContainerValues {
+    value: String,
+}
+
+#[derive(Instructor)]
+struct InvalidFieldExample {
+    #[llm(example = false)]
+    value: i64,
+
+    #[llm(example = "42")]
+    quoted_integer: i64,
+
+    #[llm(example = "3.5")]
+    quoted_float: f64,
+
+    #[llm(example = "true")]
+    quoted_boolean: bool,
+}
+
+fn main() {}

--- a/rstructor_derive/tests/ui/fail/malformed_values.stderr
+++ b/rstructor_derive/tests/ui/fail/malformed_values.stderr
@@ -1,0 +1,35 @@
+error: expected string literal
+ --> tests/ui/fail/malformed_values.rs:4:21
+  |
+4 | #[llm(description = 42)]
+  |                     ^^
+
+error: expected `=`
+ --> tests/ui/fail/malformed_values.rs:5:12
+  |
+5 | #[llm(title)]
+  |            ^
+
+error: invalid `example` value: expected an integer literal
+  --> tests/ui/fail/malformed_values.rs:12:21
+   |
+12 |     #[llm(example = false)]
+   |                     ^^^^^
+
+error: invalid `example` value: expected an integer literal
+  --> tests/ui/fail/malformed_values.rs:15:21
+   |
+15 |     #[llm(example = "42")]
+   |                     ^^^^
+
+error: invalid `example` value: expected a numeric literal
+  --> tests/ui/fail/malformed_values.rs:18:21
+   |
+18 |     #[llm(example = "3.5")]
+   |                     ^^^^^
+
+error: invalid `example` value: expected a boolean literal
+  --> tests/ui/fail/malformed_values.rs:21:21
+   |
+21 |     #[llm(example = "true")]
+   |                     ^^^^^^

--- a/rstructor_derive/tests/ui/fail/unknown_attributes.rs
+++ b/rstructor_derive/tests/ui/fail/unknown_attributes.rs
@@ -1,0 +1,19 @@
+use rstructor::Instructor;
+
+#[derive(Instructor)]
+#[llm(descripton = "misspelled")]
+struct UnknownContainer {
+    #[llm(exampel = 42)]
+    value: i32,
+
+    #[llm(optional)]
+    legacy_optional: Option<String>,
+}
+
+#[derive(Instructor)]
+enum UnknownVariant {
+    #[llm(label = "wrong namespace key")]
+    Active,
+}
+
+fn main() {}

--- a/rstructor_derive/tests/ui/fail/unknown_attributes.stderr
+++ b/rstructor_derive/tests/ui/fail/unknown_attributes.stderr
@@ -1,0 +1,23 @@
+error: unsupported container `llm` attribute; expected one of: `description`, `title`, `examples`, `validate`
+ --> tests/ui/fail/unknown_attributes.rs:4:7
+  |
+4 | #[llm(descripton = "misspelled")]
+  |       ^^^^^^^^^^
+
+error: unsupported field `llm` attribute; expected one of: `description`, `example`, `examples`
+ --> tests/ui/fail/unknown_attributes.rs:6:11
+  |
+6 |     #[llm(exampel = 42)]
+  |           ^^^^^^^
+
+error: unsupported field `llm` attribute; expected one of: `description`, `example`, `examples`
+ --> tests/ui/fail/unknown_attributes.rs:9:11
+  |
+9 |     #[llm(optional)]
+  |           ^^^^^^^^
+
+error: unsupported variant `llm` attribute; expected `description`
+  --> tests/ui/fail/unknown_attributes.rs:15:11
+   |
+15 |     #[llm(label = "wrong namespace key")]
+   |           ^^^^^

--- a/rstructor_derive/tests/ui/fail/unsupported_inputs.rs
+++ b/rstructor_derive/tests/ui/fail/unsupported_inputs.rs
@@ -1,0 +1,15 @@
+use rstructor::Instructor;
+
+#[derive(Instructor)]
+struct TupleStruct(String);
+
+#[derive(Instructor)]
+struct UnitStruct;
+
+#[derive(Instructor)]
+union UnsupportedUnion {
+    integer: i64,
+    float: f64,
+}
+
+fn main() {}

--- a/rstructor_derive/tests/ui/fail/unsupported_inputs.stderr
+++ b/rstructor_derive/tests/ui/fail/unsupported_inputs.stderr
@@ -1,0 +1,20 @@
+error: Instructor requires a struct with named fields
+ --> tests/ui/fail/unsupported_inputs.rs:4:19
+  |
+4 | struct TupleStruct(String);
+  |                   ^^^^^^^^
+
+error: Instructor requires a struct with named fields
+ --> tests/ui/fail/unsupported_inputs.rs:7:8
+  |
+7 | struct UnitStruct;
+  |        ^^^^^^^^^^
+
+error: Instructor can only be derived for structs with named fields and enums
+  --> tests/ui/fail/unsupported_inputs.rs:10:1
+   |
+10 | / union UnsupportedUnion {
+11 | |     integer: i64,
+12 | |     float: f64,
+13 | | }
+   | |_^

--- a/rstructor_derive/tests/ui/pass/supported_attributes.rs
+++ b/rstructor_derive/tests/ui/pass/supported_attributes.rs
@@ -1,0 +1,89 @@
+use rstructor::{Instructor, SchemaType};
+use serde::{Deserialize, Serialize};
+
+fn validate_position(position: &Position) -> rstructor::Result<()> {
+    if position.symbol.is_empty() {
+        return Err(rstructor::RStructorError::ValidationError(
+            "symbol must not be empty".into(),
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Instructor, Serialize, Deserialize, Default)]
+struct Metadata {
+    venue: String,
+}
+
+#[derive(Instructor, Serialize, Deserialize)]
+struct Leg {
+    symbol: String,
+    weight: f64,
+}
+
+#[derive(Instructor, Serialize, Deserialize, Default)]
+#[llm(
+    description = "A position from a risk system",
+    title = "RiskPosition",
+    examples = [::serde_json::json!({"symbol": "AAPL", "quantity": 100})],
+    validate = "validate_position"
+)]
+#[serde(default, rename_all = "camelCase")]
+struct Position {
+    #[llm(
+        description = "Exchange-listed symbol",
+        example = "AAPL",
+        examples = ["AAPL", "MSFT"]
+    )]
+    #[serde(alias = "ticker")]
+    symbol: String,
+
+    #[llm(description = "Signed share count", example = -100)]
+    quantity: i64,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    note: Option<String>,
+
+    // Instructor deliberately ignores Serde options it does not own. Their
+    // schema semantics are covered by a separate compatibility project.
+    #[serde(skip)]
+    ignored: String,
+
+    #[serde(flatten)]
+    metadata: Metadata,
+
+    #[llm(
+        description = "Constituent positions",
+        example = [
+            ::serde_json::json!({"symbol": "AAPL", "weight": 0.5}),
+            ::serde_json::json!({"symbol": "MSFT", "weight": 0.5})
+        ]
+    )]
+    legs: Vec<Leg>,
+}
+
+#[derive(Instructor, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "payload")]
+enum Event {
+    #[llm(description = "A fill event")]
+    #[serde(rename = "fill")]
+    Fill {
+        #[llm(description = "Execution price", example = 187.25)]
+        price: f64,
+    },
+    #[serde(rename(serialize = "haltOut", deserialize = "haltIn"))]
+    Halt,
+}
+
+#[derive(Instructor, Serialize, Deserialize)]
+#[llm(examples(::serde_json::json!({"tickers": ["SPY", "QQQ"]})))]
+struct ParenthesizedExamples {
+    #[llm(examples("SPY", "QQQ"))]
+    tickers: Vec<String>,
+}
+
+fn main() {
+    let _ = Position::schema();
+    let _ = Event::schema();
+    let _ = ParenthesizedExamples::schema();
+}

--- a/tests/derive_schema_offline_tests.rs
+++ b/tests/derive_schema_offline_tests.rs
@@ -651,7 +651,7 @@ fn rename_all_matches_serde_serialization() {
 }
 
 // ============================================================================
-// example / examples string-coercion + empty-array edges
+// example / examples typed-value + empty-array edges
 // ============================================================================
 
 // Native-literal examples (the supported, working form): an integer/float/bool
@@ -688,36 +688,11 @@ fn literal_examples_render_as_typed_values() {
     assert_eq!(str_example, &serde_json::Value::String("hello".to_string()));
 }
 
-#[derive(Instructor, Serialize, Deserialize, Debug)]
-struct CoercionHolder {
-    #[llm(description = "an int from a string", example = "42")]
-    int_field: i32,
-    #[llm(description = "a float from a string", example = "3.5")]
-    float_field: f64,
-    #[llm(description = "a bool from a string", example = "true")]
-    bool_field: bool,
-}
-
 // CONTRACT: `#[llm(example = ...)]` takes a NATIVE typed literal matching the
 // field — `example = 42` for an i32, `example = true` for a bool, `example =
 // "text"` for a String (all covered by the test above). A *string-form* example
-// on a numeric/bool field (`example = "42"`) is a type mismatch and is
-// intentionally NOT coerced: no `example` key is emitted, and the field is
-// otherwise unaffected. (Auto-coercing string-form literals to the field type
-// could be a future enhancement; the native typed form is the supported path.)
-#[test]
-fn string_form_example_on_numeric_field_is_omitted() {
-    let schema = CoercionHolder::schema().to_json();
-    assert!(
-        schema["properties"]["int_field"]["example"].is_null(),
-        "string-form example on an i32 should emit no example key"
-    );
-    assert!(schema["properties"]["float_field"]["example"].is_null());
-    assert!(schema["properties"]["bool_field"]["example"].is_null());
-    // The fields themselves are still present and correctly typed.
-    assert_eq!(schema["properties"]["int_field"]["type"], "integer");
-    assert_eq!(schema["properties"]["bool_field"]["type"], "boolean");
-}
+// on a numeric/bool field (`example = "42"`) is a type mismatch. Compile-fail
+// coverage for these cases lives in rstructor_derive/tests/ui/fail.
 
 #[derive(Instructor, Serialize, Deserialize, Debug)]
 struct EmptyArrayExampleHolder {


### PR DESCRIPTION
## Summary

Make `#[derive(Instructor)]` report malformed or unsupported input as normal,
spanned compiler diagnostics instead of silently dropping metadata or panicking
inside the procedural macro.

This intentionally changes only invalid derive input. Valid derives keep their
existing schema and runtime behavior, as asserted by exact schema snapshots.

## User impact

Typos and type mismatches in the owned `llm` namespace are now caught where
they are written:

```rust
#[derive(Instructor, Serialize, Deserialize)]
struct Position {
    // Error: `optional` is not a supported field attribute.
    #[llm(description = "Optional benchmark", optional)]
    benchmark: Option<String>,

    // Error: a numeric field requires a native numeric literal.
    #[llm(example = "0.92")]
    confidence: f32,
}
```

The corrected usage is:

```rust
#[derive(Instructor, Serialize, Deserialize)]
struct Position {
    // Optionality is inferred from Option<T>.
    #[llm(description = "Optional benchmark")]
    benchmark: Option<String>,

    #[llm(example = 0.92)]
    confidence: f32,
}
```

Complex examples use native Rust expressions and remain typed JSON values:

```rust
#[llm(example = [
    ::serde_json::json!({"symbol": "AAPL", "weight": 0.6}),
    ::serde_json::json!({"symbol": "MSFT", "weight": 0.4}),
])]
legs: Vec<AllocationLeg>,
```

Multi-value examples support both native forms:

```rust
#[llm(examples = ["SPY", "QQQ"])]
tickers: Vec<String>,

#[llm(examples("SPY", "QQQ"))]
alternate_tickers: Vec<String>,
```

## Root cause

The derive parsers discarded `syn::Result` values from `parse_nested_meta`.
That made an invalid key or value indistinguishable from an absent attribute.
Several generator paths also used `panic!`, `expect`, or guarded `unwrap`
instead of returning diagnostics.

Serde metadata was parsed through the same pattern even though Serde owns that
namespace, which made it difficult to be strict about `llm` metadata without
accidentally rejecting unrelated valid Serde options.

## Implementation

- Add a single `expand(DeriveInput) -> syn::Result<TokenStream>` boundary and
  turn errors into `compile_error!` tokens at the proc-macro entry point.
- Return `syn::Result` from container, field, variant, struct, and enum parsing
  and generation paths.
- Aggregate independent container, field, and variant errors so one compile
  reports multiple actionable problems.
- Validate the owned `llm` namespace by context:
  - container: `description`, `title`, `examples`, `validate`
  - field: `description`, `example`, `examples`
  - variant: `description`
- Parse validation functions as spanned `syn::Path` values.
- Keep unknown Serde options permissive while extracting only the subset that
  currently affects schemas.
- Support `serde_json::json!` object examples and both array and
  parenthesized multi-value example syntax.
- Replace unsupported tuple/unit struct and union panics with targeted errors.
- Repair shipped examples whose invalid metadata had previously been ignored.
- Document the checked attribute API and `Option<T>` optionality.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features --no-fail-fast`
- `cargo build --workspace --all-features --examples`
- Trybuild pass coverage for every supported `llm` key, representative
  non-schema Serde options, `json!` object arrays, and both multi-value forms.
- Trybuild compile-fail snapshots for unknown keys, malformed values,
  non-array examples, invalid validation paths, tuple/unit structs, and unions.
- Exact runtime schema assertions proving valid attribute output remains stable
  and object examples remain JSON values rather than strings.
