### PR TITLE
[codex] Align schemas with Serde input contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,26 +327,33 @@ enum PaymentMethod {
 }
 ```
 
-### Serde Rename Support
+### Serde Deserialization Support
 
-rstructor respects `#[serde(rename)]` and `#[serde(rename_all)]` attributes:
+rstructor interprets supported Serde metadata from the deserialization side of
+the wire contract. It respects `rename`, `rename_all`, `rename_all_fields`,
+`skip`, and `skip_deserializing`. When Serde has separate directions, the
+deserialize-side name is used:
 
 ```rust
 #[derive(Instructor, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct UserProfile {
-    first_name: String,      // becomes "firstName" in schema
-    last_name: String,       // becomes "lastName" in schema
-    email_address: String,   // becomes "emailAddress" in schema
-}
+#[serde(rename_all(serialize = "snake_case", deserialize = "camelCase"))]
+struct BrokerOrder {
+    // Omitted from the input schema; Serde supplies String::default().
+    #[serde(skip_deserializing)]
+    server_timestamp: String,
 
-#[derive(Instructor, Serialize, Deserialize)]
-struct CommitMessage {
-    #[serde(rename = "type")]  // use "type" as JSON key
-    commit_type: String,
-    description: String,
-}
+    // Included because it is accepted during deserialization.
+    #[serde(skip_serializing)]
+    client_order_id: String,
 
+    #[serde(rename(serialize = "symbol", deserialize = "ticker"))]
+    instrument: String,
+}
+```
+
+For symmetric names, the usual shorthand remains unchanged:
+
+```rust
 #[derive(Instructor, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 enum CommitType {

--- a/examples/serde_rename_example.rs
+++ b/examples/serde_rename_example.rs
@@ -1,7 +1,7 @@
 //! Example demonstrating serde rename attribute support.
 //!
-//! rstructor respects `#[serde(rename)]` and `#[serde(rename_all)]` attributes,
-//! ensuring the generated JSON schema matches serde's serialization behavior.
+//! rstructor follows Serde's deserialization-facing `rename`, `rename_all`,
+//! `rename_all_fields`, `skip`, and `skip_deserializing` behavior.
 
 use rstructor::{Instructor, SchemaType};
 use serde::{Deserialize, Serialize};
@@ -59,6 +59,21 @@ enum StatusCode {
     NotFound,
     InternalError,
     BadRequest,
+}
+
+/// Directional metadata demonstrates that schemas describe accepted input,
+/// rather than serialized output.
+#[derive(Instructor, Serialize, Deserialize, Debug)]
+#[serde(rename_all(serialize = "snake_case", deserialize = "camelCase"))]
+struct BrokerOrder {
+    #[serde(skip_deserializing)]
+    server_timestamp: String,
+
+    #[serde(skip_serializing)]
+    client_order_id: String,
+
+    #[serde(rename(serialize = "symbol", deserialize = "ticker"))]
+    instrument: String,
 }
 
 fn main() {
@@ -125,4 +140,16 @@ fn main() {
         "\nSerialized StatusCode::NotFound: {}",
         serde_json::to_string(&status).unwrap()
     );
+
+    println!("\n=== BrokerOrder (deserialization contract) ===");
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&BrokerOrder::schema().to_json()).unwrap()
+    );
+    let order: BrokerOrder = serde_json::from_value(serde_json::json!({
+        "clientOrderId": "co-123",
+        "ticker": "AAPL"
+    }))
+    .unwrap();
+    println!("Deserialized BrokerOrder: {order:?}");
 }

--- a/rstructor_derive/src/container_attrs.rs
+++ b/rstructor_derive/src/container_attrs.rs
@@ -13,6 +13,9 @@ pub struct ContainerAttributes {
     /// Serde rename_all case style (from serde attribute)
     pub serde_rename_all: Option<String>,
 
+    /// Serde rename_all_fields case style for enum struct-variant fields
+    pub serde_rename_all_fields: Option<String>,
+
     /// Custom validation function path (e.g., "validate_product" or "my_module::validate")
     pub validate: Option<syn::Path>,
 
@@ -33,6 +36,7 @@ pub struct ContainerAttributesBuilder {
     title: Option<String>,
     examples: Vec<proc_macro2::TokenStream>,
     serde_rename_all: Option<String>,
+    serde_rename_all_fields: Option<String>,
     validate: Option<syn::Path>,
     serde_tag: Option<String>,
     serde_content: Option<String>,
@@ -57,6 +61,11 @@ impl ContainerAttributesBuilder {
 
     pub fn serde_rename_all(mut self, rename_all: Option<String>) -> Self {
         self.serde_rename_all = rename_all;
+        self
+    }
+
+    pub fn serde_rename_all_fields(mut self, rename_all_fields: Option<String>) -> Self {
+        self.serde_rename_all_fields = rename_all_fields;
         self
     }
 
@@ -86,6 +95,7 @@ impl ContainerAttributesBuilder {
             title: self.title,
             examples: self.examples,
             serde_rename_all: self.serde_rename_all,
+            serde_rename_all_fields: self.serde_rename_all_fields,
             validate: self.validate,
             serde_tag: self.serde_tag,
             serde_content: self.serde_content,
@@ -108,6 +118,7 @@ impl ContainerAttributes {
             && self.title.is_none()
             && self.examples.is_empty()
             && self.serde_rename_all.is_none()
+            && self.serde_rename_all_fields.is_none()
             && self.validate.is_none()
             && self.serde_tag.is_none()
             && self.serde_content.is_none()

--- a/rstructor_derive/src/generators/enum_schema.rs
+++ b/rstructor_derive/src/generators/enum_schema.rs
@@ -19,8 +19,16 @@ pub fn generate_enum_schema(
     container_attrs: &ContainerAttributes,
     generics: &syn::Generics,
 ) -> syn::Result<TokenStream> {
-    // Check if it's a simple enum (no data)
-    let all_simple = data_enum.variants.iter().all(|v| v.fields.is_empty());
+    // Check whether every deserializable variant has no data. A skipped
+    // data-carrying variant does not affect the accepted wire shape.
+    let mut all_simple = true;
+    for variant in &data_enum.variants {
+        let attrs = parse_variant_attributes(variant)?;
+        if !attrs.serde_skip_deserializing && !variant.fields.is_empty() {
+            all_simple = false;
+            break;
+        }
+    }
     let has_tag = container_attrs.serde_tag.is_some();
 
     if all_simple && !has_tag {
@@ -43,6 +51,33 @@ fn schema_bounded_generics(generics: &syn::Generics) -> syn::Generics {
     )
 }
 
+fn deserialization_name(
+    original: &str,
+    explicit_rename: Option<&str>,
+    rename_all: Option<&str>,
+) -> String {
+    if let Some(rename) = explicit_rename {
+        rename.to_string()
+    } else if let Some(rule) = rename_all {
+        apply_rename_all(original, rule)
+    } else {
+        original.to_string()
+    }
+}
+
+fn deserialization_field_name(
+    original: &str,
+    explicit_rename: Option<&str>,
+    variant_rename_all: Option<&str>,
+    container_rename_all_fields: Option<&str>,
+) -> String {
+    deserialization_name(
+        original,
+        explicit_rename,
+        variant_rename_all.or(container_rename_all_fields),
+    )
+}
+
 /// Generate schema for a simple enum (no associated data)
 fn generate_simple_enum_schema(
     name: &Ident,
@@ -51,22 +86,18 @@ fn generate_simple_enum_schema(
     generics: &syn::Generics,
 ) -> syn::Result<TokenStream> {
     // Generate implementation for simple enum with serde rename support
-    let variant_values: Vec<_> = data_enum
-        .variants
-        .iter()
-        .map(|v| {
-            let attrs = parse_variant_attributes(v)?;
-            let original_name = v.ident.to_string();
-            // Priority: 1) variant #[serde(rename)], 2) container #[serde(rename_all)], 3) original name
-            Ok(if let Some(ref rename) = attrs.serde_rename {
-                rename.clone()
-            } else if let Some(ref rename_all) = container_attrs.serde_rename_all {
-                apply_rename_all(&original_name, rename_all)
-            } else {
-                original_name
-            })
-        })
-        .collect::<syn::Result<_>>()?;
+    let mut variant_values = Vec::new();
+    for variant in &data_enum.variants {
+        let attrs = parse_variant_attributes(variant)?;
+        if attrs.serde_skip_deserializing {
+            continue;
+        }
+        variant_values.push(deserialization_name(
+            &variant.ident.to_string(),
+            attrs.serde_rename.as_deref(),
+            container_attrs.serde_rename_all.as_deref(),
+        ));
+    }
 
     // Handle container attributes
     let mut container_setters = Vec::new();
@@ -112,7 +143,7 @@ fn generate_simple_enum_schema(
         impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
             fn schema() -> ::rstructor::schema::Schema {
                 // Create array of enum values
-                let enum_values = vec![
+                let enum_values: Vec<::serde_json::Value> = vec![
                     #(::serde_json::Value::String(#variant_values.to_string())),*
                 ];
 
@@ -187,16 +218,16 @@ fn generate_externally_tagged_enum_schema(
     for variant in &data_enum.variants {
         // Get description and rename from variant attributes
         let attrs = parse_variant_attributes(variant)?;
+        if attrs.serde_skip_deserializing {
+            continue;
+        }
 
         let original_variant_name = variant.ident.to_string();
-        // Priority: 1) variant #[serde(rename)], 2) container #[serde(rename_all)], 3) original name
-        let variant_name = if let Some(ref rename) = attrs.serde_rename {
-            rename.clone()
-        } else if let Some(ref rename_all) = container_attrs.serde_rename_all {
-            apply_rename_all(&original_variant_name, rename_all)
-        } else {
-            original_variant_name.clone()
-        };
+        let variant_name = deserialization_name(
+            &original_variant_name,
+            attrs.serde_rename.as_deref(),
+            container_attrs.serde_rename_all.as_deref(),
+        );
 
         let description = attrs
             .description
@@ -229,6 +260,18 @@ fn generate_externally_tagged_enum_schema(
                             "expected one field in a single-field enum variant",
                         )
                     })?;
+                    if parse_field_attributes(field)?.serde_skip_deserializing {
+                        let variant_name_str = variant_name.clone();
+                        let description_str = description.clone();
+                        variant_schemas.push(quote! {
+                            ::serde_json::json!({
+                                "type": "string",
+                                "enum": [#variant_name_str],
+                                "description": #description_str
+                            })
+                        });
+                        continue;
+                    }
 
                     // Extract field schema based on its type
                     let field_schema = generate_field_schema(&field.ty, &None);
@@ -260,13 +303,16 @@ fn generate_externally_tagged_enum_schema(
                     let mut field_schemas = Vec::new();
 
                     for field in fields.unnamed.iter() {
+                        if parse_field_attributes(field)?.serde_skip_deserializing {
+                            continue;
+                        }
                         let field_schema = generate_field_schema(&field.ty, &None);
                         field_schemas.push(field_schema);
                     }
 
                     let variant_name_str = variant_name.clone();
                     let description_str = description.clone();
-                    let field_count = fields.unnamed.len();
+                    let field_count = field_schemas.len();
                     variant_schemas.push(quote! {
                         // Tuple variant with multiple fields - { "variant": [values...] }
                         {
@@ -309,13 +355,16 @@ fn generate_externally_tagged_enum_schema(
                     if let Some(field_ident) = &field.ident {
                         let original_field_name = field_ident.to_string();
                         let field_attrs = parse_field_attributes(field)?;
+                        if field_attrs.serde_skip_deserializing {
+                            continue;
+                        }
 
-                        // Apply serde rename if present
-                        let field_name_str = if let Some(ref rename) = field_attrs.serde_rename {
-                            rename.clone()
-                        } else {
-                            original_field_name.clone()
-                        };
+                        let field_name_str = deserialization_field_name(
+                            &original_field_name,
+                            field_attrs.serde_rename.as_deref(),
+                            attrs.serde_rename_all.as_deref(),
+                            container_attrs.serde_rename_all_fields.as_deref(),
+                        );
 
                         let field_desc = field_attrs
                             .description
@@ -738,14 +787,15 @@ fn generate_internally_tagged_enum_schema(
 
     for variant in &data_enum.variants {
         let attrs = parse_variant_attributes(variant)?;
+        if attrs.serde_skip_deserializing {
+            continue;
+        }
         let original_variant_name = variant.ident.to_string();
-        let variant_name = if let Some(ref rename) = attrs.serde_rename {
-            rename.clone()
-        } else if let Some(ref rename_all) = container_attrs.serde_rename_all {
-            apply_rename_all(&original_variant_name, rename_all)
-        } else {
-            original_variant_name.clone()
-        };
+        let variant_name = deserialization_name(
+            &original_variant_name,
+            attrs.serde_rename.as_deref(),
+            container_attrs.serde_rename_all.as_deref(),
+        );
 
         let description = attrs
             .description
@@ -789,12 +839,16 @@ fn generate_internally_tagged_enum_schema(
                     if let Some(field_ident) = &field.ident {
                         let original_field_name = field_ident.to_string();
                         let field_attrs = parse_field_attributes(field)?;
+                        if field_attrs.serde_skip_deserializing {
+                            continue;
+                        }
 
-                        let field_name_str = if let Some(ref rename) = field_attrs.serde_rename {
-                            rename.clone()
-                        } else {
-                            original_field_name.clone()
-                        };
+                        let field_name_str = deserialization_field_name(
+                            &original_field_name,
+                            field_attrs.serde_rename.as_deref(),
+                            attrs.serde_rename_all.as_deref(),
+                            container_attrs.serde_rename_all_fields.as_deref(),
+                        );
 
                         let field_desc = field_attrs
                             .description
@@ -853,15 +907,21 @@ fn generate_internally_tagged_enum_schema(
                 let description_str = description.clone();
                 let tag_name_str = tag_name.to_string();
 
-                if fields.unnamed.len() == 1 {
-                    // Newtype variant (e.g. Present(InnerStruct)):
-                    // serde flattens the inner struct's fields alongside the tag.
+                let deserializable_newtype = if fields.unnamed.len() == 1 {
                     let field = fields.unnamed.first().ok_or_else(|| {
                         syn::Error::new_spanned(
                             fields,
                             "expected one field in a single-field enum variant",
                         )
                     })?;
+                    (!parse_field_attributes(field)?.serde_skip_deserializing).then_some(field)
+                } else {
+                    None
+                };
+
+                if let Some(field) = deserializable_newtype {
+                    // Newtype variant (e.g. Present(InnerStruct)):
+                    // serde flattens the inner struct's fields alongside the tag.
                     let inner_ty = &field.ty;
 
                     // Unwrap Box<T> if present — Box<T> doesn't implement SchemaType
@@ -1001,14 +1061,15 @@ fn generate_adjacently_tagged_enum_schema(
 
     for variant in &data_enum.variants {
         let attrs = parse_variant_attributes(variant)?;
+        if attrs.serde_skip_deserializing {
+            continue;
+        }
         let original_variant_name = variant.ident.to_string();
-        let variant_name = if let Some(ref rename) = attrs.serde_rename {
-            rename.clone()
-        } else if let Some(ref rename_all) = container_attrs.serde_rename_all {
-            apply_rename_all(&original_variant_name, rename_all)
-        } else {
-            original_variant_name.clone()
-        };
+        let variant_name = deserialization_name(
+            &original_variant_name,
+            attrs.serde_rename.as_deref(),
+            container_attrs.serde_rename_all.as_deref(),
+        );
 
         let description = attrs
             .description
@@ -1055,6 +1116,35 @@ fn generate_adjacently_tagged_enum_schema(
                             "expected one field in a single-field enum variant",
                         )
                     })?;
+                    if parse_field_attributes(field)?.serde_skip_deserializing {
+                        variant_schemas.push(quote! {
+                            {
+                                let mut schema_obj = ::serde_json::Map::new();
+                                schema_obj.insert("type".to_string(), ::serde_json::Value::String("object".to_string()));
+
+                                let mut properties = ::serde_json::Map::new();
+                                properties.insert(#tag_name_str.to_string(), ::serde_json::json!({
+                                    "type": "string",
+                                    "enum": [#variant_name_str]
+                                }));
+                                properties.insert(#content_name_str.to_string(), ::serde_json::json!({
+                                    "type": "null"
+                                }));
+                                schema_obj.insert("properties".to_string(), ::serde_json::Value::Object(properties));
+
+                                let required = vec![
+                                    ::serde_json::Value::String(#tag_name_str.to_string()),
+                                    ::serde_json::Value::String(#content_name_str.to_string())
+                                ];
+                                schema_obj.insert("required".to_string(), ::serde_json::Value::Array(required));
+                                schema_obj.insert("description".to_string(), ::serde_json::Value::String(#description_str.to_string()));
+                                schema_obj.insert("additionalProperties".to_string(), ::serde_json::Value::Bool(false));
+
+                                ::serde_json::Value::Object(schema_obj)
+                            }
+                        });
+                        continue;
+                    }
                     let field_schema = generate_field_schema(&field.ty, &None);
 
                     // Create an explicit description for single unnamed field
@@ -1091,10 +1181,13 @@ fn generate_adjacently_tagged_enum_schema(
                     // Multiple fields: {"tag": "Variant", "content": [values...]}
                     let mut field_schemas = Vec::new();
                     for field in fields.unnamed.iter() {
+                        if parse_field_attributes(field)?.serde_skip_deserializing {
+                            continue;
+                        }
                         let field_schema = generate_field_schema(&field.ty, &None);
                         field_schemas.push(field_schema);
                     }
-                    let field_count = fields.unnamed.len();
+                    let field_count = field_schemas.len();
 
                     // Create an explicit description for multiple unnamed fields
                     let explicit_description = format!(
@@ -1153,12 +1246,16 @@ fn generate_adjacently_tagged_enum_schema(
                     if let Some(field_ident) = &field.ident {
                         let original_field_name = field_ident.to_string();
                         let field_attrs = parse_field_attributes(field)?;
+                        if field_attrs.serde_skip_deserializing {
+                            continue;
+                        }
 
-                        let field_name_str = if let Some(ref rename) = field_attrs.serde_rename {
-                            rename.clone()
-                        } else {
-                            original_field_name.clone()
-                        };
+                        let field_name_str = deserialization_field_name(
+                            &original_field_name,
+                            field_attrs.serde_rename.as_deref(),
+                            attrs.serde_rename_all.as_deref(),
+                            container_attrs.serde_rename_all_fields.as_deref(),
+                        );
 
                         field_names.push(field_name_str.clone());
 
@@ -1299,6 +1396,9 @@ fn generate_untagged_enum_schema(
 
     for variant in &data_enum.variants {
         let attrs = parse_variant_attributes(variant)?;
+        if attrs.serde_skip_deserializing {
+            continue;
+        }
         let variant_name = variant.ident.to_string();
         let description = attrs
             .description
@@ -1325,16 +1425,29 @@ fn generate_untagged_enum_schema(
                             "expected one field in a single-field enum variant",
                         )
                     })?;
+                    if parse_field_attributes(field)?.serde_skip_deserializing {
+                        let description_str = description.clone();
+                        variant_schemas.push(quote! {
+                            ::serde_json::json!({
+                                "type": "null",
+                                "description": #description_str
+                            })
+                        });
+                        continue;
+                    }
                     let field_schema = generate_field_schema(&field.ty, &Some(description.clone()));
                     variant_schemas.push(quote! { #field_schema });
                 } else {
                     // Multiple fields - array
                     let mut field_schemas = Vec::new();
                     for field in fields.unnamed.iter() {
+                        if parse_field_attributes(field)?.serde_skip_deserializing {
+                            continue;
+                        }
                         let field_schema = generate_field_schema(&field.ty, &None);
                         field_schemas.push(field_schema);
                     }
-                    let field_count = fields.unnamed.len();
+                    let field_count = field_schemas.len();
                     let description_str = description.clone();
                     variant_schemas.push(quote! {
                         {
@@ -1363,12 +1476,16 @@ fn generate_untagged_enum_schema(
                     if let Some(field_ident) = &field.ident {
                         let original_field_name = field_ident.to_string();
                         let field_attrs = parse_field_attributes(field)?;
+                        if field_attrs.serde_skip_deserializing {
+                            continue;
+                        }
 
-                        let field_name_str = if let Some(ref rename) = field_attrs.serde_rename {
-                            rename.clone()
-                        } else {
-                            original_field_name.clone()
-                        };
+                        let field_name_str = deserialization_field_name(
+                            &original_field_name,
+                            field_attrs.serde_rename.as_deref(),
+                            attrs.serde_rename_all.as_deref(),
+                            container_attrs.serde_rename_all_fields.as_deref(),
+                        );
 
                         let field_desc = field_attrs
                             .description

--- a/rstructor_derive/src/generators/struct_schema.rs
+++ b/rstructor_derive/src/generators/struct_schema.rs
@@ -25,17 +25,15 @@ pub fn generate_struct_schema(
 
     match &data_struct.fields {
         Fields::Named(fields) => {
-            // First pass: check for self-references
-            for field in &fields.named {
-                if is_self_reference(&field.ty, &struct_name_str) {
-                    has_self_reference = true;
-                    break;
-                }
-            }
-
             for field in &fields.named {
                 // Parse field attributes first to check for serde rename
                 let attrs = parse_field_attributes(field)?;
+                if attrs.serde_skip_deserializing {
+                    continue;
+                }
+                if is_self_reference(&field.ty, &struct_name_str) {
+                    has_self_reference = true;
+                }
 
                 let original_field_name = field
                     .ident

--- a/rstructor_derive/src/lib.rs
+++ b/rstructor_derive/src/lib.rs
@@ -155,9 +155,17 @@ use syn::{Data, DeriveInput, Fields, parse_macro_input};
 ///
 /// ### Serde Integration
 ///
-/// - Respects `#[serde(rename_all = "...")]` for transforming property names
-///   - Supported values: "lowercase", "UPPERCASE", "camelCase", "PascalCase", "snake_case"
-///   - Example: With `#[serde(rename_all = "camelCase")]`, a field `user_id` becomes `userId` in the schema
+/// Supported Serde name and skip metadata is interpreted from the
+/// deserialization side of the wire contract:
+///
+/// - Respects `rename`, `rename_all`, and `rename_all_fields`
+/// - Uses `deserialize = "..."` when names differ by direction
+/// - Omits fields and variants marked `skip` or `skip_deserializing`
+/// - Keeps `skip_serializing` fields because they remain valid inputs
+///
+/// Supported case transformations include "lowercase", "UPPERCASE",
+/// "camelCase", "PascalCase", and "snake_case". For example, with
+/// `#[serde(rename_all = "camelCase")]`, `user_id` becomes `userId`.
 #[proc_macro_derive(Instructor, attributes(llm))]
 pub fn derive_instructor(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -419,6 +427,7 @@ fn extract_container_attributes(attrs: &[syn::Attribute]) -> syn::Result<Contain
         .title(title)
         .examples(examples)
         .serde_rename_all(serde.rename_all)
+        .serde_rename_all_fields(serde.rename_all_fields)
         .validate(validate)
         .serde_tag(serde.tag)
         .serde_content(serde.content)

--- a/rstructor_derive/src/parsers/field_parser.rs
+++ b/rstructor_derive/src/parsers/field_parser.rs
@@ -15,6 +15,8 @@ pub struct FieldAttributes {
     pub examples_array: Vec<TokenStream>,
     /// Field rename from `#[serde(rename = "...")]`.
     pub serde_rename: Option<String>,
+    /// Whether Serde excludes this field from deserialization.
+    pub serde_skip_deserializing: bool,
 }
 
 /// Parse a single field's `llm` attributes and the schema-relevant subset of
@@ -57,11 +59,13 @@ pub fn parse_field_attributes(field: &Field) -> syn::Result<FieldAttributes> {
         })?;
     }
 
+    let serde = parse_serde_attributes(&field.attrs);
     Ok(FieldAttributes {
         description,
         example_value,
         examples_array,
-        serde_rename: parse_serde_attributes(&field.attrs).rename,
+        serde_rename: serde.rename,
+        serde_skip_deserializing: serde.skip_deserializing,
     })
 }
 

--- a/rstructor_derive/src/parsers/serde_parser.rs
+++ b/rstructor_derive/src/parsers/serde_parser.rs
@@ -8,11 +8,18 @@ use syn::{Attribute, Expr, Lit, Meta, Token};
 /// of rejecting valid Serde options such as `default`, `flatten`, or `with`.
 #[derive(Default)]
 pub struct SerdeAttributes {
+    /// The field/variant name accepted during deserialization.
     pub rename: Option<String>,
+    /// The case rule applied during deserialization.
     pub rename_all: Option<String>,
+    /// The case rule applied to all struct-variant fields during
+    /// deserialization.
+    pub rename_all_fields: Option<String>,
     pub tag: Option<String>,
     pub content: Option<String>,
     pub untagged: bool,
+    /// Whether Serde excludes this field or variant from deserialization.
+    pub skip_deserializing: bool,
 }
 
 pub fn parse_serde_attributes(attrs: &[Attribute]) -> SerdeAttributes {
@@ -34,6 +41,18 @@ pub fn parse_serde_attributes(attrs: &[Attribute]) -> SerdeAttributes {
                 Meta::NameValue(meta) if meta.path.is_ident("rename_all") => {
                     parsed.rename_all = string_value(&meta.value);
                 }
+                Meta::NameValue(meta) if meta.path.is_ident("rename_all_fields") => {
+                    parsed.rename_all_fields = string_value(&meta.value);
+                }
+                Meta::List(meta) if meta.path.is_ident("rename") => {
+                    parsed.rename = directional_string(&meta, "deserialize");
+                }
+                Meta::List(meta) if meta.path.is_ident("rename_all") => {
+                    parsed.rename_all = directional_string(&meta, "deserialize");
+                }
+                Meta::List(meta) if meta.path.is_ident("rename_all_fields") => {
+                    parsed.rename_all_fields = directional_string(&meta, "deserialize");
+                }
                 Meta::NameValue(meta) if meta.path.is_ident("tag") => {
                     parsed.tag = string_value(&meta.value);
                 }
@@ -43,6 +62,11 @@ pub fn parse_serde_attributes(attrs: &[Attribute]) -> SerdeAttributes {
                 Meta::Path(path) if path.is_ident("untagged") => {
                     parsed.untagged = true;
                 }
+                Meta::Path(path)
+                    if path.is_ident("skip") || path.is_ident("skip_deserializing") =>
+                {
+                    parsed.skip_deserializing = true;
+                }
                 _ => {
                     // All other Serde metadata is intentionally left to Serde.
                 }
@@ -51,6 +75,17 @@ pub fn parse_serde_attributes(attrs: &[Attribute]) -> SerdeAttributes {
     }
 
     parsed
+}
+
+fn directional_string(meta: &syn::MetaList, direction: &str) -> Option<String> {
+    let items = meta
+        .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+        .ok()?;
+
+    items.into_iter().find_map(|item| match item {
+        Meta::NameValue(meta) if meta.path.is_ident(direction) => string_value(&meta.value),
+        _ => None,
+    })
 }
 
 fn string_value(value: &Expr) -> Option<String> {
@@ -73,22 +108,45 @@ mod tests {
     fn extracts_supported_values_and_ignores_other_valid_serde_metadata() {
         let input: syn::DeriveInput = parse_quote! {
             #[serde(
-                rename = "renamed",
-                rename_all = "camelCase",
+                rename(serialize = "writeName", deserialize = "readName"),
+                rename_all(serialize = "PascalCase", deserialize = "camelCase"),
+                rename_all_fields(serialize = "UPPERCASE", deserialize = "snake_case"),
                 tag = "kind",
                 content = "payload",
                 untagged,
+                skip_deserializing,
                 default,
                 alias = "legacy"
             )]
-            struct Example;
+            enum Example {}
         };
 
         let attrs = parse_serde_attributes(&input.attrs);
-        assert_eq!(attrs.rename.as_deref(), Some("renamed"));
+        assert_eq!(attrs.rename.as_deref(), Some("readName"));
         assert_eq!(attrs.rename_all.as_deref(), Some("camelCase"));
+        assert_eq!(attrs.rename_all_fields.as_deref(), Some("snake_case"));
         assert_eq!(attrs.tag.as_deref(), Some("kind"));
         assert_eq!(attrs.content.as_deref(), Some("payload"));
         assert!(attrs.untagged);
+        assert!(attrs.skip_deserializing);
+    }
+
+    #[test]
+    fn serialize_only_metadata_does_not_change_deserialization_names() {
+        let input: syn::DeriveInput = parse_quote! {
+            #[serde(
+                rename(serialize = "writeName"),
+                rename_all(serialize = "PascalCase"),
+                rename_all_fields(serialize = "UPPERCASE"),
+                skip_serializing
+            )]
+            enum Example {}
+        };
+
+        let attrs = parse_serde_attributes(&input.attrs);
+        assert_eq!(attrs.rename, None);
+        assert_eq!(attrs.rename_all, None);
+        assert_eq!(attrs.rename_all_fields, None);
+        assert!(!attrs.skip_deserializing);
     }
 }

--- a/rstructor_derive/src/parsers/variant_parser.rs
+++ b/rstructor_derive/src/parsers/variant_parser.rs
@@ -7,6 +7,10 @@ pub struct VariantAttributes {
     pub description: Option<String>,
     /// Variant rename from #[serde(rename = "...")]
     pub serde_rename: Option<String>,
+    /// Case rule for named fields inside this variant.
+    pub serde_rename_all: Option<String>,
+    /// Whether Serde excludes this variant from deserialization.
+    pub serde_skip_deserializing: bool,
 }
 
 /// Parse a single enum variant's llm and serde attributes
@@ -32,8 +36,11 @@ pub fn parse_variant_attributes(variant: &Variant) -> syn::Result<VariantAttribu
         })?;
     }
 
+    let serde = parse_serde_attributes(&variant.attrs);
     Ok(VariantAttributes {
         description,
-        serde_rename: parse_serde_attributes(&variant.attrs).rename,
+        serde_rename: serde.rename,
+        serde_rename_all: serde.rename_all,
+        serde_skip_deserializing: serde.skip_deserializing,
     })
 }

--- a/rstructor_derive/tests/serde_deserialization_contract_tests.rs
+++ b/rstructor_derive/tests/serde_deserialization_contract_tests.rs
@@ -1,0 +1,414 @@
+#![allow(dead_code)]
+
+use rstructor::{Instructor, SchemaType};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+fn required_names(schema: &Value) -> Vec<&str> {
+    schema["required"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .collect()
+}
+
+fn only_variant(schema: &Value) -> &Value {
+    let variants = schema["anyOf"].as_array().expect("enum anyOf");
+    assert_eq!(variants.len(), 1, "unexpected schema: {schema:#}");
+    &variants[0]
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "SCREAMING-KEBAB-CASE", deserialize = "camelCase"))]
+struct OrderInput {
+    #[serde(skip_deserializing)]
+    internal_risk_score: i64,
+
+    #[serde(skip_serializing)]
+    client_secret: String,
+
+    #[serde(rename(serialize = "SYMBOL", deserialize = "ticker"))]
+    symbol: String,
+
+    order_quantity: i64,
+
+    #[serde(rename(serialize = "LIMIT-PRICE"))]
+    limit_price: f64,
+}
+
+#[test]
+fn struct_schema_uses_deserialization_names_and_omits_skipped_inputs() {
+    let schema = OrderInput::schema().to_json();
+    let properties = schema["properties"].as_object().expect("properties");
+
+    assert_eq!(
+        properties.keys().map(String::as_str).collect::<Vec<_>>(),
+        ["clientSecret", "limitPrice", "orderQuantity", "ticker"]
+    );
+    assert_eq!(
+        required_names(&schema),
+        ["clientSecret", "ticker", "orderQuantity", "limitPrice"]
+    );
+    assert!(!properties.contains_key("internalRiskScore"));
+    assert!(!properties.contains_key("CLIENT-SECRET"));
+    assert!(!properties.contains_key("SYMBOL"));
+
+    let decoded: OrderInput = serde_json::from_value(json!({
+        "clientSecret": "desk-a",
+        "ticker": "AAPL",
+        "orderQuantity": 125_000,
+        "limitPrice": 213.75
+    }))
+    .expect("schema-shaped input must deserialize");
+    assert_eq!(
+        decoded,
+        OrderInput {
+            internal_risk_score: 0,
+            client_secret: "desk-a".into(),
+            symbol: "AAPL".into(),
+            order_quantity: 125_000,
+            limit_price: 213.75,
+        }
+    );
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "SCREAMING-KEBAB-CASE"))]
+struct SerializeOnlyContainerRename {
+    account_id: String,
+}
+
+#[test]
+fn serialize_only_container_rule_leaves_deserialization_schema_unchanged() {
+    let schema = SerializeOnlyContainerRename::schema().to_json();
+    assert!(schema["properties"].get("account_id").is_some());
+    assert!(schema["properties"].get("ACCOUNT-ID").is_none());
+
+    let decoded: SerializeOnlyContainerRename =
+        serde_json::from_value(json!({"account_id": "acct-7"})).unwrap();
+    assert_eq!(decoded.account_id, "acct-7");
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "SCREAMING-KEBAB-CASE", deserialize = "snake_case"))]
+enum OrderKind {
+    #[serde(skip_deserializing)]
+    InternalCross,
+
+    #[serde(skip_serializing, rename(serialize = "CLIENT-OUT"))]
+    ClientOrder,
+
+    #[serde(rename(serialize = "MARKET-OUT", deserialize = "market"))]
+    MarketOrder,
+}
+
+#[test]
+fn simple_enum_contains_only_deserializable_variant_names() {
+    let schema = OrderKind::schema().to_json();
+    assert_eq!(schema["enum"], json!(["client_order", "market"]));
+
+    assert_eq!(
+        serde_json::from_value::<OrderKind>(json!("client_order")).unwrap(),
+        OrderKind::ClientOrder
+    );
+    assert_eq!(
+        serde_json::from_value::<OrderKind>(json!("market")).unwrap(),
+        OrderKind::MarketOrder
+    );
+    assert!(serde_json::from_value::<OrderKind>(json!("internal_cross")).is_err());
+    assert!(serde_json::from_value::<OrderKind>(json!("MARKET-OUT")).is_err());
+}
+
+#[derive(Debug, Instructor, Serialize, Deserialize)]
+enum UnitInputWithSkippedData {
+    Active,
+    #[serde(skip_deserializing)]
+    Internal {
+        risk_score: i64,
+    },
+}
+
+#[derive(Debug, Instructor, Serialize, Deserialize)]
+enum NoDeserializableVariant {
+    #[serde(skip_deserializing)]
+    Internal,
+}
+
+#[test]
+fn skipped_data_variants_do_not_change_simple_enum_shape() {
+    let schema = UnitInputWithSkippedData::schema().to_json();
+    assert_eq!(schema["type"], "string");
+    assert_eq!(schema["enum"], json!(["Active"]));
+
+    let empty_schema = NoDeserializableVariant::schema().to_json();
+    assert_eq!(empty_schema["type"], "string");
+    assert_eq!(empty_schema["enum"], json!([]));
+}
+
+#[derive(Debug, Instructor, Serialize, Deserialize)]
+struct NodeInput {
+    value: String,
+    #[serde(skip_deserializing)]
+    parent: Option<Box<NodeInput>>,
+}
+
+#[test]
+fn skipped_self_reference_does_not_leave_unused_recursive_definitions() {
+    let schema = NodeInput::schema().to_json();
+    assert!(schema["properties"].get("value").is_some());
+    assert!(schema["properties"].get("parent").is_none());
+    assert!(schema.get("$defs").is_none());
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+#[serde(
+    rename_all(serialize = "SCREAMING-KEBAB-CASE", deserialize = "snake_case"),
+    rename_all_fields(serialize = "UPPERCASE", deserialize = "camelCase")
+)]
+enum ExternalOrder {
+    #[serde(skip_deserializing)]
+    Internal { risk_score: i64 },
+
+    #[serde(skip_serializing, rename_all(deserialize = "PascalCase"))]
+    Submit {
+        #[serde(skip_deserializing)]
+        server_id: String,
+        client_order_id: String,
+        #[serde(rename(serialize = "SIZE", deserialize = "quantity"))]
+        size: i64,
+    },
+}
+
+#[test]
+fn external_enum_applies_variant_field_rules_and_skips_read_only_data() {
+    let schema = ExternalOrder::schema().to_json();
+    let variant = only_variant(&schema);
+    let payload = &variant["properties"]["submit"];
+    let properties = payload["properties"]
+        .as_object()
+        .expect("payload properties");
+
+    assert_eq!(
+        properties.keys().map(String::as_str).collect::<Vec<_>>(),
+        ["ClientOrderId", "quantity"]
+    );
+    assert_eq!(required_names(payload), ["ClientOrderId", "quantity"]);
+    assert!(!properties.contains_key("server_id"));
+
+    let decoded: ExternalOrder = serde_json::from_value(json!({
+        "submit": {
+            "ClientOrderId": "co-123",
+            "quantity": 250
+        }
+    }))
+    .expect("schema-shaped external enum must deserialize");
+    assert_eq!(
+        decoded,
+        ExternalOrder::Submit {
+            server_id: String::new(),
+            client_order_id: "co-123".into(),
+            size: 250,
+        }
+    );
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+enum ExternalTuple {
+    Legs(String, #[serde(skip_deserializing)] bool, i64),
+    Ack(#[serde(skip_deserializing)] bool),
+}
+
+#[test]
+fn external_tuple_schema_removes_skipped_elements_and_collapses_skipped_newtype() {
+    let schema = ExternalTuple::schema().to_json();
+    let variants = schema["anyOf"].as_array().expect("anyOf");
+
+    let legs = variants
+        .iter()
+        .find(|variant| variant["properties"].get("Legs").is_some())
+        .expect("Legs variant");
+    let legs_schema = &legs["properties"]["Legs"];
+    assert_eq!(legs_schema["minItems"], 2);
+    assert_eq!(legs_schema["maxItems"], 2);
+    assert_eq!(legs_schema["items"].as_array().unwrap().len(), 2);
+
+    assert!(
+        variants
+            .iter()
+            .any(|variant| { variant["type"] == "string" && variant["enum"] == json!(["Ack"]) })
+    );
+
+    assert_eq!(
+        serde_json::from_value::<ExternalTuple>(json!({"Legs": ["AAPL", 100]})).unwrap(),
+        ExternalTuple::Legs("AAPL".into(), false, 100)
+    );
+    assert_eq!(
+        serde_json::from_value::<ExternalTuple>(json!("Ack")).unwrap(),
+        ExternalTuple::Ack(false)
+    );
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+#[serde(
+    tag = "kind",
+    rename_all(serialize = "SCREAMING-KEBAB-CASE", deserialize = "snake_case"),
+    rename_all_fields(deserialize = "camelCase")
+)]
+enum InternalOrder {
+    #[serde(skip_deserializing)]
+    Internal { risk_score: i64 },
+
+    #[serde(skip_serializing)]
+    Submit {
+        #[serde(skip_deserializing)]
+        server_id: String,
+        client_order_id: String,
+    },
+}
+
+#[test]
+fn internal_enum_matches_deserialization_tag_and_field_contract() {
+    let schema = InternalOrder::schema().to_json();
+    let variant = only_variant(&schema);
+    let properties = variant["properties"].as_object().expect("properties");
+
+    assert_eq!(properties["kind"]["enum"], json!(["submit"]));
+    assert!(properties.contains_key("clientOrderId"));
+    assert!(!properties.contains_key("serverId"));
+    assert_eq!(required_names(variant), ["kind", "clientOrderId"]);
+
+    let decoded: InternalOrder = serde_json::from_value(json!({
+        "kind": "submit",
+        "clientOrderId": "co-456"
+    }))
+    .expect("schema-shaped internal enum must deserialize");
+    assert_eq!(
+        decoded,
+        InternalOrder::Submit {
+            server_id: String::new(),
+            client_order_id: "co-456".into(),
+        }
+    );
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+#[serde(
+    tag = "kind",
+    content = "order",
+    rename_all(serialize = "SCREAMING-KEBAB-CASE", deserialize = "snake_case"),
+    rename_all_fields(deserialize = "camelCase")
+)]
+enum AdjacentOrder {
+    #[serde(skip_deserializing)]
+    Internal {
+        risk_score: i64,
+    },
+
+    #[serde(skip_serializing)]
+    Submit {
+        #[serde(skip_deserializing)]
+        server_id: String,
+        client_order_id: String,
+    },
+
+    Ack(#[serde(skip_deserializing)] bool),
+}
+
+#[test]
+fn adjacent_enum_uses_deserialization_contract_for_content_and_skipped_newtypes() {
+    let schema = AdjacentOrder::schema().to_json();
+    let variants = schema["anyOf"].as_array().expect("anyOf");
+    assert_eq!(variants.len(), 2);
+
+    let submit = variants
+        .iter()
+        .find(|variant| variant["properties"]["kind"]["enum"] == json!(["submit"]))
+        .expect("submit variant");
+    let content = &submit["properties"]["order"];
+    assert!(content["properties"].get("clientOrderId").is_some());
+    assert!(content["properties"].get("serverId").is_none());
+    assert_eq!(required_names(content), ["clientOrderId"]);
+
+    let ack = variants
+        .iter()
+        .find(|variant| variant["properties"]["kind"]["enum"] == json!(["ack"]))
+        .expect("ack variant");
+    assert_eq!(ack["properties"]["order"], json!({"type": "null"}));
+    assert_eq!(required_names(ack), ["kind", "order"]);
+
+    let submit_value = json!({
+        "kind": "submit",
+        "order": {"clientOrderId": "co-789"}
+    });
+    assert_eq!(
+        serde_json::from_value::<AdjacentOrder>(submit_value).unwrap(),
+        AdjacentOrder::Submit {
+            server_id: String::new(),
+            client_order_id: "co-789".into(),
+        }
+    );
+    assert_eq!(
+        serde_json::from_value::<AdjacentOrder>(json!({"kind": "ack", "order": null})).unwrap(),
+        AdjacentOrder::Ack(false)
+    );
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+#[serde(untagged, rename_all_fields(deserialize = "camelCase"))]
+enum UntaggedOrder {
+    #[serde(skip_deserializing)]
+    Internal {
+        risk_score: i64,
+    },
+
+    Submit {
+        #[serde(skip_deserializing)]
+        server_id: String,
+        client_order_id: String,
+    },
+
+    Pair(String, #[serde(skip_deserializing)] bool, i64),
+
+    Ack(#[serde(skip_deserializing)] bool),
+}
+
+#[test]
+fn untagged_enum_filters_skipped_shapes_fields_and_tuple_elements() {
+    let schema = UntaggedOrder::schema().to_json();
+    let variants = schema["anyOf"].as_array().expect("anyOf");
+    assert_eq!(variants.len(), 3);
+
+    let object = variants
+        .iter()
+        .find(|variant| variant["type"] == "object")
+        .expect("object variant");
+    assert!(object["properties"].get("clientOrderId").is_some());
+    assert!(object["properties"].get("serverId").is_none());
+
+    let tuple = variants
+        .iter()
+        .find(|variant| variant["type"] == "array")
+        .expect("tuple variant");
+    assert_eq!(tuple["minItems"], 2);
+    assert_eq!(tuple["maxItems"], 2);
+    assert_eq!(tuple["items"].as_array().unwrap().len(), 2);
+
+    assert!(variants.iter().any(Value::is_null) || variants.iter().any(|v| v["type"] == "null"));
+
+    assert_eq!(
+        serde_json::from_value::<UntaggedOrder>(json!({"clientOrderId": "co-999"})).unwrap(),
+        UntaggedOrder::Submit {
+            server_id: String::new(),
+            client_order_id: "co-999".into(),
+        }
+    );
+    assert_eq!(
+        serde_json::from_value::<UntaggedOrder>(json!(["AAPL", 50])).unwrap(),
+        UntaggedOrder::Pair("AAPL".into(), false, 50)
+    );
+    assert_eq!(
+        serde_json::from_value::<UntaggedOrder>(Value::Null).unwrap(),
+        UntaggedOrder::Ack(false)
+    );
+}


### PR DESCRIPTION
## Summary

- make derive-generated schemas describe Serde's accepted input contract rather than its serialized output
- honor deserialization-facing `rename`, `rename_all`, and `rename_all_fields`, including directional Serde metadata
- omit fields and variants marked `skip` or `skip_deserializing`, while keeping `skip_serializing` inputs
- apply the same behavior to structs and externally, internally, adjacently, and untagged enums
- cover named fields, tuple elements, newtypes, skipped recursive fields, skipped data variants, and enums with no deserializable variants

## Why

The derive parser previously understood only symmetric name-value rename metadata and did not model Serde's skip directions. That allowed generated schemas to advertise keys or enum shapes that Serde would reject, while omitting directional input names that Serde actually accepts.

For example:

```rust
#[derive(Instructor, Serialize, Deserialize)]
#[serde(rename_all(serialize = "snake_case", deserialize = "camelCase"))]
struct BrokerOrder {
    #[serde(skip_deserializing)]
    server_timestamp: String,

    #[serde(skip_serializing)]
    client_order_id: String,

    #[serde(rename(serialize = "symbol", deserialize = "ticker"))]
    instrument: String,
}
```

Before, the schema could expose `server_timestamp`, miss the `clientOrderId` input name, and use the wrong name for `instrument`. After this change, the accepted input is:

```json
{
  "clientOrderId": "co-123",
  "ticker": "AAPL"
}
```

`server_timestamp` is absent because Serde does not deserialize it. `clientOrderId` remains required because `skip_serializing` affects output only.

The same correction applies to enum inputs:

```rust
#[derive(Instructor, Serialize, Deserialize)]
#[serde(rename_all_fields(deserialize = "camelCase"))]
enum Order {
    Submit {
        #[serde(skip_deserializing)]
        server_id: String,
        client_order_id: String,
    },
}
```

The generated payload schema now accepts `clientOrderId` and omits `serverId`, matching a real `serde_json::from_value` call.

## Behavior boundary

This intentionally changes schemas that currently reflect serialization-only names or expose non-deserializable members. It does not change runtime Serde behavior; it brings the schema into alignment with it.

This PR does not yet interpret `default`, `flatten`, custom deserializers, aliases, or `other`. In particular, `default` and `flatten` can change requiredness/object composition and strict-provider behavior, so they should be handled as separate design decisions.

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo check --workspace --all-targets --all-features`
- `cargo test --workspace --all-features --no-fail-fast`
- `cargo build --workspace --all-features --examples`

The new parity suite asserts generated schema shapes and then deserializes schema-shaped, market/order-style fixtures with Serde. It covers structs plus all four enum representations. It also retains regressions discovered while implementing this work:

- an adjacent-tagged skipped newtype still requires its content key with `null`
- an enum whose every variant is skipped generates a valid empty string enum
- a skipped self-reference does not leave an unused `$defs` tree
