### PR TITLE
[codex] Build schemas with a context-aware type graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,49 @@ struct Recipe {
 }
 ```
 
+Derived schemas also support direct and mutual recursion. Recursive definitions
+are hoisted to the document root, and concrete Rust type identity keeps
+same-named types from different modules or generic instantiations distinct:
+
+```rust
+#[derive(Instructor, Serialize, Deserialize)]
+struct Fund {
+    lei: String,
+    prime_broker: Option<Box<PrimeBroker>>,
+}
+
+#[derive(Instructor, Serialize, Deserialize)]
+struct PrimeBroker {
+    lei: String,
+    sponsored_funds: Vec<Fund>,
+}
+
+let schema = Fund::schema().to_json();
+assert!(schema["$defs"].is_object());
+```
+
+OpenAI, Anthropic, and Grok preserve those recursive references in their
+structured-output schemas. Gemini cannot currently represent an unbounded
+recursive schema. Its client returns a local, non-retryable compatibility error
+instead of silently replacing the deepest recursive branch with `{}`:
+
+```rust
+use rstructor::{GeminiClient, LLMClient, RStructorError};
+
+let result = GeminiClient::from_env()?
+    .materialize::<Fund>("Extract the fund and prime-broker hierarchy")
+    .await;
+
+assert!(matches!(
+    result,
+    Err(RStructorError::SchemaCompatibilityError { provider, .. })
+        if provider.as_ref() == "Gemini"
+));
+```
+
+Run the complete example with
+`cargo run --example recursive_schema_graph`.
+
 ### Enums with Data
 
 ```rust

--- a/examples/recursive_schema_graph.rs
+++ b/examples/recursive_schema_graph.rs
@@ -1,0 +1,35 @@
+//! Context-aware schema generation for mutually recursive domain types.
+//!
+//! Derived schemas share one build context, so cycles terminate in root-level
+//! `$defs` and each `$ref` resolves from the JSON Schema document root.
+
+use rstructor::{Instructor, SchemaType};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Instructor, Serialize, Deserialize)]
+struct Fund {
+    lei: String,
+    prime_broker: Option<Box<PrimeBroker>>,
+}
+
+#[derive(Debug, Instructor, Serialize, Deserialize)]
+struct PrimeBroker {
+    lei: String,
+    sponsored_funds: Vec<Fund>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let schema = Fund::schema().to_json();
+    println!("{}", serde_json::to_string_pretty(&schema)?);
+
+    let fund: Fund = serde_json::from_value(serde_json::json!({
+        "lei": "5493001KJTIIGC8Y1R12",
+        "prime_broker": {
+            "lei": "7H6GLXDRUGQFU57RNE97",
+            "sponsored_funds": []
+        }
+    }))?;
+    println!("{fund:#?}");
+
+    Ok(())
+}

--- a/rstructor_derive/src/generators/enum_schema.rs
+++ b/rstructor_derive/src/generators/enum_schema.rs
@@ -41,13 +41,16 @@ pub fn generate_enum_schema(
 }
 
 /// Clone the enum's generics, additionally binding every type parameter by
-/// `SchemaType` — the generated code calls `<T as SchemaType>::schema()` for
-/// type-parameter fields inside variants. Use with `split_for_impl()` to emit
+/// `SchemaType` — generated code composes type-parameter fields through
+/// `SchemaType::schema_in`. Use with `split_for_impl()` to emit
 /// the `impl ... SchemaType for ...` header.
 fn schema_bounded_generics(generics: &syn::Generics) -> syn::Generics {
     crate::type_utils::generics_with_bounds(
         generics,
-        &[syn::parse_quote!(::rstructor::schema::SchemaType)],
+        &[
+            syn::parse_quote!(::rstructor::schema::SchemaType),
+            syn::parse_quote!('static),
+        ],
     )
 }
 
@@ -142,21 +145,29 @@ fn generate_simple_enum_schema(
     Ok(quote! {
         impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
             fn schema() -> ::rstructor::schema::Schema {
-                // Create array of enum values
-                let enum_values: Vec<::serde_json::Value> = vec![
-                    #(::serde_json::Value::String(#variant_values.to_string())),*
-                ];
+                let mut context = ::rstructor::schema::__private::SchemaBuildContext::new();
+                let root = <Self as ::rstructor::schema::SchemaType>::schema_in(&mut context);
+                ::rstructor::schema::Schema::new(context.finish(root))
+            }
 
-                let mut schema_obj = ::serde_json::json!({
-                    "type": "string",
-                    "enum": enum_values,
-                    "title": stringify!(#name)
-                });
+            fn schema_in(
+                __rstructor_context: &mut ::rstructor::schema::__private::SchemaBuildContext
+            ) -> ::serde_json::Value {
+                __rstructor_context.schema_for::<Self, _>(stringify!(#name), |__rstructor_context| {
+                    let _ = __rstructor_context;
+                    let enum_values: Vec<::serde_json::Value> = vec![
+                        #(::serde_json::Value::String(#variant_values.to_string())),*
+                    ];
 
-                // Add container attributes if available
-                #container_setter
+                    let mut schema_obj = ::serde_json::json!({
+                        "type": "string",
+                        "enum": enum_values,
+                        "title": stringify!(#name)
+                    });
 
-                ::rstructor::schema::Schema::new(schema_obj)
+                    #container_setter
+                    schema_obj
+                })
             }
 
             fn schema_name() -> Option<String> {
@@ -477,20 +488,27 @@ fn generate_externally_tagged_enum_schema(
     Ok(quote! {
         impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
             fn schema() -> ::rstructor::schema::Schema {
-                // Create oneOf schema for enum variants
-                let variant_schemas = vec![
-                    #(#variant_schemas),*
-                ];
+                let mut context = ::rstructor::schema::__private::SchemaBuildContext::new();
+                let root = <Self as ::rstructor::schema::SchemaType>::schema_in(&mut context);
+                ::rstructor::schema::Schema::new(context.finish(root))
+            }
 
-                let mut schema_obj = ::serde_json::json!({
-                    "anyOf": variant_schemas,
-                    "title": stringify!(#name)
-                });
+            fn schema_in(
+                __rstructor_context: &mut ::rstructor::schema::__private::SchemaBuildContext
+            ) -> ::serde_json::Value {
+                __rstructor_context.schema_for::<Self, _>(stringify!(#name), |__rstructor_context| {
+                    let variant_schemas = vec![
+                        #(#variant_schemas),*
+                    ];
 
-                // Add container attributes if available
-                #container_setter
+                    let mut schema_obj = ::serde_json::json!({
+                        "anyOf": variant_schemas,
+                        "title": stringify!(#name)
+                    });
 
-                ::rstructor::schema::Schema::new(schema_obj)
+                    #container_setter
+                    schema_obj
+                })
             }
 
             fn schema_name() -> Option<String> {
@@ -537,9 +555,9 @@ fn generate_field_schema(field_type: &Type, description: &Option<String>) -> Tok
                         "type": "object",
                         #desc_prop
                     });
-                    let value_schema = <#val_ty as ::rstructor::schema::SchemaType>::schema();
+                    let value_schema = <#val_ty as ::rstructor::schema::SchemaType>::schema_in(__rstructor_context);
                     if let ::serde_json::Value::Object(map) = &mut schema {
-                        map.insert("additionalProperties".to_string(), value_schema.to_json());
+                        map.insert("additionalProperties".to_string(), value_schema);
                     }
                     schema
                 }
@@ -625,7 +643,7 @@ fn generate_field_schema(field_type: &Type, description: &Option<String>) -> Tok
                 let elem_schema_type = get_schema_type_from_rust_type(elem_ty);
                 if elem_schema_type == "object" {
                     quote! {
-                        <#elem_ty as ::rstructor::schema::SchemaType>::schema().to_json()
+                        <#elem_ty as ::rstructor::schema::SchemaType>::schema_in(__rstructor_context)
                     }
                 } else {
                     quote! {
@@ -709,7 +727,7 @@ fn generate_field_schema(field_type: &Type, description: &Option<String>) -> Tok
                 // For arrays of complex types
                 return quote! {
                     {
-                        let items_schema = <#inner_type as ::rstructor::schema::SchemaType>::schema().to_json();
+                        let items_schema = <#inner_type as ::rstructor::schema::SchemaType>::schema_in(__rstructor_context);
                         ::serde_json::json!({
                             "type": "array",
                             #desc_prop
@@ -750,7 +768,7 @@ fn generate_field_schema(field_type: &Type, description: &Option<String>) -> Tok
             let desc_str = desc.clone();
             return quote! {
                 {
-                    let mut obj = <#type_path as ::rstructor::schema::SchemaType>::schema().to_json().clone();
+                    let mut obj = <#type_path as ::rstructor::schema::SchemaType>::schema_in(__rstructor_context);
                     if let ::serde_json::Value::Object(map) = &mut obj {
                         map.insert("description".to_string(), ::serde_json::Value::String(#desc_str.to_string()));
                     }
@@ -759,7 +777,7 @@ fn generate_field_schema(field_type: &Type, description: &Option<String>) -> Tok
             };
         } else {
             return quote! {
-                <#type_path as ::rstructor::schema::SchemaType>::schema().to_json()
+                <#type_path as ::rstructor::schema::SchemaType>::schema_in(__rstructor_context)
             };
         }
     }
@@ -933,60 +951,23 @@ fn generate_internally_tagged_enum_schema(
 
                     variant_schemas.push(quote! {
                         {
-                            let inner_schema = <#schema_ty as ::rstructor::schema::SchemaType>::schema().to_json();
-
-                            let mut properties = ::serde_json::Map::new();
-                            properties.insert(#tag_name_str.to_string(), ::serde_json::json!({
-                                "type": "string",
-                                "enum": [#variant_name_str]
-                            }));
-
-                            let mut required = vec![::serde_json::Value::String(#tag_name_str.to_string())];
-                            let mut defs = ::serde_json::Map::new();
-
-                            if let Some(inner_obj) = inner_schema.as_object() {
-                                let resolved_obj = if inner_obj.get("properties").is_some() {
-                                    Some(inner_obj)
-                                } else {
-                                    inner_obj
-                                        .get("$ref")
-                                        .and_then(|r| r.as_str())
-                                        .and_then(|r| r.strip_prefix("#/$defs/"))
-                                        .and_then(|def_name| inner_obj.get("$defs").and_then(|defs| defs.get(def_name)))
-                                        .and_then(|def_schema| def_schema.as_object())
-                                };
-
-                                if let Some(::serde_json::Value::Object(inner_defs)) = inner_obj.get("$defs") {
-                                    for (k, v) in inner_defs {
-                                        defs.insert(k.clone(), v.clone());
-                                    }
-                                }
-
-                                if let Some(resolved_obj) = resolved_obj {
-                                    if let Some(::serde_json::Value::Object(inner_props)) = resolved_obj.get("properties") {
-                                        for (k, v) in inner_props {
-                                            properties.insert(k.clone(), v.clone());
-                                        }
-                                    }
-                                    if let Some(::serde_json::Value::Array(inner_req)) = resolved_obj.get("required") {
-                                        for r in inner_req {
-                                            required.push(r.clone());
-                                        }
-                                    }
-                                }
-                            }
+                            let inner_schema = <#schema_ty as ::rstructor::schema::SchemaType>::schema_in(__rstructor_context);
 
                             let mut schema_obj = ::serde_json::Map::new();
                             schema_obj.insert("type".to_string(), ::serde_json::Value::String("object".to_string()));
-                            schema_obj.insert("properties".to_string(), ::serde_json::Value::Object(properties));
-                            schema_obj.insert("required".to_string(), ::serde_json::Value::Array(required));
+                            schema_obj.insert("properties".to_string(), ::serde_json::json!({
+                                #tag_name_str: {
+                                    "type": "string",
+                                    "enum": [#variant_name_str]
+                                }
+                            }));
+                            schema_obj.insert("required".to_string(), ::serde_json::json!([#tag_name_str]));
                             schema_obj.insert("description".to_string(), ::serde_json::Value::String(#description_str.to_string()));
                             schema_obj.insert("additionalProperties".to_string(), ::serde_json::Value::Bool(false));
-                            if !defs.is_empty() {
-                                schema_obj.insert("$defs".to_string(), ::serde_json::Value::Object(defs));
-                            }
-
-                            ::serde_json::Value::Object(schema_obj)
+                            __rstructor_context.flatten_into_object(
+                                ::serde_json::Value::Object(schema_obj),
+                                inner_schema,
+                            )
                         }
                     });
                 } else {
@@ -1026,18 +1007,27 @@ fn generate_internally_tagged_enum_schema(
     Ok(quote! {
         impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
             fn schema() -> ::rstructor::schema::Schema {
-                let variant_schemas = vec![
-                    #(#variant_schemas),*
-                ];
+                let mut context = ::rstructor::schema::__private::SchemaBuildContext::new();
+                let root = <Self as ::rstructor::schema::SchemaType>::schema_in(&mut context);
+                ::rstructor::schema::Schema::new(context.finish(root))
+            }
 
-                let mut schema_obj = ::serde_json::json!({
-                    "anyOf": variant_schemas,
-                    "title": stringify!(#name)
-                });
+            fn schema_in(
+                __rstructor_context: &mut ::rstructor::schema::__private::SchemaBuildContext
+            ) -> ::serde_json::Value {
+                __rstructor_context.schema_for::<Self, _>(stringify!(#name), |__rstructor_context| {
+                    let variant_schemas = vec![
+                        #(#variant_schemas),*
+                    ];
 
-                #container_setter
+                    let mut schema_obj = ::serde_json::json!({
+                        "anyOf": variant_schemas,
+                        "title": stringify!(#name)
+                    });
 
-                ::rstructor::schema::Schema::new(schema_obj)
+                    #container_setter
+                    schema_obj
+                })
             }
 
             fn schema_name() -> Option<String> {
@@ -1363,18 +1353,27 @@ fn generate_adjacently_tagged_enum_schema(
     Ok(quote! {
         impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
             fn schema() -> ::rstructor::schema::Schema {
-                let variant_schemas = vec![
-                    #(#variant_schemas),*
-                ];
+                let mut context = ::rstructor::schema::__private::SchemaBuildContext::new();
+                let root = <Self as ::rstructor::schema::SchemaType>::schema_in(&mut context);
+                ::rstructor::schema::Schema::new(context.finish(root))
+            }
 
-                let mut schema_obj = ::serde_json::json!({
-                    "anyOf": variant_schemas,
-                    "title": stringify!(#name)
-                });
+            fn schema_in(
+                __rstructor_context: &mut ::rstructor::schema::__private::SchemaBuildContext
+            ) -> ::serde_json::Value {
+                __rstructor_context.schema_for::<Self, _>(stringify!(#name), |__rstructor_context| {
+                    let variant_schemas = vec![
+                        #(#variant_schemas),*
+                    ];
 
-                #container_setter
+                    let mut schema_obj = ::serde_json::json!({
+                        "anyOf": variant_schemas,
+                        "title": stringify!(#name)
+                    });
 
-                ::rstructor::schema::Schema::new(schema_obj)
+                    #container_setter
+                    schema_obj
+                })
             }
 
             fn schema_name() -> Option<String> {
@@ -1549,18 +1548,27 @@ fn generate_untagged_enum_schema(
     Ok(quote! {
         impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
             fn schema() -> ::rstructor::schema::Schema {
-                let variant_schemas = vec![
-                    #(#variant_schemas),*
-                ];
+                let mut context = ::rstructor::schema::__private::SchemaBuildContext::new();
+                let root = <Self as ::rstructor::schema::SchemaType>::schema_in(&mut context);
+                ::rstructor::schema::Schema::new(context.finish(root))
+            }
 
-                let mut schema_obj = ::serde_json::json!({
-                    "anyOf": variant_schemas,
-                    "title": stringify!(#name)
-                });
+            fn schema_in(
+                __rstructor_context: &mut ::rstructor::schema::__private::SchemaBuildContext
+            ) -> ::serde_json::Value {
+                __rstructor_context.schema_for::<Self, _>(stringify!(#name), |__rstructor_context| {
+                    let variant_schemas = vec![
+                        #(#variant_schemas),*
+                    ];
 
-                #container_setter
+                    let mut schema_obj = ::serde_json::json!({
+                        "anyOf": variant_schemas,
+                        "title": stringify!(#name)
+                    });
 
-                ::rstructor::schema::Schema::new(schema_obj)
+                    #container_setter
+                    schema_obj
+                })
             }
 
             fn schema_name() -> Option<String> {

--- a/rstructor_derive/src/generators/enum_schema.rs
+++ b/rstructor_derive/src/generators/enum_schema.rs
@@ -45,13 +45,20 @@ pub fn generate_enum_schema(
 /// `SchemaType::schema_in`. Use with `split_for_impl()` to emit
 /// the `impl ... SchemaType for ...` header.
 fn schema_bounded_generics(generics: &syn::Generics) -> syn::Generics {
-    crate::type_utils::generics_with_bounds(
-        generics,
-        &[
-            syn::parse_quote!(::rstructor::schema::SchemaType),
-            syn::parse_quote!('static),
-        ],
-    )
+    let mut bounds = vec![syn::parse_quote!(::rstructor::schema::SchemaType)];
+    if generics.lifetimes().next().is_none() {
+        bounds.push(syn::parse_quote!('static));
+    }
+    crate::type_utils::generics_with_bounds(generics, &bounds)
+}
+
+fn schema_for_method(generics: &syn::Generics) -> Ident {
+    let method = if generics.lifetimes().next().is_some() {
+        "schema_for_named"
+    } else {
+        "schema_for"
+    };
+    Ident::new(method, proc_macro2::Span::call_site())
 }
 
 fn deserialization_name(
@@ -141,6 +148,7 @@ fn generate_simple_enum_schema(
 
     let schema_generics = schema_bounded_generics(generics);
     let (impl_generics, ty_generics, where_clause) = schema_generics.split_for_impl();
+    let schema_for_method = schema_for_method(generics);
 
     Ok(quote! {
         impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
@@ -153,7 +161,7 @@ fn generate_simple_enum_schema(
             fn schema_in(
                 __rstructor_context: &mut ::rstructor::schema::__private::SchemaBuildContext
             ) -> ::serde_json::Value {
-                __rstructor_context.schema_for::<Self, _>(stringify!(#name), |__rstructor_context| {
+                __rstructor_context.#schema_for_method::<Self, _>(stringify!(#name), |__rstructor_context| {
                     let _ = __rstructor_context;
                     let enum_values: Vec<::serde_json::Value> = vec![
                         #(::serde_json::Value::String(#variant_values.to_string())),*
@@ -484,6 +492,7 @@ fn generate_externally_tagged_enum_schema(
     // Generate the final schema implementation
     let schema_generics = schema_bounded_generics(generics);
     let (impl_generics, ty_generics, where_clause) = schema_generics.split_for_impl();
+    let schema_for_method = schema_for_method(generics);
 
     Ok(quote! {
         impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
@@ -496,7 +505,7 @@ fn generate_externally_tagged_enum_schema(
             fn schema_in(
                 __rstructor_context: &mut ::rstructor::schema::__private::SchemaBuildContext
             ) -> ::serde_json::Value {
-                __rstructor_context.schema_for::<Self, _>(stringify!(#name), |__rstructor_context| {
+                __rstructor_context.#schema_for_method::<Self, _>(stringify!(#name), |__rstructor_context| {
                     let variant_schemas = vec![
                         #(#variant_schemas),*
                     ];
@@ -1003,6 +1012,7 @@ fn generate_internally_tagged_enum_schema(
 
     let schema_generics = schema_bounded_generics(generics);
     let (impl_generics, ty_generics, where_clause) = schema_generics.split_for_impl();
+    let schema_for_method = schema_for_method(generics);
 
     Ok(quote! {
         impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
@@ -1015,7 +1025,7 @@ fn generate_internally_tagged_enum_schema(
             fn schema_in(
                 __rstructor_context: &mut ::rstructor::schema::__private::SchemaBuildContext
             ) -> ::serde_json::Value {
-                __rstructor_context.schema_for::<Self, _>(stringify!(#name), |__rstructor_context| {
+                __rstructor_context.#schema_for_method::<Self, _>(stringify!(#name), |__rstructor_context| {
                     let variant_schemas = vec![
                         #(#variant_schemas),*
                     ];
@@ -1349,6 +1359,7 @@ fn generate_adjacently_tagged_enum_schema(
 
     let schema_generics = schema_bounded_generics(generics);
     let (impl_generics, ty_generics, where_clause) = schema_generics.split_for_impl();
+    let schema_for_method = schema_for_method(generics);
 
     Ok(quote! {
         impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
@@ -1361,7 +1372,7 @@ fn generate_adjacently_tagged_enum_schema(
             fn schema_in(
                 __rstructor_context: &mut ::rstructor::schema::__private::SchemaBuildContext
             ) -> ::serde_json::Value {
-                __rstructor_context.schema_for::<Self, _>(stringify!(#name), |__rstructor_context| {
+                __rstructor_context.#schema_for_method::<Self, _>(stringify!(#name), |__rstructor_context| {
                     let variant_schemas = vec![
                         #(#variant_schemas),*
                     ];
@@ -1544,6 +1555,7 @@ fn generate_untagged_enum_schema(
 
     let schema_generics = schema_bounded_generics(generics);
     let (impl_generics, ty_generics, where_clause) = schema_generics.split_for_impl();
+    let schema_for_method = schema_for_method(generics);
 
     Ok(quote! {
         impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
@@ -1556,7 +1568,7 @@ fn generate_untagged_enum_schema(
             fn schema_in(
                 __rstructor_context: &mut ::rstructor::schema::__private::SchemaBuildContext
             ) -> ::serde_json::Value {
-                __rstructor_context.schema_for::<Self, _>(stringify!(#name), |__rstructor_context| {
+                __rstructor_context.#schema_for_method::<Self, _>(stringify!(#name), |__rstructor_context| {
                     let variant_schemas = vec![
                         #(#variant_schemas),*
                     ];

--- a/rstructor_derive/src/generators/struct_schema.rs
+++ b/rstructor_derive/src/generators/struct_schema.rs
@@ -420,14 +420,18 @@ pub fn generate_struct_schema(
     // Emit a generics-aware impl: every type parameter is additionally bound
     // by SchemaType, since the generated code composes each nested T's schema.
     // for type-parameter fields.
-    let schema_generics = generics_with_bounds(
-        generics,
-        &[
-            syn::parse_quote!(::rstructor::schema::SchemaType),
-            syn::parse_quote!('static),
-        ],
-    );
+    let mut schema_bounds = vec![syn::parse_quote!(::rstructor::schema::SchemaType)];
+    let has_lifetime_parameters = generics.lifetimes().next().is_some();
+    if !has_lifetime_parameters {
+        schema_bounds.push(syn::parse_quote!('static));
+    }
+    let schema_generics = generics_with_bounds(generics, &schema_bounds);
     let (impl_generics, ty_generics, where_clause) = schema_generics.split_for_impl();
+    let schema_for_method = if has_lifetime_parameters {
+        Ident::new("schema_for_named", proc_macro2::Span::call_site())
+    } else {
+        Ident::new("schema_for", proc_macro2::Span::call_site())
+    };
 
     Ok(quote! {
         impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
@@ -440,7 +444,7 @@ pub fn generate_struct_schema(
             fn schema_in(
                 __rstructor_context: &mut ::rstructor::schema::__private::SchemaBuildContext
             ) -> ::serde_json::Value {
-                __rstructor_context.schema_for::<Self, _>(stringify!(#name), |__rstructor_context| {
+                __rstructor_context.#schema_for_method::<Self, _>(stringify!(#name), |__rstructor_context| {
                     // Create base schema object
                     let mut schema_obj = ::serde_json::json!({
                         "type": "object",

--- a/rstructor_derive/src/generators/struct_schema.rs
+++ b/rstructor_derive/src/generators/struct_schema.rs
@@ -7,8 +7,7 @@ use crate::parsers::field_parser::parse_field_attributes;
 use crate::type_utils::{
     generics_with_bounds, get_array_inner_type, get_box_inner_type, get_map_types,
     get_option_inner_type, get_schema_type_from_rust_type, get_tuple_element_types, get_type_name,
-    is_array_type, is_box_type, is_json_value_type, is_map_type, is_option_type, is_self_reference,
-    is_tuple_type,
+    is_array_type, is_box_type, is_json_value_type, is_map_type, is_option_type, is_tuple_type,
 };
 
 /// Generate the schema implementation for a struct
@@ -20,8 +19,6 @@ pub fn generate_struct_schema(
 ) -> syn::Result<TokenStream> {
     let mut property_setters = Vec::new();
     let mut required_setters = Vec::new();
-    let mut has_self_reference = false;
-    let struct_name_str = name.to_string();
 
     match &data_struct.fields {
         Fields::Named(fields) => {
@@ -31,10 +28,6 @@ pub fn generate_struct_schema(
                 if attrs.serde_skip_deserializing {
                     continue;
                 }
-                if is_self_reference(&field.ty, &struct_name_str) {
-                    has_self_reference = true;
-                }
-
                 let original_field_name = field
                     .ident
                     .as_ref()
@@ -102,9 +95,9 @@ pub fn generate_struct_schema(
                         // preferring the type's own SchemaType impl when present
                         let probed = {
                             #[allow(unused_imports)]
-                            use ::rstructor::schema::__private::SchemaProbeFallback as _;
+                            use ::rstructor::schema::__private::SchemaProbeContextFallback as _;
                             ::rstructor::schema::__private::SchemaProbe::<#actual_type>::new()
-                                .rstructor_schema_or(#fallback)
+                                .rstructor_schema_in_or(__rstructor_context, #fallback)
                         };
                         let mut props = if let ::serde_json::Value::Object(m) = probed {
                             m
@@ -127,7 +120,7 @@ pub fn generate_struct_schema(
                     if let Some(inner_type) = get_array_inner_type(actual_array_type) {
                         // Generate the items schema, recursing into nested
                         // collections so e.g. Vec<Vec<i32>> keeps its inner items
-                        let items_expr = generate_array_items_schema(inner_type, &struct_name_str);
+                        let items_expr = generate_array_items_schema(inner_type);
                         quote! {
                             // Create property for this array field
                             let mut props = ::serde_json::Map::new();
@@ -167,19 +160,19 @@ pub fn generate_struct_schema(
                         &field.ty
                     };
                     if let Some((key_ty, val_ty)) = get_map_types(actual_type) {
-                        // Use SchemaType::schema() for all value types to get complete schema
+                        // Use the shared schema context for all value types.
                         // This ensures arrays get proper `items`, objects get properties, etc.
                         // For enum keys, extract the enum variants and add them to description
                         // so that Gemini can use the correct keys instead of generic placeholders
                         quote! {
                             let mut props = ::serde_json::Map::new();
                             props.insert("type".to_string(), ::serde_json::Value::String("object".to_string()));
-                            let value_schema = <#val_ty as ::rstructor::schema::SchemaType>::schema();
-                            props.insert("additionalProperties".to_string(), value_schema.to_json());
+                            let value_schema = <#val_ty as ::rstructor::schema::SchemaType>::schema_in(__rstructor_context);
+                            props.insert("additionalProperties".to_string(), value_schema);
 
                             // Try to extract enum keys from key type schema (for enum keys)
-                            let key_schema = <#key_ty as ::rstructor::schema::SchemaType>::schema();
-                            if let Some(enum_values) = key_schema.to_json().get("enum")
+                            let key_schema = <#key_ty as ::rstructor::schema::SchemaType>::schema_in(__rstructor_context);
+                            if let Some(enum_values) = key_schema.get("enum")
                                 .and_then(|e| e.as_array())
                             {
                                 let keys: Vec<String> = enum_values
@@ -216,22 +209,11 @@ pub fn generate_struct_schema(
                     };
                     if let Some(inner_ty) = get_box_inner_type(actual_type) {
                         let inner_schema_type = get_schema_type_from_rust_type(inner_ty);
-                        if is_self_reference(inner_ty, &struct_name_str) {
-                            // Self-referential type (e.g. Option<Box<Self>>): use $ref
-                            // to prevent infinite recursion at schema() time, mirroring
-                            // the guard in the array branch. The root schema places the
-                            // struct's definition under $defs in this case.
-                            quote! {
-                                let mut props = ::serde_json::Map::new();
-                                props.insert("$ref".to_string(),
-                                    ::serde_json::Value::String(format!("#/$defs/{}", #struct_name_str)));
-                            }
-                        } else if inner_schema_type == "object" {
+                        if inner_schema_type == "object" {
                             // Inner type is a complex type, use its schema
                             quote! {
-                                let nested_schema = <#inner_ty as ::rstructor::schema::SchemaType>::schema();
-                                let props_json = nested_schema.to_json();
-                                let mut props = if let ::serde_json::Value::Object(m) = props_json {
+                                let nested_schema = <#inner_ty as ::rstructor::schema::SchemaType>::schema_in(__rstructor_context);
+                                let mut props = if let ::serde_json::Value::Object(m) = nested_schema {
                                     m
                                 } else {
                                     let mut m = ::serde_json::Map::new();
@@ -271,7 +253,7 @@ pub fn generate_struct_schema(
                                 let elem_schema_type = get_schema_type_from_rust_type(elem_ty);
                                 if elem_schema_type == "object" {
                                     quote! {
-                                        <#elem_ty as ::rstructor::schema::SchemaType>::schema().to_json()
+                                        <#elem_ty as ::rstructor::schema::SchemaType>::schema_in(__rstructor_context)
                                     }
                                 } else {
                                     quote! {
@@ -308,8 +290,7 @@ pub fn generate_struct_schema(
                     };
                     quote! {
                         // Get the nested type's schema directly
-                        let nested_schema = <#actual_type as ::rstructor::schema::SchemaType>::schema();
-                        let props_json = nested_schema.to_json();
+                        let props_json = <#actual_type as ::rstructor::schema::SchemaType>::schema_in(__rstructor_context);
                         // Convert to a mutable map so we can add to it
                         let mut props = if let ::serde_json::Value::Object(m) = props_json {
                             m
@@ -437,58 +418,29 @@ pub fn generate_struct_schema(
     };
 
     // Emit a generics-aware impl: every type parameter is additionally bound
-    // by SchemaType, since the generated code calls <T as SchemaType>::schema()
+    // by SchemaType, since the generated code composes each nested T's schema.
     // for type-parameter fields.
     let schema_generics = generics_with_bounds(
         generics,
-        &[syn::parse_quote!(::rstructor::schema::SchemaType)],
+        &[
+            syn::parse_quote!(::rstructor::schema::SchemaType),
+            syn::parse_quote!('static),
+        ],
     );
     let (impl_generics, ty_generics, where_clause) = schema_generics.split_for_impl();
 
-    // Generate implementation with $defs support for recursive types
-    if has_self_reference {
-        Ok(quote! {
-            impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
-                fn schema() -> ::rstructor::schema::Schema {
-                    // Create base schema object (properties will be added to $defs)
-                    let mut schema_obj = ::serde_json::json!({
-                        "type": "object",
-                        "title": stringify!(#name),
-                        "properties": {}
-                    });
-
-                    // Add container attributes if available
-                    #container_setter
-
-                    // Fill properties
-                    #(#property_setters)*
-
-                    // Add required fields
-                    let mut required = Vec::new();
-                    #(#required_setters)*
-                    schema_obj["required"] = ::serde_json::Value::Array(required);
-
-                    // Create root schema with $defs for recursive types
-                    let struct_name = stringify!(#name);
-                    let root_schema = ::serde_json::json!({
-                        "$defs": {
-                            struct_name: schema_obj
-                        },
-                        "$ref": format!("#/$defs/{}", struct_name)
-                    });
-
-                    ::rstructor::schema::Schema::new(root_schema)
-                }
-
-                fn schema_name() -> Option<String> {
-                    Some(stringify!(#name).to_string())
-                }
+    Ok(quote! {
+        impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
+            fn schema() -> ::rstructor::schema::Schema {
+                let mut context = ::rstructor::schema::__private::SchemaBuildContext::new();
+                let root = <Self as ::rstructor::schema::SchemaType>::schema_in(&mut context);
+                ::rstructor::schema::Schema::new(context.finish(root))
             }
-        })
-    } else {
-        Ok(quote! {
-            impl #impl_generics ::rstructor::schema::SchemaType for #name #ty_generics #where_clause {
-                fn schema() -> ::rstructor::schema::Schema {
+
+            fn schema_in(
+                __rstructor_context: &mut ::rstructor::schema::__private::SchemaBuildContext
+            ) -> ::serde_json::Value {
+                __rstructor_context.schema_for::<Self, _>(stringify!(#name), |__rstructor_context| {
                     // Create base schema object
                     let mut schema_obj = ::serde_json::json!({
                         "type": "object",
@@ -507,15 +459,15 @@ pub fn generate_struct_schema(
                     #(#required_setters)*
                     schema_obj["required"] = ::serde_json::Value::Array(required);
 
-                    ::rstructor::schema::Schema::new(schema_obj)
-                }
-
-                fn schema_name() -> Option<String> {
-                    Some(stringify!(#name).to_string())
-                }
+                    schema_obj
+                })
             }
-        })
-    }
+
+            fn schema_name() -> Option<String> {
+                Some(stringify!(#name).to_string())
+            }
+        }
+    })
 }
 
 /// Generate an expression evaluating to the sniffed fallback schema for a
@@ -553,14 +505,14 @@ fn sniffed_fallback_schema(is_datetime: bool, is_date_only: bool) -> TokenStream
 /// array whose element type is `inner_type`.
 ///
 /// Recurses into nested collections (`Vec<Vec<i32>>`, `Vec<HashSet<String>>`,
-/// ...) so every nesting level carries its own `items` schema, and emits a
-/// `$ref` for self-referential element types to prevent infinite recursion.
-fn generate_array_items_schema(inner_type: &Type, struct_name_str: &str) -> TokenStream {
+/// ...) so every nesting level carries its own `items` schema. Complex element
+/// types share the build context, which emits references when it finds a cycle.
+fn generate_array_items_schema(inner_type: &Type) -> TokenStream {
     // Nested collections: recurse so the inner `items` schema is preserved
     if is_array_type(inner_type)
         && let Some(next_inner) = get_array_inner_type(inner_type)
     {
-        let nested_items = generate_array_items_schema(next_inner, struct_name_str);
+        let nested_items = generate_array_items_schema(next_inner);
         return quote! {
             {
                 let mut items_schema = ::serde_json::Map::new();
@@ -568,16 +520,6 @@ fn generate_array_items_schema(inner_type: &Type, struct_name_str: &str) -> Toke
                 items_schema.insert("items".to_string(), #nested_items);
                 ::serde_json::Value::Object(items_schema)
             }
-        };
-    }
-
-    // Self-referential element types use $ref to prevent infinite recursion.
-    // This must run before the well-known-name sniff below: a recursive
-    // struct that happens to be named `Date` must still get a $ref, not a
-    // probe that would call its own schema() and never terminate.
-    if is_self_reference(inner_type, struct_name_str) {
-        return quote! {
-            ::serde_json::json!({ "$ref": format!("#/$defs/{}", #struct_name_str) })
         };
     }
 
@@ -598,9 +540,9 @@ fn generate_array_items_schema(inner_type: &Type, struct_name_str: &str) -> Toke
         return quote! {
             {
                 #[allow(unused_imports)]
-                use ::rstructor::schema::__private::SchemaProbeFallback as _;
+                use ::rstructor::schema::__private::SchemaProbeContextFallback as _;
                 ::rstructor::schema::__private::SchemaProbe::<#inner_type>::new()
-                    .rstructor_schema_or(#fallback)
+                    .rstructor_schema_in_or(__rstructor_context, #fallback)
             }
         };
     }
@@ -611,7 +553,7 @@ fn generate_array_items_schema(inner_type: &Type, struct_name_str: &str) -> Toke
         // type's schema directly. This requires the inner type to implement
         // SchemaType.
         quote! {
-            <#inner_type as ::rstructor::schema::SchemaType>::schema().to_json()
+            <#inner_type as ::rstructor::schema::SchemaType>::schema_in(__rstructor_context)
         }
     } else {
         // Standard handling for primitive types

--- a/rstructor_derive/src/lib.rs
+++ b/rstructor_derive/src/lib.rs
@@ -221,6 +221,7 @@ fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
             syn::parse_quote!(::rstructor::schema::SchemaType),
             syn::parse_quote!(::serde::Serialize),
             syn::parse_quote!(::serde::de::DeserializeOwned),
+            syn::parse_quote!('static),
         ],
     );
     let (impl_generics, ty_generics, where_clause) = instructor_generics.split_for_impl();

--- a/rstructor_derive/src/lib.rs
+++ b/rstructor_derive/src/lib.rs
@@ -215,15 +215,15 @@ fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     // supertraits, so for generic types every type parameter must be bound by
     // those traits for the impl to typecheck (mirroring serde's own derive,
     // which bounds type parameters by `Serialize`/`Deserialize`).
-    let instructor_generics = type_utils::generics_with_bounds(
-        &input.generics,
-        &[
-            syn::parse_quote!(::rstructor::schema::SchemaType),
-            syn::parse_quote!(::serde::Serialize),
-            syn::parse_quote!(::serde::de::DeserializeOwned),
-            syn::parse_quote!('static),
-        ],
-    );
+    let mut instructor_bounds = vec![
+        syn::parse_quote!(::rstructor::schema::SchemaType),
+        syn::parse_quote!(::serde::Serialize),
+        syn::parse_quote!(::serde::de::DeserializeOwned),
+    ];
+    if input.generics.lifetimes().next().is_none() {
+        instructor_bounds.push(syn::parse_quote!('static));
+    }
+    let instructor_generics = type_utils::generics_with_bounds(&input.generics, &instructor_bounds);
     let (impl_generics, ty_generics, where_clause) = instructor_generics.split_for_impl();
     let instructor_impl = quote::quote! {
         impl #impl_generics ::rstructor::model::Instructor for #name #ty_generics #where_clause {

--- a/rstructor_derive/src/type_utils.rs
+++ b/rstructor_derive/src/type_utils.rs
@@ -341,47 +341,11 @@ pub fn get_tuple_element_types(ty: &Type) -> Option<Vec<&Type>> {
     None
 }
 
-/// Get the final type name after unwrapping Option and Box
-/// Returns the core type name for detecting self-references
-pub fn get_core_type_name(ty: &Type) -> Option<String> {
-    if let Type::Path(type_path) = ty {
-        if let Some(segment) = type_path.path.segments.last() {
-            let type_name = segment.ident.to_string();
-            match type_name.as_str() {
-                "Option" | "Box" => {
-                    // Unwrap and recurse
-                    if let PathArguments::AngleBracketed(args) = &segment.arguments
-                        && let Some(GenericArgument::Type(inner_ty)) = args.args.first()
-                    {
-                        return get_core_type_name(inner_ty);
-                    }
-                }
-                "Vec" | "Array" | "HashSet" | "BTreeSet" => {
-                    // For collections, get the inner type
-                    if let PathArguments::AngleBracketed(args) = &segment.arguments
-                        && let Some(GenericArgument::Type(inner_ty)) = args.args.first()
-                    {
-                        return get_core_type_name(inner_ty);
-                    }
-                }
-                _ => return Some(type_name),
-            }
-        }
-    }
-    None
-}
-
-/// Check if a type is a self-reference (matches the given struct name)
-/// Unwraps Option, Box, Vec, etc. to find the core type
-pub fn is_self_reference(ty: &Type, struct_name: &str) -> bool {
-    get_core_type_name(ty).is_some_and(|name| name == struct_name)
-}
-
 /// Clone `generics`, adding the given trait bounds to every type parameter.
 ///
-/// Used when emitting `impl` blocks for generic types: the generated schema
-/// code calls `<T as SchemaType>::schema()` for type-parameter fields, so the
-/// `SchemaType` impl needs every type parameter bound by `SchemaType` (and
+/// Used when emitting `impl` blocks for generic types: generated schemas
+/// compose type-parameter fields through `SchemaType`, so each type parameter
+/// needs a `SchemaType` bound (and
 /// the `Instructor` impl additionally by serde's traits, which `Instructor`
 /// requires as supertraits).
 pub fn generics_with_bounds(

--- a/rstructor_derive/tests/internally_tagged_tests.rs
+++ b/rstructor_derive/tests/internally_tagged_tests.rs
@@ -457,8 +457,12 @@ fn test_recursive_newtype_variant_fields_appear() {
         "recursive newtype variant should include recursive child field"
     );
     assert!(
-        root_variant["$defs"].get("RecursiveNode").is_some(),
-        "recursive definitions should be preserved for nested $ref values"
+        schema["$defs"].get("RecursiveNode").is_some(),
+        "recursive definitions should be hoisted to the document root so nested $ref values resolve"
+    );
+    assert!(
+        root_variant.get("$defs").is_none(),
+        "nested definitions would not be document-root JSON Pointer targets"
     );
 
     let required: Vec<&str> = root_variant["required"]

--- a/rstructor_derive/tests/schema_identity_recursion_tests.rs
+++ b/rstructor_derive/tests/schema_identity_recursion_tests.rs
@@ -882,18 +882,23 @@ struct ManualDeskTree {
 impl SchemaType for ManualDeskTree {
     fn schema() -> rstructor::Schema {
         rstructor::Schema::new(json!({
-            "type": "object",
-            "title": "ManualDeskTree",
-            "properties": {
-                "desk": {"type": "string"},
-                "child": {
-                    "anyOf": [
-                        {"$ref": "#"},
-                        {"type": "null"}
-                    ]
+            "title": "Node",
+            "$ref": "#/$defs/Node",
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {
+                        "desk": {"type": "string"},
+                        "child": {
+                            "anyOf": [
+                                {"$ref": "#"},
+                                {"type": "null"}
+                            ]
+                        }
+                    },
+                    "required": ["desk"]
                 }
-            },
-            "required": ["desk"]
+            }
         }))
     }
 }
@@ -912,8 +917,17 @@ fn embedded_manual_root_references_keep_their_original_scope() {
     let hierarchy_reference = schema["properties"]["hierarchy"]["$ref"]
         .as_str()
         .expect("embedded manual root reference");
-    let hierarchy =
+    let hierarchy_root =
         resolve_local_ref(&schema, hierarchy_reference).expect("embedded manual root definition");
+    assert_eq!(
+        hierarchy_root["title"], "Node",
+        "embedded-root sibling constraints must remain on the wrapper"
+    );
+    let node_reference = hierarchy_root["$ref"]
+        .as_str()
+        .expect("manual root's local Node reference");
+    let hierarchy =
+        resolve_local_ref(&schema, node_reference).expect("hoisted manual Node definition");
     assert!(
         hierarchy["properties"]["child"]["anyOf"]
             .as_array()

--- a/rstructor_derive/tests/schema_identity_recursion_tests.rs
+++ b/rstructor_derive/tests/schema_identity_recursion_tests.rs
@@ -1,0 +1,1033 @@
+#![allow(dead_code)]
+#![allow(clippy::vec_box)]
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::env;
+use std::process::Command;
+use std::thread;
+
+use rstructor::{Instructor, SchemaType};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+const CONTRACT_CHILD_ENV: &str = "RSTRUCTOR_SCHEMA_GRAPH_CONTRACT_CHILD";
+
+/// Assert that the schema is a closed, minimal local-reference graph:
+///
+/// - every local `$ref` resolves from the schema document root; and
+/// - every `$defs`/`definitions` entry is reachable from the emitted root.
+///
+/// The reachability walk deliberately does not treat merely being present below
+/// `$defs` as use. A definition becomes live only when a reachable schema node
+/// references it.
+#[track_caller]
+fn assert_schema_graph_integrity(schema: &Value) {
+    if let Some(definitions) = schema.get("$defs").and_then(Value::as_object) {
+        for key in definitions.keys() {
+            assert!(
+                key.bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.')),
+                "definition key {key:?} is not URI-fragment safe"
+            );
+        }
+    }
+
+    let definitions = collect_definitions(schema);
+    let all_refs = collect_local_refs(schema, true);
+
+    for reference in &all_refs {
+        assert!(
+            resolve_local_ref(schema, reference).is_some(),
+            "local reference {reference:?} does not resolve in schema:\n{schema:#}"
+        );
+    }
+
+    let mut pending: VecDeque<String> = collect_local_refs(schema, false).into_iter().collect();
+    let mut visited_refs = BTreeSet::new();
+    let mut used_definitions = BTreeSet::new();
+
+    while let Some(reference) = pending.pop_front() {
+        if !visited_refs.insert(reference.clone()) {
+            continue;
+        }
+
+        let target = resolve_local_ref(schema, &reference).unwrap_or_else(|| {
+            panic!("local reference {reference:?} does not resolve in schema:\n{schema:#}")
+        });
+
+        for definition_pointer in definitions.keys() {
+            if reference == *definition_pointer
+                || reference
+                    .strip_prefix(definition_pointer.as_str())
+                    .is_some_and(|suffix| suffix.starts_with('/'))
+            {
+                used_definitions.insert(definition_pointer.clone());
+            }
+        }
+
+        pending.extend(collect_local_refs(target, false));
+    }
+
+    let unused: Vec<_> = definitions
+        .keys()
+        .filter(|pointer| !used_definitions.contains(*pointer))
+        .cloned()
+        .collect();
+    assert!(
+        unused.is_empty(),
+        "schema contains unreachable definitions {unused:?}:\n{schema:#}"
+    );
+}
+
+fn collect_definitions(schema: &Value) -> BTreeMap<String, &Value> {
+    fn visit<'a>(
+        value: &'a Value,
+        path: &mut Vec<String>,
+        definitions: &mut BTreeMap<String, &'a Value>,
+    ) {
+        let Some(object) = value.as_object() else {
+            return;
+        };
+
+        for keyword in ["$defs", "definitions"] {
+            if let Some(entries) = object.get(keyword).and_then(Value::as_object) {
+                for (name, definition) in entries {
+                    path.push(keyword.to_string());
+                    path.push(name.clone());
+                    definitions.insert(json_pointer(path), definition);
+                    visit(definition, path, definitions);
+                    path.pop();
+                    path.pop();
+                }
+            }
+        }
+
+        for (key, child) in object {
+            if key == "$defs" || key == "definitions" {
+                continue;
+            }
+            path.push(key.clone());
+            visit(child, path, definitions);
+            path.pop();
+        }
+    }
+
+    let mut definitions = BTreeMap::new();
+    visit(schema, &mut Vec::new(), &mut definitions);
+    definitions
+}
+
+fn collect_local_refs(value: &Value, include_definitions: bool) -> BTreeSet<String> {
+    fn visit(value: &Value, include_definitions: bool, references: &mut BTreeSet<String>) {
+        match value {
+            Value::Object(object) => {
+                if let Some(reference) = object.get("$ref").and_then(Value::as_str)
+                    && reference.starts_with('#')
+                {
+                    references.insert(reference.to_string());
+                }
+
+                for (key, child) in object {
+                    if !include_definitions && (key == "$defs" || key == "definitions") {
+                        continue;
+                    }
+                    visit(child, include_definitions, references);
+                }
+            }
+            Value::Array(values) => {
+                for child in values {
+                    visit(child, include_definitions, references);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut references = BTreeSet::new();
+    visit(value, include_definitions, &mut references);
+    references
+}
+
+fn resolve_local_ref<'a>(schema: &'a Value, reference: &str) -> Option<&'a Value> {
+    if reference == "#" {
+        return Some(schema);
+    }
+
+    reference
+        .strip_prefix('#')
+        .and_then(|pointer| schema.pointer(pointer))
+}
+
+fn json_pointer(path: &[String]) -> String {
+    let escaped = path
+        .iter()
+        .map(|segment| segment.replace('~', "~0").replace('/', "~1"))
+        .collect::<Vec<_>>()
+        .join("/");
+    format!("#/{escaped}")
+}
+
+fn schema_contains_property(schema: &Value, property: &str) -> bool {
+    match schema {
+        Value::Object(object) => {
+            object
+                .get("properties")
+                .and_then(Value::as_object)
+                .is_some_and(|properties| properties.contains_key(property))
+                || object
+                    .values()
+                    .any(|value| schema_contains_property(value, property))
+        }
+        Value::Array(values) => values
+            .iter()
+            .any(|value| schema_contains_property(value, property)),
+        _ => false,
+    }
+}
+
+fn find_tagged_variant<'a>(
+    schema: &'a Value,
+    tag_name: &str,
+    variant_name: &str,
+) -> Option<&'a Value> {
+    match schema {
+        Value::Object(object) => {
+            let is_match = object
+                .get("properties")
+                .and_then(Value::as_object)
+                .and_then(|properties| properties.get(tag_name))
+                .and_then(|tag| tag.get("enum"))
+                .and_then(Value::as_array)
+                .is_some_and(|values| {
+                    values
+                        .iter()
+                        .any(|value| value.as_str() == Some(variant_name))
+                });
+            if is_match {
+                return Some(schema);
+            }
+            object
+                .values()
+                .find_map(|child| find_tagged_variant(child, tag_name, variant_name))
+        }
+        Value::Array(values) => values
+            .iter()
+            .find_map(|child| find_tagged_variant(child, tag_name, variant_name)),
+        _ => None,
+    }
+}
+
+fn find_property_schema<'a>(schema: &'a Value, property: &str) -> Option<&'a Value> {
+    match schema {
+        Value::Object(object) => {
+            if let Some(property_schema) = object
+                .get("properties")
+                .and_then(Value::as_object)
+                .and_then(|properties| properties.get(property))
+            {
+                return Some(property_schema);
+            }
+
+            object
+                .values()
+                .find_map(|value| find_property_schema(value, property))
+        }
+        Value::Array(values) => values
+            .iter()
+            .find_map(|value| find_property_schema(value, property)),
+        _ => None,
+    }
+}
+
+fn count_object_key(value: &Value, key: &str) -> usize {
+    match value {
+        Value::Object(object) => {
+            usize::from(object.contains_key(key))
+                + object
+                    .values()
+                    .map(|child| count_object_key(child, key))
+                    .sum::<usize>()
+        }
+        Value::Array(values) => values
+            .iter()
+            .map(|child| count_object_key(child, key))
+            .sum(),
+        _ => 0,
+    }
+}
+
+fn definitions_with_property(schema: &Value, property: &str) -> Vec<String> {
+    collect_definitions(schema)
+        .into_iter()
+        .filter_map(|(pointer, definition)| {
+            definition
+                .get("properties")
+                .and_then(Value::as_object)
+                .is_some_and(|properties| properties.contains_key(property))
+                .then_some(pointer)
+        })
+        .collect()
+}
+
+fn definition_property_types(schema: &Value, property: &str) -> BTreeMap<String, String> {
+    collect_definitions(schema)
+        .into_iter()
+        .filter_map(|(pointer, definition)| {
+            let property_type = definition
+                .get("properties")?
+                .get(property)?
+                .get("type")?
+                .as_str()?;
+            Some((pointer, property_type.to_string()))
+        })
+        .collect()
+}
+
+/// Run contracts that intentionally exercise a recursive cycle in a child
+/// process. The pre-fix stack overflow then becomes an ordinary assertion
+/// failure instead of aborting every test in this integration-test binary.
+fn run_recursive_contract(test_name: &str, contract: fn()) {
+    if env::var(CONTRACT_CHILD_ENV).as_deref() == Ok(test_name) {
+        contract();
+        return;
+    }
+
+    let output = Command::new(env::current_exe().expect("resolve integration-test executable"))
+        .arg("--exact")
+        .arg(test_name)
+        .arg("--nocapture")
+        .env(CONTRACT_CHILD_ENV, test_name)
+        .output()
+        .expect("run recursive schema contract in child process");
+
+    assert!(
+        output.status.success(),
+        "recursive schema contract {test_name:?} failed with {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+struct OrderRevision {
+    order_id: String,
+    version: u32,
+    previous: Option<Box<OrderRevision>>,
+}
+
+#[test]
+fn direct_recursion_preserves_the_existing_defs_and_ref_contract() {
+    let schema = OrderRevision::schema().to_json();
+
+    assert_schema_graph_integrity(&schema);
+    assert_eq!(schema["$ref"], "#/$defs/OrderRevision");
+    assert_eq!(
+        schema["$defs"]["OrderRevision"]["properties"]["previous"]["$ref"],
+        "#/$defs/OrderRevision"
+    );
+    assert_eq!(
+        schema["$defs"]["OrderRevision"]["properties"]["version"]["type"],
+        "integer"
+    );
+
+    let decoded: OrderRevision = serde_json::from_value(json!({
+        "order_id": "ORD-20260728-0042",
+        "version": 2,
+        "previous": {
+            "order_id": "ORD-20260728-0042",
+            "version": 1,
+            "previous": null
+        }
+    }))
+    .expect("a finite order-revision chain must deserialize");
+    assert_eq!(decoded.version, 2);
+    assert_eq!(decoded.previous.expect("prior revision").version, 1);
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+struct ManagedFund {
+    fund_lei: String,
+    nav_usd_cents: i64,
+    prime_broker: Option<Box<PrimeBrokerRelationship>>,
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+struct PrimeBrokerRelationship {
+    broker_lei: String,
+    sponsored_funds: Vec<ManagedFund>,
+}
+
+fn struct_to_struct_contract() {
+    let schema = ManagedFund::schema().to_json();
+
+    assert_schema_graph_integrity(&schema);
+    assert!(schema_contains_property(&schema, "fund_lei"));
+    assert!(schema_contains_property(&schema, "broker_lei"));
+    assert!(
+        !definitions_with_property(&schema, "fund_lei").is_empty(),
+        "the fund type must have a graph definition:\n{schema:#}"
+    );
+    assert!(
+        !definitions_with_property(&schema, "broker_lei").is_empty(),
+        "the prime-broker type must have a graph definition:\n{schema:#}"
+    );
+
+    let decoded: ManagedFund = serde_json::from_value(json!({
+        "fund_lei": "5493001KJTIIGC8Y1R12",
+        "nav_usd_cents": 12_575_000_000_i64,
+        "prime_broker": {
+            "broker_lei": "7H6GLXDRUGQFU57RNE97",
+            "sponsored_funds": []
+        }
+    }))
+    .expect("a finite fund/prime-broker graph must deserialize");
+    assert_eq!(
+        decoded.prime_broker.expect("prime broker").sponsored_funds,
+        Vec::<ManagedFund>::new()
+    );
+}
+
+#[test]
+fn struct_to_struct_mutual_recursion_is_a_closed_schema_graph() {
+    run_recursive_contract(
+        "struct_to_struct_mutual_recursion_is_a_closed_schema_graph",
+        struct_to_struct_contract,
+    );
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+struct AllocationNode {
+    sleeve_id: String,
+    transition: Option<Box<AllocationTransition>>,
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+enum AllocationTransition {
+    Hold,
+    Rebalance {
+        target_weight_bps: i32,
+        destination: Box<AllocationNode>,
+    },
+}
+
+fn struct_to_enum_contract() {
+    let schema = AllocationNode::schema().to_json();
+
+    assert_schema_graph_integrity(&schema);
+    assert!(schema_contains_property(&schema, "sleeve_id"));
+    assert!(schema_contains_property(&schema, "transition"));
+    assert!(schema_contains_property(&schema, "target_weight_bps"));
+    assert!(schema_contains_property(&schema, "destination"));
+
+    let decoded: AllocationNode = serde_json::from_value(json!({
+        "sleeve_id": "GLOBAL-MACRO",
+        "transition": {
+            "Rebalance": {
+                "target_weight_bps": 3_500,
+                "destination": {
+                    "sleeve_id": "UST-DURATION",
+                    "transition": "Hold"
+                }
+            }
+        }
+    }))
+    .expect("a finite allocation/transition graph must deserialize");
+    assert_eq!(decoded.sleeve_id, "GLOBAL-MACRO");
+}
+
+#[test]
+fn struct_to_enum_mutual_recursion_is_a_closed_schema_graph() {
+    run_recursive_contract(
+        "struct_to_enum_mutual_recursion_is_a_closed_schema_graph",
+        struct_to_enum_contract,
+    );
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+enum OrderLifecycle {
+    Accepted {
+        order_id: String,
+        next: Option<Box<SettlementLifecycle>>,
+    },
+    Rejected {
+        reason_code: String,
+    },
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+enum SettlementLifecycle {
+    Pending {
+        custodian_bic: String,
+        fallback: Box<OrderLifecycle>,
+    },
+    Settled {
+        settlement_instruction_id: String,
+    },
+}
+
+fn enum_to_enum_contract() {
+    let schema = OrderLifecycle::schema().to_json();
+
+    assert_schema_graph_integrity(&schema);
+    assert!(schema_contains_property(&schema, "order_id"));
+    assert!(schema_contains_property(&schema, "custodian_bic"));
+    assert!(schema_contains_property(&schema, "fallback"));
+    assert!(schema_contains_property(
+        &schema,
+        "settlement_instruction_id"
+    ));
+    assert!(
+        collect_definitions(&schema).len() >= 2,
+        "both enum identities must participate in the recursive graph:\n{schema:#}"
+    );
+
+    let decoded: OrderLifecycle = serde_json::from_value(json!({
+        "Accepted": {
+            "order_id": "FIX-UST-20260728-8821",
+            "next": {
+                "Pending": {
+                    "custodian_bic": "IRVTUS3N",
+                    "fallback": {
+                        "Rejected": {
+                            "reason_code": "CUSTODY_CUTOFF"
+                        }
+                    }
+                }
+            }
+        }
+    }))
+    .expect("a finite order/settlement lifecycle graph must deserialize");
+    assert!(matches!(decoded, OrderLifecycle::Accepted { .. }));
+}
+
+#[test]
+fn enum_to_enum_mutual_recursion_is_a_closed_schema_graph() {
+    run_recursive_contract(
+        "enum_to_enum_mutual_recursion_is_a_closed_schema_graph",
+        enum_to_enum_contract,
+    );
+}
+
+mod same_short_name {
+    use super::*;
+
+    pub mod cme {
+        use super::*;
+
+        #[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+        pub struct Order {
+            pub cme_order_id: String,
+            pub ice_hedge: Option<Box<super::ice::Order>>,
+        }
+    }
+
+    pub mod ice {
+        use super::*;
+
+        #[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+        pub struct Order {
+            pub ice_order_id: String,
+            pub originating_cme_order: Option<Box<super::cme::Order>>,
+        }
+    }
+}
+
+#[test]
+fn same_short_name_types_keep_distinct_schema_identities() {
+    let schema = same_short_name::cme::Order::schema().to_json();
+
+    assert_schema_graph_integrity(&schema);
+    assert!(schema_contains_property(&schema, "cme_order_id"));
+    assert!(
+        schema_contains_property(&schema, "ice_order_id"),
+        "the ICE Order must not be mistaken for CME Order merely because both have the short name `Order`:\n{schema:#}"
+    );
+
+    let cme_definitions = definitions_with_property(&schema, "cme_order_id");
+    let ice_definitions = definitions_with_property(&schema, "ice_order_id");
+    assert!(
+        !cme_definitions.is_empty() && !ice_definitions.is_empty(),
+        "both venue-specific Order types need definitions:\n{schema:#}"
+    );
+    assert!(
+        cme_definitions
+            .iter()
+            .all(|pointer| !ice_definitions.contains(pointer)),
+        "CME and ICE Order resolved to the same definition:\n{schema:#}"
+    );
+
+    let decoded: same_short_name::cme::Order = serde_json::from_value(json!({
+        "cme_order_id": "CME-ES-202609-91827",
+        "ice_hedge": {
+            "ice_order_id": "ICE-DX-202609-44102",
+            "originating_cme_order": null
+        }
+    }))
+    .expect("a finite cross-venue order graph must deserialize");
+    assert_eq!(
+        decoded.ice_hedge.expect("ICE hedge").ice_order_id,
+        "ICE-DX-202609-44102"
+    );
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+struct ConsolidatedRiskBook {
+    desks_by_code: BTreeMap<String, RiskDesk>,
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+struct RiskDesk {
+    portfolios: Vec<RiskPortfolio>,
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+struct RiskPortfolio {
+    hedge_books_by_currency: BTreeMap<String, Box<ConsolidatedRiskBook>>,
+}
+
+fn three_type_container_cycle_contract() {
+    let schema = ConsolidatedRiskBook::schema().to_json();
+
+    assert_schema_graph_integrity(&schema);
+
+    let desks = find_property_schema(&schema, "desks_by_code")
+        .expect("risk book must expose its dynamic desk map");
+    assert_eq!(desks["type"], "object");
+    assert!(
+        desks.get("additionalProperties").is_some(),
+        "desk map must describe its value type:\n{schema:#}"
+    );
+
+    let portfolios =
+        find_property_schema(&schema, "portfolios").expect("risk desk must expose portfolios");
+    assert_eq!(portfolios["type"], "array");
+    assert!(
+        portfolios.get("items").is_some(),
+        "portfolio collection must describe its item type:\n{schema:#}"
+    );
+
+    let hedge_books = find_property_schema(&schema, "hedge_books_by_currency")
+        .expect("portfolio must expose its dynamic hedge-book map");
+    assert_eq!(hedge_books["type"], "object");
+    assert!(
+        hedge_books.get("additionalProperties").is_some(),
+        "hedge-book map must describe its recursive value type:\n{schema:#}"
+    );
+    assert!(
+        collect_definitions(&schema).len() >= 3,
+        "all three concrete types must have graph identities:\n{schema:#}"
+    );
+
+    let decoded: ConsolidatedRiskBook = serde_json::from_value(json!({
+        "desks_by_code": {
+            "RATES-NY": {
+                "portfolios": [{
+                    "hedge_books_by_currency": {
+                        "JPY": {
+                            "desks_by_code": {}
+                        }
+                    }
+                }]
+            }
+        }
+    }))
+    .expect("a finite three-type market-risk graph must deserialize");
+    assert!(
+        decoded.desks_by_code["RATES-NY"].portfolios[0]
+            .hedge_books_by_currency
+            .contains_key("JPY")
+    );
+}
+
+#[test]
+fn three_type_cycle_through_maps_and_collections_is_closed() {
+    run_recursive_contract(
+        "three_type_cycle_through_maps_and_collections_is_closed",
+        three_type_container_cycle_contract,
+    );
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+struct SettlementLink {
+    link_id: String,
+    edge: SettlementEdge,
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "edge_type")]
+enum SettlementEdge {
+    Terminal { settlement_account: String },
+    Next(Box<SettlementLink>),
+}
+
+fn internally_tagged_recursive_newtype_contract() {
+    let schema = SettlementLink::schema().to_json();
+
+    assert_schema_graph_integrity(&schema);
+    assert!(
+        !serde_json::to_string(&schema)
+            .expect("schema serialization")
+            .contains("__rstructor_deferred_flatten"),
+        "private deferred-flatten markers must never escape schema generation:\n{schema:#}"
+    );
+
+    let next = find_tagged_variant(&schema, "edge_type", "Next")
+        .expect("recursive internally tagged Next variant");
+    let properties = next["properties"]
+        .as_object()
+        .expect("Next variant properties");
+    assert!(properties.contains_key("edge_type"));
+    assert!(
+        properties.contains_key("link_id"),
+        "the active recursive inner struct must be flattened after graph completion:\n{schema:#}"
+    );
+    assert!(
+        properties.contains_key("edge"),
+        "recursive inner fields must not be silently dropped:\n{schema:#}"
+    );
+
+    let decoded: SettlementLink = serde_json::from_value(json!({
+        "link_id": "ALLOC-20260728-001",
+        "edge": {
+            "edge_type": "Next",
+            "link_id": "ALLOC-20260728-002",
+            "edge": {
+                "edge_type": "Terminal",
+                "settlement_account": "DTC-00001234"
+            }
+        }
+    }))
+    .expect("a finite recursive settlement link must deserialize");
+    assert!(matches!(decoded.edge, SettlementEdge::Next(_)));
+}
+
+#[test]
+fn internally_tagged_recursive_newtype_keeps_flattened_fields() {
+    run_recursive_contract(
+        "internally_tagged_recursive_newtype_keeps_flattened_fields",
+        internally_tagged_recursive_newtype_contract,
+    );
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct ManualFixedIncomeLeg {
+    cusip: String,
+}
+
+impl SchemaType for ManualFixedIncomeLeg {
+    fn schema() -> rstructor::Schema {
+        rstructor::Schema::new(json!({
+            "$ref": "#/$defs/InstrumentLeg",
+            "$defs": {
+                "InstrumentLeg": {
+                    "type": "object",
+                    "properties": {
+                        "cusip": {"type": "string"}
+                    },
+                    "required": ["cusip"]
+                }
+            }
+        }))
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct ManualEquityLeg {
+    ticker: String,
+}
+
+impl SchemaType for ManualEquityLeg {
+    fn schema() -> rstructor::Schema {
+        rstructor::Schema::new(json!({
+            "$ref": "#/$defs/InstrumentLeg",
+            "$defs": {
+                "InstrumentLeg": {
+                    "type": "object",
+                    "properties": {
+                        "ticker": {"type": "string"}
+                    },
+                    "required": ["ticker"]
+                }
+            }
+        }))
+    }
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+struct ManualMultiAssetTrade {
+    bond: ManualFixedIncomeLeg,
+    equity: ManualEquityLeg,
+}
+
+#[test]
+fn manual_schema_defs_are_hoisted_and_collisions_are_rewritten() {
+    let schema = ManualMultiAssetTrade::schema().to_json();
+
+    assert_schema_graph_integrity(&schema);
+    assert_eq!(
+        count_object_key(&schema, "$defs"),
+        1,
+        "manual definitions must be hoisted to the document root:\n{schema:#}"
+    );
+    let definitions = schema["$defs"]
+        .as_object()
+        .expect("hoisted manual definitions");
+    assert_eq!(definitions.len(), 2);
+    assert!(
+        definitions
+            .values()
+            .any(|definition| schema_contains_property(definition, "cusip"))
+    );
+    assert!(
+        definitions
+            .values()
+            .any(|definition| schema_contains_property(definition, "ticker"))
+    );
+
+    let bond_ref = schema["properties"]["bond"]["$ref"]
+        .as_str()
+        .expect("bond reference");
+    let equity_ref = schema["properties"]["equity"]["$ref"]
+        .as_str()
+        .expect("equity reference");
+    assert_ne!(
+        bond_ref, equity_ref,
+        "different manual schemas sharing a local definition name must not collapse"
+    );
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+struct ScenarioNode<T> {
+    shock: T,
+    children: Vec<Box<ScenarioNode<T>>>,
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+struct CrossAssetScenarioBook {
+    rates_bps: ScenarioNode<i64>,
+    volatility_regime: ScenarioNode<String>,
+}
+
+fn generic_identity_contract() {
+    let schema = CrossAssetScenarioBook::schema().to_json();
+
+    assert_schema_graph_integrity(&schema);
+    let shock_types = definition_property_types(&schema, "shock");
+    assert!(
+        shock_types.values().any(|kind| kind == "integer"),
+        "ScenarioNode<i64> needs an integer-valued definition:\n{schema:#}"
+    );
+    assert!(
+        shock_types.values().any(|kind| kind == "string"),
+        "ScenarioNode<String> needs a string-valued definition:\n{schema:#}"
+    );
+    assert!(
+        shock_types.len() >= 2,
+        "generic instantiations must not collapse onto one definition identity:\n{schema:#}"
+    );
+
+    let decoded: CrossAssetScenarioBook = serde_json::from_value(json!({
+        "rates_bps": {
+            "shock": -75,
+            "children": [
+                {"shock": 25, "children": []}
+            ]
+        },
+        "volatility_regime": {
+            "shock": "VOLMAGEDDON",
+            "children": [
+                {"shock": "NORMALIZATION", "children": []}
+            ]
+        }
+    }))
+    .expect("distinct finite generic scenario graphs must deserialize");
+    assert_eq!(decoded.rates_bps.children[0].shock, 25);
+    assert_eq!(decoded.volatility_regime.children[0].shock, "NORMALIZATION");
+}
+
+#[test]
+fn generic_instantiations_keep_distinct_schema_identities() {
+    run_recursive_contract(
+        "generic_instantiations_keep_distinct_schema_identities",
+        generic_identity_contract,
+    );
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+struct PositionTree {
+    position_id: String,
+    children: Vec<Box<PositionTree>>,
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+struct PortfolioSnapshot {
+    portfolio_id: String,
+    root_position: PositionTree,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct ManualPositionWrapper {
+    root: PositionTree,
+}
+
+impl SchemaType for ManualPositionWrapper {
+    fn schema() -> rstructor::Schema {
+        rstructor::Schema::new(json!({
+            "type": "object",
+            "properties": {
+                "root": PositionTree::schema().to_json()
+            },
+            "required": ["root"]
+        }))
+    }
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+struct WrappedPortfolioSnapshot {
+    portfolio_id: String,
+    positions: ManualPositionWrapper,
+}
+
+#[test]
+fn acyclic_parent_hoists_recursive_child_defs_to_the_document_root() {
+    let schema = PortfolioSnapshot::schema().to_json();
+
+    assert_schema_graph_integrity(&schema);
+    assert!(
+        schema.get("$defs").is_some(),
+        "the recursive child definition must be attached at the document root:\n{schema:#}"
+    );
+    assert_eq!(
+        count_object_key(&schema, "$defs"),
+        1,
+        "recursive child definitions must not remain nested under a property:\n{schema:#}"
+    );
+
+    let root_position =
+        find_property_schema(&schema, "root_position").expect("snapshot root position");
+    assert!(
+        root_position.get("$ref").is_some(),
+        "the acyclic parent must reference the hoisted recursive child:\n{schema:#}"
+    );
+
+    let decoded: PortfolioSnapshot = serde_json::from_value(json!({
+        "portfolio_id": "MASTER-FUND-USD",
+        "root_position": {
+            "position_id": "UST-10Y-SWAP",
+            "children": [{
+                "position_id": "SOFR-HEDGE",
+                "children": []
+            }]
+        }
+    }))
+    .expect("a finite portfolio position tree must deserialize");
+    assert_eq!(decoded.root_position.children[0].position_id, "SOFR-HEDGE");
+}
+
+#[test]
+fn manual_wrapper_hoists_nested_derived_recursive_defs() {
+    let schema = WrappedPortfolioSnapshot::schema().to_json();
+
+    assert_schema_graph_integrity(&schema);
+    assert_eq!(
+        count_object_key(&schema, "$defs"),
+        1,
+        "recursive definitions nested inside a manual wrapper must be hoisted:\n{schema:#}"
+    );
+    assert!(
+        find_property_schema(&schema, "root")
+            .and_then(|root| root.get("$ref"))
+            .is_some(),
+        "the manual wrapper must retain its reference to the hoisted position tree:\n{schema:#}"
+    );
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "SCREAMING-KEBAB-CASE", deserialize = "camelCase"))]
+struct RegulatoryFiling {
+    filing_id: String,
+
+    #[serde(rename(serialize = "NOTIONAL-USD-CENTS", deserialize = "notionalCents"))]
+    notional_usd_cents: i64,
+
+    #[serde(skip_deserializing)]
+    superseded_by: Option<Box<RegulatoryFiling>>,
+}
+
+#[test]
+fn directional_rename_and_skipped_recursive_edge_emit_no_unused_definition() {
+    let schema = RegulatoryFiling::schema().to_json();
+
+    assert_schema_graph_integrity(&schema);
+    let properties = schema["properties"]
+        .as_object()
+        .expect("regulatory filing properties");
+    assert!(properties.contains_key("filingId"));
+    assert!(properties.contains_key("notionalCents"));
+    assert!(!properties.contains_key("FILING-ID"));
+    assert!(!properties.contains_key("NOTIONAL-USD-CENTS"));
+    assert!(!properties.contains_key("supersededBy"));
+    assert!(
+        collect_definitions(&schema).is_empty(),
+        "a skipped recursive edge must not manufacture an unreachable definition:\n{schema:#}"
+    );
+    assert!(
+        collect_local_refs(&schema, true).is_empty(),
+        "a skipped recursive edge must not manufacture a reference:\n{schema:#}"
+    );
+
+    let decoded: RegulatoryFiling = serde_json::from_value(json!({
+        "filingId": "13F-2026Q2-000184",
+        "notionalCents": 8_250_000_000_i64
+    }))
+    .expect("schema-shaped regulatory filing input must deserialize");
+    assert_eq!(decoded.notional_usd_cents, 8_250_000_000);
+    assert!(decoded.superseded_by.is_none());
+}
+
+fn repeated_determinism_contract() {
+    let baseline = ManagedFund::schema().to_json();
+    assert_schema_graph_integrity(&baseline);
+
+    for iteration in 0..32 {
+        assert_eq!(
+            ManagedFund::schema().to_json(),
+            baseline,
+            "schema changed on sequential generation {iteration}"
+        );
+    }
+}
+
+#[test]
+fn repeated_generation_is_deterministic() {
+    run_recursive_contract(
+        "repeated_generation_is_deterministic",
+        repeated_determinism_contract,
+    );
+}
+
+fn concurrent_determinism_contract() {
+    let baseline = ManagedFund::schema().to_json();
+    assert_schema_graph_integrity(&baseline);
+
+    let handles: Vec<_> = (0..16)
+        .map(|_| thread::spawn(|| ManagedFund::schema().to_json()))
+        .collect();
+
+    for (worker, handle) in handles.into_iter().enumerate() {
+        assert_eq!(
+            handle.join().expect("schema worker must not panic"),
+            baseline,
+            "schema changed in concurrent worker {worker}"
+        );
+    }
+}
+
+#[test]
+fn concurrent_generation_is_deterministic() {
+    run_recursive_contract(
+        "concurrent_generation_is_deterministic",
+        concurrent_determinism_contract,
+    );
+}

--- a/rstructor_derive/tests/schema_identity_recursion_tests.rs
+++ b/rstructor_derive/tests/schema_identity_recursion_tests.rs
@@ -3,6 +3,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::env;
+use std::marker::PhantomData;
 use std::process::Command;
 use std::thread;
 
@@ -794,6 +795,156 @@ fn manual_schema_defs_are_hoisted_and_collisions_are_rewritten() {
     assert_ne!(
         bond_ref, equity_ref,
         "different manual schemas sharing a local definition name must not collapse"
+    );
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct ManualRateNode {
+    value: f64,
+}
+
+impl SchemaType for ManualRateNode {
+    fn schema() -> rstructor::Schema {
+        rstructor::Schema::new(json!({
+            "$ref": "#/$defs/Node",
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"$ref": "#/$defs/Leaf"}
+                    },
+                    "required": ["value"]
+                },
+                "Leaf": {"type": "number"}
+            }
+        }))
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct ManualCreditNode {
+    value: String,
+}
+
+impl SchemaType for ManualCreditNode {
+    fn schema() -> rstructor::Schema {
+        rstructor::Schema::new(json!({
+            "$ref": "#/$defs/Node",
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"$ref": "#/$defs/Leaf"}
+                    },
+                    "required": ["value"]
+                },
+                "Leaf": {"type": "string"}
+            }
+        }))
+    }
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+struct ManualCrossDocumentBook {
+    rate_shock: ManualRateNode,
+    credit_regime: ManualCreditNode,
+}
+
+#[test]
+fn manual_transitive_definition_collisions_do_not_cross_bind() {
+    let schema = ManualCrossDocumentBook::schema().to_json();
+
+    assert_schema_graph_integrity(&schema);
+    let leaf_type = |property: &str| {
+        let node_reference = schema["properties"][property]["$ref"]
+            .as_str()
+            .expect("manual node reference");
+        let node = resolve_local_ref(&schema, node_reference).expect("manual node definition");
+        let leaf_reference = node["properties"]["value"]["$ref"]
+            .as_str()
+            .expect("manual leaf reference");
+        resolve_local_ref(&schema, leaf_reference)
+            .and_then(|leaf| leaf.get("type"))
+            .and_then(Value::as_str)
+            .expect("manual leaf type")
+    };
+
+    assert_eq!(leaf_type("rate_shock"), "number");
+    assert_eq!(leaf_type("credit_regime"), "string");
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct ManualDeskTree {
+    desk: String,
+    child: Option<Box<ManualDeskTree>>,
+}
+
+impl SchemaType for ManualDeskTree {
+    fn schema() -> rstructor::Schema {
+        rstructor::Schema::new(json!({
+            "type": "object",
+            "title": "ManualDeskTree",
+            "properties": {
+                "desk": {"type": "string"},
+                "child": {
+                    "anyOf": [
+                        {"$ref": "#"},
+                        {"type": "null"}
+                    ]
+                }
+            },
+            "required": ["desk"]
+        }))
+    }
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+struct ManualDeskEnvelope {
+    as_of_date: String,
+    hierarchy: ManualDeskTree,
+}
+
+#[test]
+fn embedded_manual_root_references_keep_their_original_scope() {
+    let schema = ManualDeskEnvelope::schema().to_json();
+
+    assert_schema_graph_integrity(&schema);
+    let hierarchy_reference = schema["properties"]["hierarchy"]["$ref"]
+        .as_str()
+        .expect("embedded manual root reference");
+    let hierarchy =
+        resolve_local_ref(&schema, hierarchy_reference).expect("embedded manual root definition");
+    assert!(
+        hierarchy["properties"]["child"]["anyOf"]
+            .as_array()
+            .expect("nullable recursive child")
+            .iter()
+            .any(|branch| {
+                branch.get("$ref").and_then(Value::as_str) == Some(hierarchy_reference)
+            }),
+        "manual `#` must resolve to the embedded manual root, not the derived parent:\n{schema:#}"
+    );
+}
+
+#[derive(Debug, Instructor, PartialEq, Serialize, Deserialize)]
+struct BorrowedPositionTree<'a> {
+    position_id: String,
+    children: Vec<Box<BorrowedPositionTree<'a>>>,
+    #[serde(skip)]
+    marker: PhantomData<&'a ()>,
+}
+
+fn lifetime_parameterized_recursion_contract() {
+    let schema = BorrowedPositionTree::<'static>::schema().to_json();
+    assert_schema_graph_integrity(&schema);
+    assert!(schema.get("$ref").is_some());
+}
+
+#[test]
+fn lifetime_parameterized_recursive_derive_remains_supported() {
+    run_recursive_contract(
+        "lifetime_parameterized_recursive_derive_remains_supported",
+        lifetime_parameterized_recursion_contract,
     );
 }
 

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -387,7 +387,9 @@ impl GeminiClient {
 
         // Prepare schema for Gemini by stripping unsupported metadata while
         // preserving supported typed-map constraints.
-        let gemini_schema = crate::backend::utils::prepare_gemini_schema(&schema);
+        let gemini_schema =
+            crate::backend::utils::prepare_gemini_schema(&schema, "structured output")
+                .map_err(|error| (error, None))?;
         let generation_config = GenerationConfig {
             temperature: self.config.temperature,
             max_output_tokens: self.config.max_tokens,
@@ -939,7 +941,11 @@ impl LLMClient for GeminiClient {
         // final buffer can be transformed back before deserializing into `T`.
         let adjacently_tagged_info =
             crate::backend::utils::extract_adjacently_tagged_info(&schema.to_json());
-        let gemini_schema = crate::backend::utils::prepare_gemini_schema(&schema);
+        let gemini_schema =
+            match crate::backend::utils::prepare_gemini_schema(&schema, "structured output") {
+                Ok(schema) => schema,
+                Err(error) => return crate::backend::streaming::error_stream(error),
+            };
         let body = self.stream_body(prompt, Some(gemini_schema));
 
         let finalize = move |raw: &str| -> Result<T> {
@@ -973,7 +979,11 @@ impl LLMClient for GeminiClient {
         let schema = T::schema();
         let adjacently_tagged_info =
             crate::backend::utils::extract_adjacently_tagged_info(&schema.to_json());
-        let item_schema = crate::backend::utils::prepare_gemini_schema(&schema);
+        let item_schema =
+            match crate::backend::utils::prepare_gemini_schema(&schema, "streamed list item") {
+                Ok(schema) => schema,
+                Err(error) => return crate::backend::streaming::error_stream(error),
+            };
         let wrapper = crate::backend::streaming::array_wrapper_schema(item_schema, false);
         let body = self.stream_body(prompt, Some(wrapper));
 

--- a/src/backend/schema_compatibility.rs
+++ b/src/backend/schema_compatibility.rs
@@ -271,6 +271,72 @@ mod tests {
     }
 
     #[test]
+    fn mutual_recursion_definitions_receive_the_strict_transform() {
+        let canonical = schema(json!({
+            "$ref": "#/$defs/Fund",
+            "$defs": {
+                "Fund": {
+                    "type": "object",
+                    "properties": {
+                        "lei": { "type": "string" },
+                        "prime_broker": { "$ref": "#/$defs/PrimeBroker" }
+                    },
+                    "required": ["lei"]
+                },
+                "PrimeBroker": {
+                    "type": "object",
+                    "properties": {
+                        "lei": { "type": "string" },
+                        "funds": {
+                            "type": "array",
+                            "items": { "$ref": "#/$defs/Fund" }
+                        }
+                    },
+                    "required": ["lei", "funds"]
+                }
+            }
+        }));
+
+        for provider in [
+            StrictSchemaProvider::OpenAI,
+            StrictSchemaProvider::Anthropic,
+            StrictSchemaProvider::Grok,
+        ] {
+            let compiled =
+                compile_strict_schema(&canonical, provider, "mutually recursive output").unwrap();
+
+            assert_eq!(compiled["$ref"], "#/$defs/Fund");
+            assert_eq!(
+                compiled["$defs"]["Fund"]["properties"]["prime_broker"]["anyOf"][0]["$ref"],
+                "#/$defs/PrimeBroker"
+            );
+            assert_eq!(
+                compiled["$defs"]["PrimeBroker"]["properties"]["funds"]["items"]["$ref"],
+                "#/$defs/Fund"
+            );
+
+            for definition in ["Fund", "PrimeBroker"] {
+                assert_eq!(
+                    compiled["$defs"][definition]["additionalProperties"], false,
+                    "{provider} must close the {definition} definition"
+                );
+                let property_count = compiled["$defs"][definition]["properties"]
+                    .as_object()
+                    .unwrap()
+                    .len();
+                assert_eq!(
+                    compiled["$defs"][definition]["required"]
+                        .as_array()
+                        .unwrap()
+                        .len(),
+                    property_count,
+                    "{provider} must require every strict property in {definition}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn explicitly_closed_additional_properties_is_compatible() {
         let compiled = compile_strict_schema(
             &schema(json!({

--- a/src/backend/tools.rs
+++ b/src/backend/tools.rs
@@ -52,8 +52,6 @@ pub trait DynTool: Send + Sync {
     /// Provider-specific compatibility checks and transformations are applied
     /// when the toolbox is rendered for a request.
     fn parameters_schema(&self) -> Value;
-    /// The argument schema prepared for Gemini's JSON Schema transport.
-    fn parameters_schema_gemini(&self) -> Value;
     /// Invoke the tool with raw JSON arguments (deserialized into `Args`).
     async fn invoke_json(&self, args: Value) -> Result<Value>;
 }
@@ -70,10 +68,6 @@ impl<T: Tool> DynTool for T {
 
     fn parameters_schema(&self) -> Value {
         <T::Args as SchemaType>::schema().to_json()
-    }
-
-    fn parameters_schema_gemini(&self) -> Value {
-        crate::backend::utils::prepare_gemini_schema(&<T::Args as SchemaType>::schema())
     }
 
     async fn invoke_json(&self, args: Value) -> Result<Value> {
@@ -245,22 +239,30 @@ impl Toolbox {
 
     /// Render the tools as Gemini `tools` JSON (a single `functionDeclarations`).
     #[cfg(feature = "gemini")]
-    fn gemini_tools_json(&self) -> Vec<Value> {
+    fn gemini_tools_json(&self) -> Result<Vec<Value>> {
         if self.tools.is_empty() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
         let declarations: Vec<Value> = self
             .tools
             .iter()
             .map(|t| {
-                serde_json::json!({
-                    "name": t.name(),
+                let name = t.name();
+                let schema = crate::schema::Schema::new(t.parameters_schema());
+                let parameters = crate::backend::utils::prepare_gemini_schema(
+                    &schema,
+                    format!("tool `{name}` arguments"),
+                )?;
+                Ok(serde_json::json!({
+                    "name": name,
                     "description": t.description(),
-                    "parametersJsonSchema": t.parameters_schema_gemini(),
-                })
+                    "parametersJsonSchema": parameters,
+                }))
             })
-            .collect();
-        vec![serde_json::json!({ "functionDeclarations": declarations })]
+            .collect::<Result<_>>()?;
+        Ok(vec![
+            serde_json::json!({ "functionDeclarations": declarations }),
+        ])
     }
 }
 
@@ -546,7 +548,7 @@ pub(crate) async fn run_gemini_tools(
     use serde_json::json;
     use tracing::debug;
 
-    let tools_json = toolbox.gemini_tools_json();
+    let tools_json = toolbox.gemini_tools_json()?;
     let url = format!("{base_url}/models/{model}:generateContent");
     // Attach any media to the initial user turn, mirroring the materialize path:
     // inline base64 data becomes `inlineData`, URI references become `fileData`.
@@ -691,6 +693,12 @@ mod tests {
     #[derive(crate::Instructor, Serialize, Deserialize)]
     struct ScenarioPriceArgs {
         scenario_prices: HashMap<String, f64>,
+    }
+
+    #[derive(crate::Instructor, Serialize, Deserialize)]
+    struct RecursiveToolArgs {
+        account_id: String,
+        children: Vec<RecursiveToolArgs>,
     }
 
     fn scenario_price_tool()
@@ -900,14 +908,19 @@ mod tests {
     #[test]
     fn gemini_tools_json_empty_returns_empty_vec() {
         let toolbox = Toolbox::new();
-        assert!(toolbox.gemini_tools_json().is_empty());
+        assert!(
+            toolbox
+                .gemini_tools_json()
+                .expect("empty toolbox rendering")
+                .is_empty()
+        );
     }
 
     #[cfg(feature = "gemini")]
     #[test]
     fn gemini_tools_json_wraps_declarations() {
         let toolbox = Toolbox::new().with(add_tool());
-        let rendered = toolbox.gemini_tools_json();
+        let rendered = toolbox.gemini_tools_json().expect("acyclic tool schema");
         // Populated toolbox yields a single wrapper object.
         assert_eq!(rendered.len(), 1);
 
@@ -937,7 +950,9 @@ mod tests {
     #[test]
     fn gemini_tool_preserves_typed_dynamic_map() {
         let toolbox = Toolbox::new().with(scenario_price_tool());
-        let rendered = toolbox.gemini_tools_json();
+        let rendered = toolbox
+            .gemini_tools_json()
+            .expect("typed dynamic map schema");
         let declaration = &rendered[0]["functionDeclarations"][0];
         let map = &declaration["parametersJsonSchema"]["properties"]["scenario_prices"];
 
@@ -945,5 +960,31 @@ mod tests {
         assert_eq!(map["additionalProperties"]["type"], "number");
         assert!(map.get("properties").is_none());
         assert!(declaration.get("parameters").is_none());
+    }
+
+    #[cfg(feature = "gemini")]
+    #[test]
+    fn gemini_tool_rejects_recursive_arguments_with_tool_context() {
+        let tool = FnTool::new(
+            "reconcile_accounts",
+            "Reconcile a recursive account hierarchy",
+            |args: RecursiveToolArgs| std::future::ready(Ok(json!({"root": args.account_id}))),
+        );
+        let error = Toolbox::new()
+            .with(tool)
+            .gemini_tools_json()
+            .expect_err("Gemini must reject recursive tool arguments");
+
+        assert!(matches!(
+            error,
+            RStructorError::SchemaCompatibilityError {
+                provider,
+                context,
+                message,
+                ..
+            } if provider.as_ref() == "Gemini"
+                && context.as_ref() == "tool `reconcile_accounts` arguments"
+                && message.contains("finite-depth expansion")
+        ));
     }
 }

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -463,136 +463,166 @@ pub fn transform_internally_to_adjacently_tagged(
 ///
 /// # Returns
 ///
-/// A new schema Value with unsupported keywords removed
-pub fn prepare_gemini_schema(schema: &crate::schema::Schema) -> Value {
+/// A new schema value with unsupported keywords removed, or a local
+/// compatibility error when preserving the canonical schema is impossible.
+pub fn prepare_gemini_schema(
+    schema: &crate::schema::Schema,
+    context: impl Into<String>,
+) -> Result<Value> {
     let mut schema_json = schema.to_json();
-    strip_gemini_unsupported_keywords(&mut schema_json);
-    schema_json
+    let context = context.into();
+    strip_gemini_unsupported_keywords(&mut schema_json, &context)?;
+    Ok(schema_json)
 }
 
 /// Recursively removes keywords unsupported by Gemini's structured outputs.
-fn strip_gemini_unsupported_keywords(schema: &mut Value) {
-    // First, resolve any $ref references by inlining definitions
-    resolve_refs_for_gemini(schema);
-
+fn strip_gemini_unsupported_keywords(schema: &mut Value, context: &str) -> Result<()> {
+    resolve_refs_for_gemini(schema, context)?;
     strip_gemini_unsupported_keywords_recursive(schema);
+    Ok(())
 }
 
 /// Resolves $ref references by inlining definitions for Gemini compatibility.
-/// This handles recursive schemas by inlining to a limited depth.
-fn resolve_refs_for_gemini(schema: &mut Value) {
-    // Extract $defs if present
-    let defs = if let Some(obj) = schema.as_object_mut() {
-        obj.remove("$defs").or_else(|| obj.remove("definitions"))
-    } else {
-        None
-    };
+///
+/// Acyclic local references are losslessly inlined. Recursive references are
+/// rejected before any HTTP request because Gemini's schema transport cannot
+/// preserve an unbounded cycle, and finite-depth expansion would silently
+/// widen the accepted values at the cutoff.
+fn resolve_refs_for_gemini(schema: &mut Value, context: &str) -> Result<()> {
+    let definitions = schema
+        .get("$defs")
+        .or_else(|| schema.get("definitions"))
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
 
-    if let Some(defs) = defs {
-        // If schema has $ref at root, replace with the referenced definition
-        if let Some(obj) = schema.as_object_mut()
-            && let Some(ref_value) = obj.remove("$ref")
-            && let Some(ref_str) = ref_value.as_str()
-            && let Some(def_name) = ref_str
-                .strip_prefix("#/$defs/")
-                .or_else(|| ref_str.strip_prefix("#/definitions/"))
-            && let Some(defs_obj) = defs.as_object()
-            && let Some(definition) = defs_obj.get(def_name)
-        {
-            // Replace schema with the definition
-            *schema = definition.clone();
+    let mut expanded = schema.clone();
+    if let Some(object) = expanded.as_object_mut() {
+        object.remove("$defs");
+        object.remove("definitions");
+    }
+    inline_refs_for_gemini(&mut expanded, &definitions, context, "$", &mut Vec::new())?;
+    *schema = expanded;
+    Ok(())
+}
 
-            // Recursively inline refs in the new schema (with depth limit)
-            inline_refs_recursive(schema, &defs, 3);
+fn inline_refs_for_gemini(
+    schema: &mut Value,
+    definitions: &serde_json::Map<String, Value>,
+    context: &str,
+    path: &str,
+    active_references: &mut Vec<String>,
+) -> Result<()> {
+    match schema {
+        Value::Object(object) => {
+            if let Some(reference) = object
+                .get("$ref")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+            {
+                if active_references.contains(&reference) {
+                    return Err(gemini_schema_compatibility_error(
+                        context,
+                        path,
+                        format!(
+                            "recursive reference `{reference}` cannot be represented without \
+                             changing the schema; Gemini compilation does not apply a lossy \
+                             finite-depth expansion"
+                        ),
+                    ));
+                }
+
+                let Some(mut target) = referenced_definition(&reference, definitions) else {
+                    return Err(gemini_schema_compatibility_error(
+                        context,
+                        path,
+                        format!(
+                            "local reference `{reference}` does not resolve from the schema \
+                             document root"
+                        ),
+                    ));
+                };
+
+                let mut siblings = std::mem::take(object);
+                siblings.remove("$ref");
+                if !siblings.is_empty() {
+                    target = serde_json::json!({
+                        "allOf": [target, Value::Object(siblings)]
+                    });
+                }
+
+                active_references.push(reference);
+                inline_refs_for_gemini(&mut target, definitions, context, path, active_references)?;
+                active_references.pop();
+                *schema = target;
+                return Ok(());
+            }
+
+            for (key, child) in object {
+                inline_refs_for_gemini(
+                    child,
+                    definitions,
+                    context,
+                    &append_json_path(path, key),
+                    active_references,
+                )?;
+            }
         }
+        Value::Array(array) => {
+            for (index, child) in array.iter_mut().enumerate() {
+                inline_refs_for_gemini(
+                    child,
+                    definitions,
+                    context,
+                    &format!("{path}[{index}]"),
+                    active_references,
+                )?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn referenced_definition(
+    reference: &str,
+    definitions: &serde_json::Map<String, Value>,
+) -> Option<Value> {
+    let pointer = reference
+        .strip_prefix("#/$defs/")
+        .or_else(|| reference.strip_prefix("#/definitions/"))?;
+    let (encoded_key, suffix) = pointer
+        .split_once('/')
+        .map_or((pointer, None), |(key, suffix)| (key, Some(suffix)));
+    let key = encoded_key.replace("~1", "/").replace("~0", "~");
+    let definition = definitions.get(&key)?;
+    suffix.map_or_else(
+        || Some(definition.clone()),
+        |suffix| definition.pointer(&format!("/{suffix}")).cloned(),
+    )
+}
+
+fn append_json_path(path: &str, key: &str) -> String {
+    let mut characters = key.chars();
+    let is_identifier = matches!(
+        characters.next(),
+        Some(first) if first == '_' || first.is_ascii_alphabetic()
+    ) && characters
+        .all(|character| character == '_' || character.is_ascii_alphanumeric());
+    if is_identifier {
+        format!("{path}.{key}")
+    } else {
+        let quoted = serde_json::to_string(key).expect("serializing a string cannot fail");
+        format!("{path}[{quoted}]")
     }
 }
 
-/// Recursively inlines $ref references with a depth limit to prevent infinite recursion.
-fn inline_refs_recursive(schema: &mut Value, defs: &Value, depth: usize) {
-    if depth == 0 {
-        // At max depth, replace self-references with a simple object schema
-        if let Some(obj) = schema.as_object_mut()
-            && obj.contains_key("$ref")
-        {
-            obj.remove("$ref");
-            obj.insert("type".to_string(), Value::String("object".to_string()));
-            obj.insert(
-                "description".to_string(),
-                Value::String("Recursive reference (depth limit reached)".to_string()),
-            );
-        }
-        return;
-    }
-
-    if let Some(obj) = schema.as_object_mut() {
-        // Replace $ref with inline definition
-        if let Some(ref_value) = obj.remove("$ref")
-            && let Some(ref_str) = ref_value.as_str()
-            && let Some(def_name) = ref_str
-                .strip_prefix("#/$defs/")
-                .or_else(|| ref_str.strip_prefix("#/definitions/"))
-            && let Some(defs_obj) = defs.as_object()
-            && let Some(definition) = defs_obj.get(def_name)
-        {
-            // Replace with inline definition
-            *schema = definition.clone();
-            // Continue recursively with reduced depth
-            inline_refs_recursive(schema, defs, depth - 1);
-            return;
-        }
-
-        // Process nested schemas
-        if let Some(properties) = obj.get_mut("properties")
-            && let Some(props_obj) = properties.as_object_mut()
-        {
-            for prop_schema in props_obj.values_mut() {
-                inline_refs_recursive(prop_schema, defs, depth);
-            }
-        }
-
-        if let Some(items) = obj.get_mut("items") {
-            inline_refs_recursive(items, defs, depth);
-        }
-
-        if let Some(prefix_items) = obj.get_mut("prefixItems")
-            && let Some(arr) = prefix_items.as_array_mut()
-        {
-            for item in arr.iter_mut() {
-                inline_refs_recursive(item, defs, depth);
-            }
-        }
-
-        if let Some(one_of) = obj.get_mut("oneOf")
-            && let Some(arr) = one_of.as_array_mut()
-        {
-            for item in arr.iter_mut() {
-                inline_refs_recursive(item, defs, depth);
-            }
-        }
-
-        if let Some(any_of) = obj.get_mut("anyOf")
-            && let Some(arr) = any_of.as_array_mut()
-        {
-            for item in arr.iter_mut() {
-                inline_refs_recursive(item, defs, depth);
-            }
-        }
-
-        if let Some(all_of) = obj.get_mut("allOf")
-            && let Some(arr) = all_of.as_array_mut()
-        {
-            for item in arr.iter_mut() {
-                inline_refs_recursive(item, defs, depth);
-            }
-        }
-
-        // Handle additionalProperties if it's a schema object (for maps)
-        if let Some(additional) = obj.get_mut("additionalProperties")
-            && additional.is_object()
-        {
-            inline_refs_recursive(additional, defs, depth);
-        }
+fn gemini_schema_compatibility_error(context: &str, path: &str, message: String) -> RStructorError {
+    RStructorError::SchemaCompatibilityError {
+        provider: "Gemini".into(),
+        context: context.into(),
+        path: path.into(),
+        message: message.into_boxed_str(),
     }
 }
 
@@ -782,7 +812,10 @@ fn strip_gemini_unsupported_keywords_recursive(schema: &mut Value) {
         obj.remove("default");
         obj.remove("$defs");
         obj.remove("definitions");
-        obj.remove("$ref"); // Should be resolved by now, but remove if any remain
+        debug_assert!(
+            !obj.contains_key("$ref"),
+            "all references must be resolved before Gemini keyword stripping"
+        );
 
         // `x-enum-keys` is a rstructor hint, not part of Gemini's schema dialect.
         obj.remove("x-enum-keys");
@@ -2225,7 +2258,7 @@ mod tests {
             }]
         }));
 
-        let gemini_schema = prepare_gemini_schema(&schema);
+        let gemini_schema = prepare_gemini_schema(&schema, "test output").expect("acyclic schema");
 
         // Verify examples is stripped
         assert!(
@@ -2275,7 +2308,7 @@ mod tests {
             }]
         }));
 
-        let gemini_schema = prepare_gemini_schema(&schema);
+        let gemini_schema = prepare_gemini_schema(&schema, "test output").expect("acyclic schema");
 
         // Verify examples is stripped at root
         assert!(
@@ -2302,7 +2335,8 @@ mod tests {
             "additionalProperties": false
         });
 
-        strip_gemini_unsupported_keywords(&mut schema_json);
+        strip_gemini_unsupported_keywords(&mut schema_json, "test output")
+            .expect("reference-free schema");
 
         assert_eq!(schema_json["additionalProperties"], false);
     }
@@ -2321,7 +2355,8 @@ mod tests {
             }
         });
 
-        strip_gemini_unsupported_keywords(&mut schema_json);
+        strip_gemini_unsupported_keywords(&mut schema_json, "test output")
+            .expect("reference-free schema");
 
         assert!(
             schema_json.get("$schema").is_none(),
@@ -3235,7 +3270,7 @@ mod tests {
                 }
             }
         });
-        strip_gemini_unsupported_keywords(&mut schema);
+        strip_gemini_unsupported_keywords(&mut schema, "test output").expect("acyclic reference");
 
         assert_eq!(schema["type"], "object");
         assert_eq!(schema["properties"]["name"]["type"], "string");
@@ -3256,7 +3291,8 @@ mod tests {
                 }
             }
         });
-        strip_gemini_unsupported_keywords(&mut schema);
+        strip_gemini_unsupported_keywords(&mut schema, "test output")
+            .expect("acyclic legacy reference");
 
         assert_eq!(schema["type"], "object");
         assert_eq!(schema["properties"]["id"]["type"], "integer");
@@ -3265,15 +3301,7 @@ mod tests {
     }
 
     #[test]
-    fn gemini_recursive_ref_inlining_is_depth_limited() {
-        // A self-referential Node schema. Inlining is depth-limited (depth 3 from
-        // the root), and no `$ref` survives anywhere after stripping. The full
-        // public pipeline does NOT emit the "depth limit reached" placeholder for
-        // an object whose self-reference lives in a `child` *property* (the
-        // placeholder branch only fires for a bare `{$ref}` schema at depth 0 —
-        // see `inline_refs_recursive_depth_zero_emits_placeholder`). Here the
-        // innermost `child` is left as an empty object once the dangling $ref is
-        // stripped. This pins the observable behavior of the public path.
+    fn gemini_recursive_ref_is_rejected_instead_of_widened() {
         let mut schema = serde_json::json!({
             "$ref": "#/$defs/Node",
             "$defs": {
@@ -3287,58 +3315,122 @@ mod tests {
                 }
             }
         });
-        strip_gemini_unsupported_keywords(&mut schema);
+        let error = strip_gemini_unsupported_keywords(&mut schema, "file tree output")
+            .expect_err("recursive schemas must not be widened");
 
-        // No $ref or $defs should survive anywhere in the serialized schema.
-        let serialized = serde_json::to_string(&schema).unwrap();
-        assert!(
-            !serialized.contains("$ref"),
-            "no $ref should remain after depth-limited inlining: {}",
-            serialized
-        );
-        assert!(!serialized.contains("$defs"));
-
-        // Root is the inlined Node.
-        assert_eq!(schema["type"], "object");
-        assert_eq!(schema["properties"]["value"]["type"], "integer");
-
-        // Walk the child chain (each level is `properties.child`): it terminates
-        // after a finite number of levels in an empty object (the stripped
-        // innermost self-reference).
-        let mut node = &schema;
-        let mut depth = 0;
-        while let Some(child) = node.get("properties").and_then(|p| p.get("child")) {
-            depth += 1;
-            if child.as_object().map(|o| o.is_empty()).unwrap_or(false) {
-                // Reached the stripped innermost self-reference.
-                break;
-            }
-            node = child;
-            assert!(depth < 10, "child chain should be depth-limited");
-        }
-        assert!(depth >= 1, "expected at least one inlined child level");
+        assert!(matches!(
+            error,
+            RStructorError::SchemaCompatibilityError {
+                provider,
+                context,
+                path,
+                message,
+            } if provider.as_ref() == "Gemini"
+                && context.as_ref() == "file tree output"
+                && path.as_ref() == "$.properties.child"
+                && message.contains("finite-depth expansion")
+        ));
     }
 
     #[test]
-    fn inline_refs_recursive_depth_zero_emits_placeholder() {
-        // Directly exercise the depth-limit placeholder branch: a bare `{$ref}`
-        // schema processed at depth 0 is replaced with a placeholder object
-        // carrying the "depth limit reached" description.
-        let defs = serde_json::json!({
-            "Node": {
-                "type": "object",
-                "properties": { "value": { "type": "integer" } }
+    fn gemini_mutual_recursion_is_rejected_instead_of_widened() {
+        let mut schema = serde_json::json!({
+            "$ref": "#/$defs/Fund",
+            "$defs": {
+                "Fund": {
+                    "type": "object",
+                    "properties": {
+                        "lei": { "type": "string" },
+                        "prime_broker": { "$ref": "#/$defs/PrimeBroker" }
+                    },
+                    "required": ["lei"]
+                },
+                "PrimeBroker": {
+                    "type": "object",
+                    "properties": {
+                        "lei": { "type": "string" },
+                        "funds": {
+                            "type": "array",
+                            "items": { "$ref": "#/$defs/Fund" }
+                        }
+                    },
+                    "required": ["lei", "funds"]
+                }
             }
         });
-        let mut schema = serde_json::json!({ "$ref": "#/$defs/Node" });
-        inline_refs_recursive(&mut schema, &defs, 0);
 
-        assert_eq!(schema["type"], "object");
-        assert_eq!(
-            schema["description"],
-            "Recursive reference (depth limit reached)"
+        let error = strip_gemini_unsupported_keywords(&mut schema, "fund ownership output")
+            .expect_err("mutual recursion must not be widened");
+
+        assert!(matches!(
+            error,
+            RStructorError::SchemaCompatibilityError {
+                provider,
+                context,
+                path,
+                message,
+            } if provider.as_ref() == "Gemini"
+                && context.as_ref() == "fund ownership output"
+                && path.as_ref()
+                    == "$.properties.prime_broker.properties.funds.items"
+                && message.contains("#/$defs/Fund")
+        ));
+    }
+
+    #[test]
+    fn gemini_acyclic_refs_decode_json_pointer_escapes() {
+        let mut schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "slash": {"$ref": "#/$defs/a~1b"},
+                "tilde": {"$ref": "#/$defs/a~0b"}
+            },
+            "$defs": {
+                "a/b": {
+                    "type": "string",
+                    "description": "slash key"
+                },
+                "a~b": {
+                    "type": "integer",
+                    "description": "tilde key"
+                }
+            }
+        });
+        strip_gemini_unsupported_keywords(&mut schema, "escaped definition output")
+            .expect("escaped acyclic references must resolve");
+
+        assert_eq!(schema["properties"]["slash"]["type"], "string");
+        assert_eq!(schema["properties"]["tilde"]["type"], "integer");
+        assert!(schema.get("$defs").is_none());
+    }
+
+    #[test]
+    fn gemini_ref_siblings_remain_conjunctive() {
+        let mut schema = serde_json::json!({
+            "$ref": "#/$defs/CounterpartyCode",
+            "minLength": 5,
+            "$defs": {
+                "CounterpartyCode": {
+                    "type": "string",
+                    "minLength": 10
+                }
+            }
+        });
+        strip_gemini_unsupported_keywords(&mut schema, "counterparty code output")
+            .expect("acyclic reference with validation sibling");
+
+        let all_of = schema["allOf"]
+            .as_array()
+            .expect("$ref siblings must compile as a conjunction");
+        assert_eq!(all_of.len(), 2);
+        assert!(
+            all_of.iter().any(|branch| branch["minLength"] == 10),
+            "the referenced constraint must be preserved: {schema:#}"
         );
-        assert!(schema.get("$ref").is_none());
+        assert!(
+            all_of.iter().any(|branch| branch["minLength"] == 5),
+            "the sibling constraint must be preserved: {schema:#}"
+        );
     }
 
     #[test]
@@ -3439,7 +3531,8 @@ mod tests {
             serde_json::json!(false)
         );
 
-        strip_gemini_unsupported_keywords(&mut schema);
+        strip_gemini_unsupported_keywords(&mut schema, "test output")
+            .expect("reference-free schema");
 
         assert_eq!(schema["additionalProperties"], serde_json::json!(false));
         assert_eq!(
@@ -3528,19 +3621,30 @@ mod tests {
     }
 
     #[test]
-    fn gemini_orphan_ref_without_defs_is_stripped() {
-        // A $ref with no matching $defs cannot be resolved, but the dangling
-        // $ref keyword is removed during stripping.
+    fn gemini_orphan_ref_without_defs_is_rejected() {
         let mut schema = serde_json::json!({
             "type": "object",
             "properties": {
                 "x": { "$ref": "#/$defs/Missing" }
             }
         });
-        strip_gemini_unsupported_keywords(&mut schema);
-        assert!(
-            schema["properties"]["x"].get("$ref").is_none(),
-            "orphan $ref should be stripped"
+        let original = schema.clone();
+        let error = strip_gemini_unsupported_keywords(&mut schema, "orphan ref output")
+            .expect_err("orphan references must not be stripped");
+        assert!(matches!(
+            error,
+            RStructorError::SchemaCompatibilityError {
+                provider,
+                path,
+                message,
+                ..
+            } if provider.as_ref() == "Gemini"
+                && path.as_ref() == "$.properties.x"
+                && message.contains("does not resolve")
+        ));
+        assert_eq!(
+            schema, original,
+            "failed resolution must leave the canonical schema untouched"
         );
     }
 
@@ -3554,7 +3658,8 @@ mod tests {
                 "name": { "type": "string", "default": "anon" }
             }
         });
-        strip_gemini_unsupported_keywords(&mut schema);
+        strip_gemini_unsupported_keywords(&mut schema, "test output")
+            .expect("reference-free schema");
         assert!(schema.get("$id").is_none(), "$id should be stripped");
         assert!(
             schema.get("default").is_none(),

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -205,6 +205,16 @@ pub trait SchemaType {
     /// Generate a JSON Schema representation of this type
     fn schema() -> Schema;
 
+    /// Build this type's schema inside an existing derived-schema graph.
+    ///
+    /// This hook lets derive-generated implementations share recursion state
+    /// while composing nested schemas. Manual implementations may rely on the
+    /// default, which preserves their existing [`SchemaType::schema`] behavior.
+    #[doc(hidden)]
+    fn schema_in(context: &mut __private::SchemaBuildContext) -> Value {
+        context.import_schema(Self::schema().to_json())
+    }
+
     /// Optional name for the schema
     ///
     /// This method returns an optional name for the schema. It's used by the LLM clients
@@ -220,7 +230,441 @@ pub trait SchemaType {
 pub mod __private {
     use super::SchemaType;
     use serde_json::Value;
+    use std::any::TypeId;
+    use std::collections::{BTreeMap, HashMap, HashSet};
     use std::marker::PhantomData;
+
+    #[derive(Clone)]
+    struct ActiveType {
+        type_id: TypeId,
+        identity: String,
+        preferred_key: String,
+    }
+
+    /// Per-call state for composing derive-generated schemas as a type graph.
+    ///
+    /// The context is owned by one root `SchemaType::schema()` call. It is
+    /// deliberately neither global nor thread-local, so concurrent and nested
+    /// schema builds cannot contaminate one another.
+    #[doc(hidden)]
+    #[derive(Default)]
+    pub struct SchemaBuildContext {
+        active: Vec<ActiveType>,
+        recursive: HashSet<TypeId>,
+        definition_keys: HashMap<TypeId, String>,
+        key_owners: HashMap<String, TypeId>,
+        manual_keys: HashSet<String>,
+        definitions: BTreeMap<String, Value>,
+        completed: HashMap<TypeId, Value>,
+    }
+
+    impl SchemaBuildContext {
+        /// Create an empty schema-build context.
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        /// Build one concrete type inside this schema graph.
+        ///
+        /// `preferred_key` is the derive-visible short type name. Direct,
+        /// non-generic self recursion keeps that familiar key. Multi-type and
+        /// generic cycles use the fully-qualified concrete Rust type identity
+        /// to avoid collisions.
+        pub fn schema_for<T, F>(&mut self, preferred_key: &str, build: F) -> Value
+        where
+            T: ?Sized + 'static,
+            F: FnOnce(&mut Self) -> Value,
+        {
+            let type_id = TypeId::of::<T>();
+            let identity = std::any::type_name::<T>().to_string();
+
+            if let Some(key) = self.definition_keys.get(&type_id) {
+                return schema_reference(key);
+            }
+
+            if let Some(index) = self
+                .active
+                .iter()
+                .position(|active| active.type_id == type_id)
+            {
+                let cycle = self.active[index..].to_vec();
+                let use_qualified_keys = cycle.len() > 1;
+                for active in cycle {
+                    self.mark_recursive(active, use_qualified_keys);
+                }
+                let key = self
+                    .definition_keys
+                    .get(&type_id)
+                    .expect("active recursive type must have a definition key");
+                return schema_reference(key);
+            }
+
+            if let Some(schema) = self.completed.get(&type_id) {
+                return schema.clone();
+            }
+
+            self.active.push(ActiveType {
+                type_id,
+                identity: identity.clone(),
+                preferred_key: preferred_key.to_string(),
+            });
+            let schema = build(self);
+            let popped = self
+                .active
+                .pop()
+                .expect("schema build stack must contain the current type");
+            debug_assert_eq!(popped.type_id, type_id);
+
+            if self.recursive.contains(&type_id) {
+                let key = self
+                    .definition_keys
+                    .get(&type_id)
+                    .expect("recursive type must have a definition key")
+                    .clone();
+                self.definitions.entry(key.clone()).or_insert(schema);
+                schema_reference(&key)
+            } else {
+                self.completed.insert(type_id, schema.clone());
+                schema
+            }
+        }
+
+        /// Import a complete schema document produced by a manual
+        /// [`SchemaType`] implementation.
+        ///
+        /// Local definitions are hoisted into this context and local references
+        /// are rewritten when a definition name collides. This keeps references
+        /// document-root relative after the manual schema is embedded in a
+        /// derive-generated parent.
+        pub fn import_schema(&mut self, mut schema: Value) -> Value {
+            self.import_schema_scopes(&mut schema);
+            schema
+        }
+
+        /// Merge the fields from an internally tagged newtype variant's inner
+        /// schema into the variant object.
+        ///
+        /// Active recursive references cannot be resolved until the full type
+        /// graph has been built. Those merges are recorded as private markers
+        /// and completed by [`SchemaBuildContext::finish`].
+        pub fn flatten_into_object(&self, mut outer: Value, inner: Value) -> Value {
+            if let Some(inner) = self.resolve(&inner) {
+                merge_flattened_object(&mut outer, &inner);
+            } else if let Value::Object(outer) = &mut outer {
+                outer.insert(DEFERRED_FLATTEN_KEY.to_string(), inner);
+            }
+            outer
+        }
+
+        /// Attach all definitions discovered while building `root`.
+        pub fn finish(mut self, mut root: Value) -> Value {
+            let definitions_snapshot = self.definitions.clone();
+            resolve_deferred_flatten(&mut root, &definitions_snapshot, &mut Vec::new());
+            for definition in self.definitions.values_mut() {
+                resolve_deferred_flatten(definition, &definitions_snapshot, &mut Vec::new());
+            }
+
+            if self.definitions.is_empty() {
+                return root;
+            }
+
+            let definitions = self
+                .definitions
+                .into_iter()
+                .collect::<serde_json::Map<String, Value>>();
+
+            match root {
+                Value::Object(mut root) => {
+                    if let Some(Value::Object(existing)) = root.get_mut("$defs") {
+                        for (key, schema) in definitions {
+                            existing.entry(key).or_insert(schema);
+                        }
+                    } else {
+                        root.insert("$defs".to_string(), Value::Object(definitions));
+                    }
+                    Value::Object(root)
+                }
+                root => serde_json::json!({
+                    "$defs": definitions,
+                    "allOf": [root]
+                }),
+            }
+        }
+
+        /// Resolve a direct local `$ref` to a definition already completed in
+        /// this context. Non-reference schemas are returned unchanged.
+        pub fn resolve(&self, schema: &Value) -> Option<Value> {
+            let Some(reference) = schema.get("$ref").and_then(Value::as_str) else {
+                return Some(schema.clone());
+            };
+            let pointer_key = reference.strip_prefix("#/$defs/")?;
+            let key = pointer_key.replace("~1", "/").replace("~0", "~");
+            self.definitions.get(&key).cloned()
+        }
+
+        fn mark_recursive(&mut self, active: ActiveType, use_qualified_key: bool) {
+            self.recursive.insert(active.type_id);
+            if self.definition_keys.contains_key(&active.type_id) {
+                return;
+            }
+
+            let prefer_qualified = use_qualified_key || active.identity.contains('<');
+            let mut key = if prefer_qualified {
+                qualified_definition_key(&active)
+            } else {
+                active.preferred_key.clone()
+            };
+
+            if self.manual_keys.contains(&key)
+                || self
+                    .key_owners
+                    .get(&key)
+                    .is_some_and(|owner| owner != &active.type_id)
+            {
+                key = qualified_definition_key(&active);
+            }
+
+            key = self.unique_derived_key(key, active.type_id);
+            self.key_owners.insert(key.clone(), active.type_id);
+            self.definition_keys.insert(active.type_id, key);
+        }
+
+        fn unique_derived_key(&self, candidate: String, type_id: TypeId) -> String {
+            if !self.manual_keys.contains(&candidate)
+                && self
+                    .key_owners
+                    .get(&candidate)
+                    .is_none_or(|owner| owner == &type_id)
+            {
+                return candidate;
+            }
+
+            for suffix in 2usize.. {
+                let candidate = format!("{candidate}{suffix}");
+                if !self.manual_keys.contains(&candidate)
+                    && !self.key_owners.contains_key(&candidate)
+                {
+                    return candidate;
+                }
+            }
+            unreachable!()
+        }
+
+        fn manual_definition_key(&mut self, preferred: &str, definition: &Value) -> String {
+            if self
+                .definitions
+                .get(preferred)
+                .is_some_and(|existing| existing == definition)
+            {
+                return preferred.to_string();
+            }
+
+            let mut key = preferred.to_string();
+            for suffix in 2usize.. {
+                if !self.definitions.contains_key(&key)
+                    && !self.key_owners.contains_key(&key)
+                    && !self.manual_keys.contains(&key)
+                {
+                    self.manual_keys.insert(key.clone());
+                    return key;
+                }
+                key = format!("{preferred}{suffix}");
+            }
+            unreachable!()
+        }
+
+        fn import_schema_scopes(&mut self, schema: &mut Value) {
+            match schema {
+                Value::Object(object) => {
+                    let definitions = object
+                        .remove("$defs")
+                        .or_else(|| object.remove("definitions"))
+                        .and_then(|definitions| definitions.as_object().cloned());
+
+                    if let Some(definitions) = definitions {
+                        let mut renamed = BTreeMap::new();
+                        for (name, definition) in &definitions {
+                            let key = self.manual_definition_key(name, definition);
+                            renamed.insert(name.clone(), key);
+                        }
+
+                        rewrite_definition_refs_in_scope(schema, &renamed, true);
+                        for (name, mut definition) in definitions {
+                            rewrite_definition_refs_in_scope(&mut definition, &renamed, true);
+                            self.import_schema_scopes(&mut definition);
+                            let key = renamed
+                                .get(&name)
+                                .expect("every imported definition must have a key")
+                                .clone();
+                            self.definitions.entry(key).or_insert(definition);
+                        }
+                    }
+
+                    if let Value::Object(object) = schema {
+                        for child in object.values_mut() {
+                            self.import_schema_scopes(child);
+                        }
+                    }
+                }
+                Value::Array(array) => {
+                    for child in array {
+                        self.import_schema_scopes(child);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn schema_reference(key: &str) -> Value {
+        let pointer_key = key.replace('~', "~0").replace('/', "~1");
+        serde_json::json!({ "$ref": format!("#/$defs/{pointer_key}") })
+    }
+
+    fn qualified_definition_key(active: &ActiveType) -> String {
+        let mut encoded_identity = String::with_capacity(active.identity.len());
+        for byte in active.identity.bytes() {
+            if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.') {
+                encoded_identity.push(char::from(byte));
+            } else {
+                use std::fmt::Write as _;
+                write!(&mut encoded_identity, "_{byte:02x}")
+                    .expect("writing to a String cannot fail");
+            }
+        }
+        format!("{}__{encoded_identity}", active.preferred_key)
+    }
+
+    fn rewrite_definition_refs_in_scope(
+        value: &mut Value,
+        renamed: &BTreeMap<String, String>,
+        is_scope_root: bool,
+    ) {
+        match value {
+            Value::Object(object) => {
+                if !is_scope_root
+                    && (object.contains_key("$defs") || object.contains_key("definitions"))
+                {
+                    return;
+                }
+                if let Some(reference) = object.get("$ref").and_then(Value::as_str) {
+                    let rewritten = rewrite_definition_ref(reference, renamed);
+                    if let Some(rewritten) = rewritten {
+                        object.insert("$ref".to_string(), Value::String(rewritten));
+                    }
+                }
+                for child in object.values_mut() {
+                    rewrite_definition_refs_in_scope(child, renamed, false);
+                }
+            }
+            Value::Array(array) => {
+                for child in array {
+                    rewrite_definition_refs_in_scope(child, renamed, false);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn rewrite_definition_ref(
+        reference: &str,
+        renamed: &BTreeMap<String, String>,
+    ) -> Option<String> {
+        let (prefix, pointer) = if let Some(pointer) = reference.strip_prefix("#/$defs/") {
+            ("#/$defs/", pointer)
+        } else {
+            ("#/$defs/", reference.strip_prefix("#/definitions/")?)
+        };
+        let (encoded_key, suffix) = pointer
+            .split_once('/')
+            .map_or((pointer, ""), |(key, suffix)| (key, suffix));
+        let key = encoded_key.replace("~1", "/").replace("~0", "~");
+        let renamed = renamed.get(&key)?;
+        let encoded = renamed.replace('~', "~0").replace('/', "~1");
+        Some(if suffix.is_empty() {
+            format!("{prefix}{encoded}")
+        } else {
+            format!("{prefix}{encoded}/{suffix}")
+        })
+    }
+
+    const DEFERRED_FLATTEN_KEY: &str = "__rstructor_deferred_flatten";
+
+    fn resolve_deferred_flatten(
+        value: &mut Value,
+        definitions: &BTreeMap<String, Value>,
+        resolving: &mut Vec<String>,
+    ) {
+        match value {
+            Value::Object(object) => {
+                if let Some(mut inner) = object.remove(DEFERRED_FLATTEN_KEY) {
+                    if let Some(reference) = inner.get("$ref").and_then(Value::as_str) {
+                        let pointer_key = reference
+                            .strip_prefix("#/$defs/")
+                            .unwrap_or_else(|| {
+                                panic!(
+                                    "deferred internally tagged flatten used unsupported reference {reference}"
+                                )
+                            });
+                        let key = pointer_key.replace("~1", "/").replace("~0", "~");
+                        assert!(
+                            !resolving.contains(&key),
+                            "internally tagged recursive newtypes form an unflattenable cycle at {reference}"
+                        );
+                        inner = definitions
+                            .get(&key)
+                            .unwrap_or_else(|| {
+                                panic!(
+                                    "deferred internally tagged flatten could not resolve {reference}"
+                                )
+                            })
+                            .clone();
+                        resolving.push(key);
+                        resolve_deferred_flatten(&mut inner, definitions, resolving);
+                        resolving.pop();
+                    } else {
+                        resolve_deferred_flatten(&mut inner, definitions, resolving);
+                    }
+                    merge_flattened_object(value, &inner);
+                }
+
+                if let Value::Object(object) = value {
+                    for child in object.values_mut() {
+                        resolve_deferred_flatten(child, definitions, resolving);
+                    }
+                }
+            }
+            Value::Array(array) => {
+                for child in array {
+                    resolve_deferred_flatten(child, definitions, resolving);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn merge_flattened_object(outer: &mut Value, inner: &Value) {
+        let Some(outer) = outer.as_object_mut() else {
+            return;
+        };
+        let Some(inner) = inner.as_object() else {
+            return;
+        };
+
+        if let Some(Value::Object(inner_properties)) = inner.get("properties")
+            && let Some(Value::Object(outer_properties)) = outer.get_mut("properties")
+        {
+            for (key, schema) in inner_properties {
+                outer_properties.insert(key.clone(), schema.clone());
+            }
+        }
+
+        if let Some(Value::Array(inner_required)) = inner.get("required")
+            && let Some(Value::Array(outer_required)) = outer.get_mut("required")
+        {
+            outer_required.extend(inner_required.iter().cloned());
+        }
+    }
 
     /// Autoref-specialization probe that lets generated code use a field type's
     /// own [`SchemaType`] schema **iff** the type implements it, and otherwise
@@ -229,14 +673,14 @@ pub mod __private {
     /// having to know which crate a type named `Date` comes from.
     ///
     /// `#[derive(Instructor)]` emits
-    /// `SchemaProbe::<FieldType>::new().rstructor_schema_or(fallback)` for
+    /// `SchemaProbe::<FieldType>::new().rstructor_schema_in_or(context, fallback)` for
     /// fields whose type *name* matches a well-known library type (`Date`,
     /// `DateTime`, `NaiveDate`, `NaiveDateTime`, `Uuid`). When the field's
     /// type implements `SchemaType` (e.g. a user-defined `struct Date` that
     /// derives `Instructor`), the inherent method below is selected (inherent
     /// methods take priority over trait methods) and the type's real schema
     /// wins; otherwise method resolution falls back to
-    /// [`SchemaProbeFallback`], which returns the sniffed fallback schema.
+    /// [`SchemaProbeContextFallback`], which returns the sniffed fallback.
     pub struct SchemaProbe<T: ?Sized>(PhantomData<T>);
 
     impl<T: ?Sized> SchemaProbe<T> {
@@ -246,23 +690,34 @@ pub mod __private {
         }
     }
 
-    /// Fallback for field types that do not implement [`SchemaType`]
-    /// (e.g. `chrono::NaiveDate`, `uuid::Uuid`).
-    pub trait SchemaProbeFallback {
-        fn rstructor_schema_or(&self, fallback: Value) -> Value;
-    }
-
-    impl<T: ?Sized> SchemaProbeFallback for SchemaProbe<T> {
-        fn rstructor_schema_or(&self, fallback: Value) -> Value {
-            fallback
+    impl<T: SchemaType + ?Sized> SchemaProbe<T> {
+        /// Return the wrapped type's schema within an existing build context.
+        pub fn rstructor_schema_in_or(
+            &self,
+            context: &mut SchemaBuildContext,
+            _fallback: Value,
+        ) -> Value {
+            T::schema_in(context)
         }
     }
 
-    impl<T: SchemaType + ?Sized> SchemaProbe<T> {
-        /// Return the wrapped type's real schema (selected over the trait
-        /// method when `T: SchemaType`).
-        pub fn rstructor_schema_or(&self, _fallback: Value) -> Value {
-            T::schema().to_json()
+    /// Context-aware fallback for field types without [`SchemaType`].
+    pub trait SchemaProbeContextFallback {
+        fn rstructor_schema_in_or(
+            &self,
+            context: &mut SchemaBuildContext,
+            fallback: Value,
+        ) -> Value;
+    }
+
+    impl<T: ?Sized> SchemaProbeContextFallback for SchemaProbe<T> {
+        fn rstructor_schema_in_or(
+            &self,
+            context: &mut SchemaBuildContext,
+            fallback: Value,
+        ) -> Value {
+            let _ = context;
+            fallback
         }
     }
 }

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -234,9 +234,15 @@ pub mod __private {
     use std::collections::{BTreeMap, HashMap, HashSet};
     use std::marker::PhantomData;
 
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    enum GraphTypeId {
+        Static(TypeId),
+        Named(String),
+    }
+
     #[derive(Clone)]
     struct ActiveType {
-        type_id: TypeId,
+        type_id: GraphTypeId,
         identity: String,
         preferred_key: String,
     }
@@ -250,12 +256,12 @@ pub mod __private {
     #[derive(Default)]
     pub struct SchemaBuildContext {
         active: Vec<ActiveType>,
-        recursive: HashSet<TypeId>,
-        definition_keys: HashMap<TypeId, String>,
-        key_owners: HashMap<String, TypeId>,
+        recursive: HashSet<GraphTypeId>,
+        definition_keys: HashMap<GraphTypeId, String>,
+        key_owners: HashMap<String, GraphTypeId>,
         manual_keys: HashSet<String>,
         definitions: BTreeMap<String, Value>,
-        completed: HashMap<TypeId, Value>,
+        completed: HashMap<GraphTypeId, Value>,
     }
 
     impl SchemaBuildContext {
@@ -275,9 +281,44 @@ pub mod __private {
             T: ?Sized + 'static,
             F: FnOnce(&mut Self) -> Value,
         {
-            let type_id = TypeId::of::<T>();
             let identity = std::any::type_name::<T>().to_string();
+            self.schema_for_key(
+                GraphTypeId::Static(TypeId::of::<T>()),
+                identity,
+                preferred_key,
+                build,
+            )
+        }
 
+        /// Build a lifetime-parameterized type inside this schema graph.
+        ///
+        /// `TypeId` is unavailable for non-`'static` types. Rust lifetimes do
+        /// not affect Serde's wire representation, so these types use their
+        /// concrete diagnostic name for per-call recursion bookkeeping.
+        pub fn schema_for_named<T, F>(&mut self, preferred_key: &str, build: F) -> Value
+        where
+            T: ?Sized,
+            F: FnOnce(&mut Self) -> Value,
+        {
+            let identity = std::any::type_name::<T>().to_string();
+            self.schema_for_key(
+                GraphTypeId::Named(identity.clone()),
+                identity,
+                preferred_key,
+                build,
+            )
+        }
+
+        fn schema_for_key<F>(
+            &mut self,
+            type_id: GraphTypeId,
+            identity: String,
+            preferred_key: &str,
+            build: F,
+        ) -> Value
+        where
+            F: FnOnce(&mut Self) -> Value,
+        {
             if let Some(key) = self.definition_keys.get(&type_id) {
                 return schema_reference(key);
             }
@@ -304,8 +345,8 @@ pub mod __private {
             }
 
             self.active.push(ActiveType {
-                type_id,
-                identity: identity.clone(),
+                type_id: type_id.clone(),
+                identity,
                 preferred_key: preferred_key.to_string(),
             });
             let schema = build(self);
@@ -337,8 +378,21 @@ pub mod __private {
         /// document-root relative after the manual schema is embedded in a
         /// derive-generated parent.
         pub fn import_schema(&mut self, mut schema: Value) -> Value {
+            let needs_embedded_root = contains_embedded_root_reference(&schema);
+            let preferred_root_key = schema
+                .get("title")
+                .and_then(Value::as_str)
+                .unwrap_or("ManualSchema")
+                .to_string();
             self.import_schema_scopes(&mut schema);
-            schema
+            if !needs_embedded_root {
+                return schema;
+            }
+
+            let root_key = self.manual_definition_key(&preferred_root_key);
+            rewrite_embedded_root_refs(&mut schema, &root_key);
+            self.definitions.insert(root_key.clone(), schema);
+            schema_reference(&root_key)
         }
 
         /// Merge the fields from an internally tagged newtype variant's inner
@@ -403,7 +457,7 @@ pub mod __private {
         }
 
         fn mark_recursive(&mut self, active: ActiveType, use_qualified_key: bool) {
-            self.recursive.insert(active.type_id);
+            self.recursive.insert(active.type_id.clone());
             if self.definition_keys.contains_key(&active.type_id) {
                 return;
             }
@@ -424,17 +478,17 @@ pub mod __private {
                 key = qualified_definition_key(&active);
             }
 
-            key = self.unique_derived_key(key, active.type_id);
-            self.key_owners.insert(key.clone(), active.type_id);
+            key = self.unique_derived_key(key, &active.type_id);
+            self.key_owners.insert(key.clone(), active.type_id.clone());
             self.definition_keys.insert(active.type_id, key);
         }
 
-        fn unique_derived_key(&self, candidate: String, type_id: TypeId) -> String {
+        fn unique_derived_key(&self, candidate: String, type_id: &GraphTypeId) -> String {
             if !self.manual_keys.contains(&candidate)
                 && self
                     .key_owners
                     .get(&candidate)
-                    .is_none_or(|owner| owner == &type_id)
+                    .is_none_or(|owner| owner == type_id)
             {
                 return candidate;
             }
@@ -450,15 +504,7 @@ pub mod __private {
             unreachable!()
         }
 
-        fn manual_definition_key(&mut self, preferred: &str, definition: &Value) -> String {
-            if self
-                .definitions
-                .get(preferred)
-                .is_some_and(|existing| existing == definition)
-            {
-                return preferred.to_string();
-            }
-
+        fn manual_definition_key(&mut self, preferred: &str) -> String {
             let mut key = preferred.to_string();
             for suffix in 2usize.. {
                 if !self.definitions.contains_key(&key)
@@ -483,8 +529,8 @@ pub mod __private {
 
                     if let Some(definitions) = definitions {
                         let mut renamed = BTreeMap::new();
-                        for (name, definition) in &definitions {
-                            let key = self.manual_definition_key(name, definition);
+                        for name in definitions.keys() {
+                            let key = self.manual_definition_key(name);
                             renamed.insert(name.clone(), key);
                         }
 
@@ -533,6 +579,61 @@ pub mod __private {
             }
         }
         format!("{}__{encoded_identity}", active.preferred_key)
+    }
+
+    fn contains_embedded_root_reference(value: &Value) -> bool {
+        match value {
+            Value::Object(object) => {
+                let has_root_reference =
+                    object
+                        .get("$ref")
+                        .and_then(Value::as_str)
+                        .is_some_and(|reference| {
+                            reference == "#"
+                                || (reference.starts_with("#/")
+                                    && !reference.starts_with("#/$defs/")
+                                    && !reference.starts_with("#/definitions/"))
+                        });
+                has_root_reference || object.values().any(contains_embedded_root_reference)
+            }
+            Value::Array(array) => array.iter().any(contains_embedded_root_reference),
+            _ => false,
+        }
+    }
+
+    fn rewrite_embedded_root_refs(value: &mut Value, root_key: &str) {
+        match value {
+            Value::Object(object) => {
+                if let Some(reference) = object.get("$ref").and_then(Value::as_str) {
+                    let suffix = if reference == "#" {
+                        Some("")
+                    } else if reference.starts_with("#/")
+                        && !reference.starts_with("#/$defs/")
+                        && !reference.starts_with("#/definitions/")
+                    {
+                        reference.strip_prefix('#')
+                    } else {
+                        None
+                    };
+                    if let Some(suffix) = suffix {
+                        let encoded_key = root_key.replace('~', "~0").replace('/', "~1");
+                        object.insert(
+                            "$ref".to_string(),
+                            Value::String(format!("#/$defs/{encoded_key}{suffix}")),
+                        );
+                    }
+                }
+                for child in object.values_mut() {
+                    rewrite_embedded_root_refs(child, root_key);
+                }
+            }
+            Value::Array(array) => {
+                for child in array {
+                    rewrite_embedded_root_refs(child, root_key);
+                }
+            }
+            _ => {}
+        }
     }
 
     fn rewrite_definition_refs_in_scope(

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -384,13 +384,23 @@ pub mod __private {
                 .and_then(Value::as_str)
                 .unwrap_or("ManualSchema")
                 .to_string();
-            self.import_schema_scopes(&mut schema);
-            if !needs_embedded_root {
-                return schema;
+            let local_definition_names = schema
+                .get("$defs")
+                .or_else(|| schema.get("definitions"))
+                .and_then(Value::as_object)
+                .map(|definitions| definitions.keys().cloned().collect::<HashSet<_>>())
+                .unwrap_or_default();
+            let root_key = needs_embedded_root.then(|| {
+                self.manual_definition_key_avoiding(&preferred_root_key, &local_definition_names)
+            });
+            if let Some(root_key) = &root_key {
+                rewrite_embedded_root_refs(&mut schema, root_key);
             }
+            self.import_schema_scopes(&mut schema);
+            let Some(root_key) = root_key else {
+                return schema;
+            };
 
-            let root_key = self.manual_definition_key(&preferred_root_key);
-            rewrite_embedded_root_refs(&mut schema, &root_key);
             self.definitions.insert(root_key.clone(), schema);
             schema_reference(&root_key)
         }
@@ -505,11 +515,20 @@ pub mod __private {
         }
 
         fn manual_definition_key(&mut self, preferred: &str) -> String {
+            self.manual_definition_key_avoiding(preferred, &HashSet::new())
+        }
+
+        fn manual_definition_key_avoiding(
+            &mut self,
+            preferred: &str,
+            reserved: &HashSet<String>,
+        ) -> String {
             let mut key = preferred.to_string();
             for suffix in 2usize.. {
                 if !self.definitions.contains_key(&key)
                     && !self.key_owners.contains_key(&key)
                     && !self.manual_keys.contains(&key)
+                    && !reserved.contains(&key)
                 {
                     self.manual_keys.insert(key.clone());
                     return key;

--- a/src/schema/primitives.rs
+++ b/src/schema/primitives.rs
@@ -1,6 +1,12 @@
-use super::{Schema, SchemaType};
+use super::{__private::SchemaBuildContext, Schema, SchemaType};
 use serde_json::{Value, json};
 use std::collections::HashMap;
+
+fn schema_from_context<T: SchemaType + ?Sized>() -> Schema {
+    let mut context = SchemaBuildContext::new();
+    let root = T::schema_in(&mut context);
+    Schema::new(context.finish(root))
+}
 
 // ============================================================================
 // Box<T> - Transparent wrapper, delegates to inner type
@@ -8,7 +14,11 @@ use std::collections::HashMap;
 
 impl<T: SchemaType> SchemaType for Box<T> {
     fn schema() -> Schema {
-        T::schema()
+        schema_from_context::<Self>()
+    }
+
+    fn schema_in(context: &mut SchemaBuildContext) -> Value {
+        T::schema_in(context)
     }
 
     fn schema_name() -> Option<String> {
@@ -37,11 +47,15 @@ impl SchemaType for Value {
 
 impl<V: SchemaType> SchemaType for HashMap<String, V> {
     fn schema() -> Schema {
-        let value_schema = V::schema().to_json();
-        Schema::new(json!({
+        schema_from_context::<Self>()
+    }
+
+    fn schema_in(context: &mut SchemaBuildContext) -> Value {
+        let value_schema = V::schema_in(context);
+        json!({
             "type": "object",
             "additionalProperties": value_schema
-        }))
+        })
     }
 
     fn schema_name() -> Option<String> {
@@ -53,11 +67,15 @@ impl<V: SchemaType> SchemaType for HashMap<String, V> {
 // Also implement for HashMap with other string-like keys that serialize to strings
 impl<V: SchemaType> SchemaType for std::collections::BTreeMap<String, V> {
     fn schema() -> Schema {
-        let value_schema = V::schema().to_json();
-        Schema::new(json!({
+        schema_from_context::<Self>()
+    }
+
+    fn schema_in(context: &mut SchemaBuildContext) -> Value {
+        let value_schema = V::schema_in(context);
+        json!({
             "type": "object",
             "additionalProperties": value_schema
-        }))
+        })
     }
 
     fn schema_name() -> Option<String> {
@@ -75,16 +93,20 @@ macro_rules! impl_tuple_schema {
     ($($idx:tt $T:ident),+) => {
         impl<$($T: SchemaType),+> SchemaType for ($($T,)+) {
             fn schema() -> Schema {
+                schema_from_context::<Self>()
+            }
+
+            fn schema_in(context: &mut SchemaBuildContext) -> Value {
                 let items = vec![
-                    $($T::schema().to_json()),+
+                    $($T::schema_in(context)),+
                 ];
                 let count = items.len();
-                Schema::new(json!({
+                json!({
                     "type": "array",
                     "prefixItems": items,
                     "minItems": count,
                     "maxItems": count
-                }))
+                })
             }
 
             fn schema_name() -> Option<String> {
@@ -191,11 +213,15 @@ impl_float_schema!(f32, f64);
 
 impl<T: SchemaType> SchemaType for Vec<T> {
     fn schema() -> Schema {
-        let item_schema = T::schema().to_json();
-        Schema::new(json!({
+        schema_from_context::<Self>()
+    }
+
+    fn schema_in(context: &mut SchemaBuildContext) -> Value {
+        let item_schema = T::schema_in(context);
+        json!({
             "type": "array",
             "items": item_schema
-        }))
+        })
     }
 
     fn schema_name() -> Option<String> {
@@ -210,9 +236,12 @@ impl<T: SchemaType> SchemaType for Vec<T> {
 
 impl<T: SchemaType> SchemaType for Option<T> {
     fn schema() -> Schema {
-        // For Option<T>, we just return the inner type's schema
-        // The "required" handling is done at the struct level
-        T::schema()
+        schema_from_context::<Self>()
+    }
+
+    fn schema_in(context: &mut SchemaBuildContext) -> Value {
+        // Requiredness is handled by the enclosing object schema.
+        T::schema_in(context)
     }
 
     fn schema_name() -> Option<String> {
@@ -227,12 +256,16 @@ impl<T: SchemaType> SchemaType for Option<T> {
 
 impl<T: SchemaType> SchemaType for std::collections::HashSet<T> {
     fn schema() -> Schema {
-        let item_schema = T::schema().to_json();
-        Schema::new(json!({
+        schema_from_context::<Self>()
+    }
+
+    fn schema_in(context: &mut SchemaBuildContext) -> Value {
+        let item_schema = T::schema_in(context);
+        json!({
             "type": "array",
             "items": item_schema,
             "uniqueItems": true
-        }))
+        })
     }
 
     fn schema_name() -> Option<String> {
@@ -243,12 +276,16 @@ impl<T: SchemaType> SchemaType for std::collections::HashSet<T> {
 
 impl<T: SchemaType> SchemaType for std::collections::BTreeSet<T> {
     fn schema() -> Schema {
-        let item_schema = T::schema().to_json();
-        Schema::new(json!({
+        schema_from_context::<Self>()
+    }
+
+    fn schema_in(context: &mut SchemaBuildContext) -> Value {
+        let item_schema = T::schema_in(context);
+        json!({
             "type": "array",
             "items": item_schema,
             "uniqueItems": true
-        }))
+        })
     }
 
     fn schema_name() -> Option<String> {

--- a/tests/recursive_structures_tests.rs
+++ b/tests/recursive_structures_tests.rs
@@ -1,9 +1,10 @@
 // tests/recursive_structures_tests.rs
 #[cfg(test)]
 mod recursive_tests {
-    use rstructor::{GeminiClient, GeminiModel, Instructor, LLMClient};
+    #[cfg(feature = "streaming")]
+    use futures_util::StreamExt;
+    use rstructor::{GeminiClient, GeminiModel, Instructor, LLMClient, RStructorError};
     use serde::{Deserialize, Serialize};
-    use std::env;
 
     #[derive(Instructor, Serialize, Deserialize, Debug)]
     #[llm(description = "A node in a file system tree")]
@@ -19,25 +20,55 @@ mod recursive_tests {
     }
 
     #[tokio::test]
-    async fn test_gemini_recursive_schema() {
-        let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set");
-        let client = GeminiClient::new(api_key)
+    async fn test_gemini_recursive_schema_is_rejected_before_http() {
+        let client = GeminiClient::new("offline-test-key")
             .unwrap()
             .model(GeminiModel::Gemini31ProPreview)
             .temperature(0.0)
-            .no_retries();
+            .no_retries()
+            .base_url("http://127.0.0.1:9");
 
         let prompt = "Represent a small directory structure: A root folder 'src' containing a file 'lib.rs' (500 bytes) and a subfolder 'backend' which is empty.";
         let result: rstructor::Result<FileNode> = client.materialize(prompt).await;
 
-        // Recursive schemas often fail if the generator doesn't handle $ref or creates infinite loops
-        assert!(
-            result.is_ok(),
-            "Recursive FileNode failed: {:?}",
-            result.err()
-        );
-        let root = result.unwrap();
-        assert_eq!(root.name, "src");
-        assert_eq!(root.children.unwrap().len(), 2);
+        assert!(matches!(
+            result,
+            Err(RStructorError::SchemaCompatibilityError {
+                provider,
+                context,
+                message,
+                ..
+            }) if provider.as_ref() == "Gemini"
+                && context.as_ref() == "structured output"
+                && message.contains("finite-depth expansion")
+        ));
+    }
+
+    #[cfg(feature = "streaming")]
+    #[tokio::test]
+    async fn test_gemini_recursive_stream_is_rejected_before_http() {
+        let client = GeminiClient::new("offline-test-key")
+            .unwrap()
+            .model(GeminiModel::Gemini31ProPreview)
+            .no_retries()
+            .base_url("http://127.0.0.1:9");
+
+        let mut stream = client.materialize_stream::<FileNode>("Extract a recursive file tree");
+        let error = stream
+            .next()
+            .await
+            .expect("compatibility error item")
+            .expect_err("recursive stream must fail locally");
+
+        assert!(matches!(
+            error,
+            RStructorError::SchemaCompatibilityError {
+                provider,
+                context,
+                ..
+            } if provider.as_ref() == "Gemini"
+                && context.as_ref() == "structured output"
+        ));
+        assert!(stream.next().await.is_none());
     }
 }


### PR DESCRIPTION
## Summary

- build each derived schema as one per-call, context-aware type graph, supporting direct and mutual recursion, same-named Rust types, generic instantiations, manual schemas, and lifetime-parameterized derives
- hoist all reusable definitions to the document root and defer recursive internally tagged newtype flattening until the graph is complete
- preserve manual schema reference scope, including embedded `#` references and colliding local definition names
- compile Gemini schemas from the canonical graph without lossy depth widening: acyclic references inline, while cyclic and orphan references fail locally before HTTP
- centralize Gemini tool-schema compilation and remove the provider-specific `DynTool::parameters_schema_gemini` hook

## Schema examples

Mutually recursive finance models now produce a closed schema graph instead of overflowing or leaving references stranded in nested `$defs`:

```rust
use rstructor::{Instructor, SchemaType};
use serde::{Deserialize, Serialize};

#[derive(Debug, Instructor, Serialize, Deserialize)]
struct Fund {
    lei: String,
    prime_broker: Option<Box<PrimeBroker>>,
}

#[derive(Debug, Instructor, Serialize, Deserialize)]
struct PrimeBroker {
    lei: String,
    sponsored_funds: Vec<Fund>,
}

let schema = Fund::schema().to_json();
assert!(schema["$defs"].is_object());
assert_eq!(schema["properties"]["prime_broker"]["anyOf"][0]["$ref"]
    .as_str()
    .map(|reference| reference.starts_with("#/$defs/")), Some(true));
```

The runnable `recursive_schema_graph` example also demonstrates direct recursion, map-mediated recursion, and deserialization of real positions:

```bash
cargo run --example recursive_schema_graph
```

## Intentional Gemini behavior correction

Gemini does not accept recursive JSON Schema references. Previously, finite-depth expansion eventually replaced the recursive edge with `{}`, silently widening the accepted data shape. Recursive schemas now return a non-retryable local compatibility error before any request is sent:

```rust
use rstructor::{backend::GeminiClient, error::RStructorError};

let result = GeminiClient::from_env()?
    .materialize::<Fund>("Extract the fund and prime-broker relationship")
    .await;

assert!(matches!(
    result,
    Err(RStructorError::SchemaCompatibilityError { provider, .. })
        if provider.as_ref() == "Gemini"
));
```

Acyclic local references still work: they are losslessly inlined with JSON Pointer escaping and `$ref` sibling conjunction preserved. OpenAI, Anthropic, and Grok continue to receive the canonical reference graph.

## Breaking API change

Custom `DynTool` implementations previously supplied both canonical and Gemini-specific schemas:

```rust
fn parameters_schema(&self) -> serde_json::Value { /* canonical schema */ }
fn parameters_schema_gemini(&self) -> serde_json::Value { /* Gemini rewrite */ }
```

They now implement only the canonical schema:

```rust
fn parameters_schema(&self) -> serde_json::Value { /* canonical schema */ }
```

Gemini compilation is centralized in the provider boundary, so every tool path gets identical validation, reference resolution, and error handling.

## Test coverage

The graph contract has 17 focused tests using realistic fund, prime-broker, venue, and position fixtures. Coverage includes:

- direct, two-node, and three-node cycles across structs, enums, maps, and collections
- same short names, multiple generic instantiations, and lifetime-parameterized derives
- manual definitions with direct and transitive name collisions
- embedded root-relative references, including colliding root and local definition names
- internally tagged recursive newtypes and Serde-skipped recursive edges
- root-only definitions, resolvable local references, deterministic sequential/concurrent output, and no unused definitions
- Gemini acyclic, cyclic, orphan, escaped-pointer, sibling, normal, streaming, and tool paths

Validation run:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features --no-fail-fast`
- `cargo check --no-default-features --features derive`
- `cargo test --doc --all-features`
- `cargo run --quiet --example recursive_schema_graph`
