### PR TITLE
Add materialization retry attempt ledgers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,10 @@ required-features = ["tools", "openai"]
 name = "mock_testing_example"
 required-features = ["mock"]
 
+[[example]]
+name = "retry_attempt_ledger"
+required-features = ["openai"]
+
 [dev-dependencies]
 # Used only by examples and tests (date/time fields, custom types); not part of
 # the public dependency closure.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ fn validate_movie(movie: &Movie) -> Result<()> {
     Ok(())
 }
 
-// Retries are enabled by default (3 attempts with error feedback)
+// Retries are enabled by default (3 retries, 4 total attempts)
 // To increase retries:
 let client = OpenAIClient::from_env()?.max_retries(5);
 
@@ -555,6 +555,9 @@ match client.materialize_with_attempts::<Portfolio>("Reconcile the fund book").a
 Usage is conservative: attempts remain in the ledger when a provider omits
 token metadata, while cumulative totals include only responses with reported
 usage. Local schema/media preflight failures record zero provider attempts.
+Built-in clients and `MockClient` set `attempts_complete` to `true`; the default
+implementation for custom clients sets it to `false` rather than inventing
+provider attempts it cannot observe.
 See `examples/retry_attempt_ledger.rs` for a complete success-and-failure
 example.
 
@@ -738,11 +741,13 @@ async fn extracts_a_movie() {
 
 Script multiple responses with `with_response`/`with_responses` (a FIFO queue), branch
 on the request with `with_responder`, simulate the validation re-ask loop with
-`with_retries`, attach token usage with `with_usage`, and assert on captured requests via
-`requests()` / `last_request()`. The `mock` feature pulls in only the lightweight
-path-aware decoder and works without the HTTP client; streaming and tool-loop mocking
-light up when the `streaming` / `tools` features are also enabled. See
-`examples/mock_testing_example.rs`.
+`with_retries`, attach final/default token usage with `with_usage`, or attach
+per-attempt usage with `with_response_and_usage`. Assert on captured requests via
+`requests()` / `last_request()`. `RequestKind` is non-exhaustive, so downstream
+matches should include a wildcard arm as new client terminals are added. The `mock`
+feature pulls in only the lightweight path-aware decoder and works without the HTTP
+client; streaming and tool-loop mocking light up when the `streaming` / `tools`
+features are also enabled. See `examples/mock_testing_example.rs`.
 
 ## Feature Flags
 

--- a/README.md
+++ b/README.md
@@ -515,6 +515,9 @@ let client = OpenAIClient::from_env()?
 
 ## Token Usage
 
+`materialize_with_metadata` preserves its original behavior: `usage` describes
+only the final successful provider response.
+
 ```rust
 let result = client.materialize_with_metadata::<Movie>("...").await?;
 println!("Movie: {}", result.data.title);
@@ -522,6 +525,38 @@ if let Some(usage) = result.usage {
     println!("Tokens: {} in, {} out", usage.input_tokens, usage.output_tokens);
 }
 ```
+
+Use `materialize_with_attempts` when retry cost or failure observability matters.
+It returns an ordered ledger plus cumulative known usage, including provider
+responses that failed decoding or validation:
+
+```rust
+match client.materialize_with_attempts::<Portfolio>("Reconcile the fund book").await {
+    Ok(report) => {
+        println!("Portfolio: {:?}", report.data);
+        println!("Provider attempts: {}", report.attempts.len());
+        if let Some(usage) = report.cumulative_usage {
+            println!("Known run tokens: {}", usage.total_tokens());
+            for (model, model_usage) in usage.by_model {
+                println!("{model}: {} tokens", model_usage.total_tokens());
+            }
+        }
+    }
+    Err(failure) => {
+        eprintln!("Final error: {}", failure.error());
+        eprintln!("Attempts made: {}", failure.attempts.len());
+        if let Some(usage) = failure.cumulative_usage {
+            eprintln!("Known tokens before failure: {}", usage.total_tokens());
+        }
+    }
+}
+```
+
+Usage is conservative: attempts remain in the ledger when a provider omits
+token metadata, while cumulative totals include only responses with reported
+usage. Local schema/media preflight failures record zero provider attempts.
+See `examples/retry_attempt_ledger.rs` for a complete success-and-failure
+example.
 
 ## Error Handling
 
@@ -743,6 +778,7 @@ cargo run --example nested_objects_example
 cargo run --example enum_with_data_example
 cargo run --example serde_rename_example
 cargo run --example gemini_multimodal_example
+cargo run --example retry_attempt_ledger --features openai
 ```
 
 ## For Python Developers

--- a/examples/retry_attempt_ledger.rs
+++ b/examples/retry_attempt_ledger.rs
@@ -1,0 +1,73 @@
+use rstructor::{AttemptOutcome, AttemptRecord, Instructor, LLMClient, OpenAIClient, RunUsage};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Instructor, Serialize, Deserialize)]
+#[llm(description = "A reconciled investment portfolio")]
+struct Portfolio {
+    portfolio_id: String,
+    as_of: String,
+    positions: Vec<Position>,
+}
+
+#[derive(Debug, Instructor, Serialize, Deserialize)]
+struct Position {
+    symbol: String,
+    quantity: i64,
+    market_value_usd: f64,
+}
+
+fn print_attempts(attempts: &[AttemptRecord], cumulative_usage: Option<&RunUsage>) {
+    for attempt in attempts {
+        let outcome = match &attempt.outcome {
+            AttemptOutcome::Succeeded => "succeeded".to_string(),
+            AttemptOutcome::Failed { message, retried } => {
+                format!("failed (retried={retried}): {message}")
+            }
+        };
+        let tokens = attempt.usage.as_ref().map_or_else(
+            || "unknown".to_string(),
+            |usage| usage.total_tokens().to_string(),
+        );
+
+        println!(
+            "attempt {}: {:?}, {outcome}, tokens={tokens}",
+            attempt.number, attempt.kind
+        );
+    }
+
+    if let Some(usage) = cumulative_usage {
+        println!(
+            "known run usage: {} input + {} output = {} tokens across {} reported attempts",
+            usage.input_tokens,
+            usage.output_tokens,
+            usage.total_tokens(),
+            usage.reported_attempts
+        );
+        for (model, model_usage) in &usage.by_model {
+            println!("  {model}: {} tokens", model_usage.total_tokens());
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = OpenAIClient::from_env()?.max_retries(2);
+    let prompt = "
+        Reconcile portfolio HF-ALPHA-001 as of 2026-07-29:
+        ESU6: short 240 contracts, market value -$38,400,000
+        AAPL: long 125,000 shares, market value $29,750,000
+    ";
+
+    match client.materialize_with_attempts::<Portfolio>(prompt).await {
+        Ok(report) => {
+            println!("{:#?}", report.data);
+            print_attempts(&report.attempts, report.cumulative_usage.as_ref());
+        }
+        Err(failure) => {
+            eprintln!("materialization failed: {}", failure.error());
+            print_attempts(&failure.attempts, failure.cumulative_usage.as_ref());
+        }
+    }
+
+    Ok(())
+}

--- a/examples/retry_attempt_ledger.rs
+++ b/examples/retry_attempt_ledger.rs
@@ -20,9 +20,13 @@ fn print_attempts(attempts: &[AttemptRecord], cumulative_usage: Option<&RunUsage
     for attempt in attempts {
         let outcome = match &attempt.outcome {
             AttemptOutcome::Succeeded => "succeeded".to_string(),
-            AttemptOutcome::Failed { message, retried } => {
-                format!("failed (retried={retried}): {message}")
+            AttemptOutcome::Failed {
+                message,
+                disposition,
+            } => {
+                format!("failed ({disposition:?}): {message}")
             }
+            _ => "unknown outcome".to_string(),
         };
         let tokens = attempt.usage.as_ref().map_or_else(
             || "unknown".to_string(),
@@ -61,10 +65,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match client.materialize_with_attempts::<Portfolio>(prompt).await {
         Ok(report) => {
             println!("{:#?}", report.data);
+            println!("complete attempt history: {}", report.attempts_complete);
             print_attempts(&report.attempts, report.cumulative_usage.as_ref());
         }
         Err(failure) => {
             eprintln!("materialization failed: {}", failure.error());
+            eprintln!("complete attempt history: {}", failure.attempts_complete);
             print_attempts(&failure.attempts, failure.cumulative_usage.as_ref());
         }
     }

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -12,7 +12,7 @@ use crate::backend::{
     MaterializeResult, ModelInfo, StrictSchemaProvider, ThinkingLevel, TokenUsage,
     build_anthropic_message_content, build_http_client, check_response_status,
     compile_strict_schema, generate_with_retry_attempts_with_history,
-    generate_with_retry_with_history, handle_http_error,
+    generate_with_retry_with_history, handle_http_error, materialize_request_error,
     materialize_with_media_and_attempts_with_retry, materialize_with_media_with_retry,
     parse_validate_and_create_output,
 };
@@ -181,9 +181,20 @@ struct UsageInfo {
 
 #[derive(Debug, Deserialize)]
 struct CompletionResponse {
+    #[serde(
+        default,
+        deserialize_with = "crate::backend::utils::deserialize_or_default"
+    )]
     content: Vec<ContentBlock>,
+    #[serde(
+        default,
+        deserialize_with = "crate::backend::utils::deserialize_or_default"
+    )]
     model: Option<String>,
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::backend::utils::deserialize_or_default"
+    )]
     usage: Option<UsageInfo>,
 }
 
@@ -386,9 +397,7 @@ impl AnthropicClient {
             .json(&request)
             .send()
             .await
-            .map_err(|error| {
-                MaterializeAttemptError::transport(handle_http_error(error, "Anthropic"))
-            })?;
+            .map_err(|error| materialize_request_error(error, "Anthropic"))?;
 
         // Parse the response
         let response = check_response_status(response, "Anthropic")

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -8,10 +8,13 @@ use tracing::{debug, error, info, instrument, trace, warn};
 use crate::backend::model_macro::define_model_enum;
 use crate::backend::{
     AnthropicMessageContent, ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient,
-    MaterializeInternalOutput, MaterializeResult, ModelInfo, StrictSchemaProvider, ThinkingLevel,
-    TokenUsage, ValidationFailureContext, build_anthropic_message_content, build_http_client,
-    check_response_status, compile_strict_schema, generate_with_retry_with_history,
-    handle_http_error, materialize_with_media_with_retry, parse_validate_and_create_output,
+    MaterializeAttemptError, MaterializeFailure, MaterializeInternalOutput, MaterializeReport,
+    MaterializeResult, ModelInfo, StrictSchemaProvider, ThinkingLevel, TokenUsage,
+    build_anthropic_message_content, build_http_client, check_response_status,
+    compile_strict_schema, generate_with_retry_attempts_with_history,
+    generate_with_retry_with_history, handle_http_error,
+    materialize_with_media_and_attempts_with_retry, materialize_with_media_with_retry,
+    parse_validate_and_create_output,
 };
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
@@ -288,10 +291,7 @@ impl AnthropicClient {
     async fn materialize_internal<T>(
         &self,
         messages: &[ChatMessage],
-    ) -> std::result::Result<
-        MaterializeInternalOutput<T>,
-        (RStructorError, Option<ValidationFailureContext>),
-    >
+    ) -> std::result::Result<MaterializeInternalOutput<T>, MaterializeAttemptError>
     where
         T: Instructor + DeserializeOwned + Send + 'static,
     {
@@ -308,7 +308,7 @@ impl AnthropicClient {
             StrictSchemaProvider::Anthropic,
             "structured output",
         )
-        .map_err(|error| (error, None))?;
+        .map_err(MaterializeAttemptError::preflight)?;
 
         // Build API messages from conversation history
         // With native structured outputs, we don't need to include schema instructions in the prompt
@@ -321,7 +321,7 @@ impl AnthropicClient {
                 })
             })
             .collect::<Result<Vec<_>>>()
-            .map_err(|e| (e, None))?;
+            .map_err(MaterializeAttemptError::preflight)?;
 
         // Build thinking config for Claude 4.x models
         let is_thinking_model = self.config.model.as_str().contains("sonnet-4")
@@ -386,17 +386,19 @@ impl AnthropicClient {
             .json(&request)
             .send()
             .await
-            .map_err(|e| (handle_http_error(e, "Anthropic"), None))?;
+            .map_err(|error| {
+                MaterializeAttemptError::transport(handle_http_error(error, "Anthropic"))
+            })?;
 
         // Parse the response
         let response = check_response_status(response, "Anthropic")
             .await
-            .map_err(|e| (e, None))?;
+            .map_err(MaterializeAttemptError::transport)?;
 
         debug!("Successfully received response from Anthropic");
         let completion: CompletionResponse = response.json().await.map_err(|e| {
             error!(error = %e, "Failed to parse JSON response from Anthropic");
-            (RStructorError::from(e), None)
+            MaterializeAttemptError::transport(RStructorError::from(e))
         })?;
 
         // Extract usage info
@@ -425,14 +427,14 @@ impl AnthropicClient {
             }
             None => {
                 error!("No text content in Anthropic response");
-                return Err((
+                return Err(MaterializeAttemptError::transport_with_usage(
                     RStructorError::api_error(
                         "Anthropic",
                         ApiErrorKind::UnexpectedResponse {
                             details: "No text content in response".to_string(),
                         },
                     ),
-                    None,
+                    usage,
                 ));
             }
         };
@@ -817,6 +819,63 @@ impl LLMClient for AnthropicClient {
         )
         .await?;
         Ok(MaterializeResult::new(output.data, output.usage))
+    }
+
+    #[instrument(
+        name = "anthropic_materialize_with_attempts",
+        skip(self, prompt),
+        fields(
+            type_name = std::any::type_name::<T>(),
+            model = %self.config.model.as_str(),
+            prompt_len = prompt.len()
+        )
+    )]
+    async fn materialize_with_attempts<T>(
+        &self,
+        prompt: &str,
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        generate_with_retry_attempts_with_history(
+            |messages: Vec<ChatMessage>| {
+                let this = self;
+                async move { this.materialize_internal::<T>(&messages).await }
+            },
+            prompt,
+            self.config.max_retries,
+        )
+        .await
+    }
+
+    #[instrument(
+        name = "anthropic_materialize_with_media_and_attempts",
+        skip(self, prompt, media),
+        fields(
+            type_name = std::any::type_name::<T>(),
+            model = %self.config.model.as_str(),
+            prompt_len = prompt.len(),
+            media_len = media.len()
+        )
+    )]
+    async fn materialize_with_media_and_attempts<T>(
+        &self,
+        prompt: &str,
+        media: &[super::MediaFile],
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        materialize_with_media_and_attempts_with_retry(
+            |messages: Vec<ChatMessage>| {
+                let this = self;
+                async move { this.materialize_internal::<T>(&messages).await }
+            },
+            prompt,
+            media,
+            self.config.max_retries,
+        )
+        .await
     }
 
     #[instrument(

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -181,20 +181,8 @@ struct UsageInfo {
 
 #[derive(Debug, Deserialize)]
 struct CompletionResponse {
-    #[serde(
-        default,
-        deserialize_with = "crate::backend::utils::deserialize_or_default"
-    )]
     content: Vec<ContentBlock>,
-    #[serde(
-        default,
-        deserialize_with = "crate::backend::utils::deserialize_or_default"
-    )]
     model: Option<String>,
-    #[serde(
-        default,
-        deserialize_with = "crate::backend::utils::deserialize_or_default"
-    )]
     usage: Option<UsageInfo>,
 }
 

--- a/src/backend/any_client.rs
+++ b/src/backend/any_client.rs
@@ -10,7 +10,9 @@
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 
-use crate::backend::usage::{GenerateResult, MaterializeResult};
+use crate::backend::usage::{
+    GenerateResult, MaterializeFailure, MaterializeReport, MaterializeResult,
+};
 use crate::backend::{LLMClient, MediaFile, ModelInfo};
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
@@ -203,6 +205,27 @@ impl LLMClient for AnyClient {
         T: Instructor + DeserializeOwned + Send + 'static,
     {
         dispatch!(self, c => c.materialize_with_metadata(prompt).await)
+    }
+
+    async fn materialize_with_attempts<T>(
+        &self,
+        prompt: &str,
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        dispatch!(self, c => c.materialize_with_attempts(prompt).await)
+    }
+
+    async fn materialize_with_media_and_attempts<T>(
+        &self,
+        prompt: &str,
+        media: &[MediaFile],
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        dispatch!(self, c => c.materialize_with_media_and_attempts(prompt, media).await)
     }
 
     async fn generate(&self, prompt: &str) -> Result<String> {

--- a/src/backend/client.rs
+++ b/src/backend/client.rs
@@ -282,8 +282,9 @@ pub trait LLMClient {
     /// Built-in clients retain each successful, semantic-failed, or transport
     /// attempt together with per-response and cumulative usage. Local preflight
     /// failures have an empty ledger because no provider attempt occurred.
-    /// Custom clients receive a one-attempt success report and an empty-ledger
-    /// failure unless they override this method with richer information.
+    /// Custom clients receive final-only success metadata or the original
+    /// failure with `attempts_complete == false` unless they override this
+    /// method with richer information.
     ///
     /// This method returns [`MaterializeFailure`] on error so callers can inspect
     /// usage and attempts even when every retry fails. [`materialize`](Self::materialize)

--- a/src/backend/client.rs
+++ b/src/backend/client.rs
@@ -2,7 +2,9 @@ use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 
 use crate::backend::ModelInfo;
-use crate::backend::usage::{GenerateResult, MaterializeResult};
+use crate::backend::usage::{
+    GenerateResult, MaterializeFailure, MaterializeReport, MaterializeResult,
+};
 use crate::error::Result;
 use crate::model::Instructor;
 
@@ -274,6 +276,76 @@ pub trait LLMClient {
     async fn materialize_with_metadata<T>(&self, prompt: &str) -> Result<MaterializeResult<T>>
     where
         T: Instructor + DeserializeOwned + Send + 'static;
+
+    /// Materialize a structured object with a complete attempt ledger.
+    ///
+    /// Built-in clients retain each successful, semantic-failed, or transport
+    /// attempt together with per-response and cumulative usage. Local preflight
+    /// failures have an empty ledger because no provider attempt occurred.
+    /// Custom clients receive a one-attempt success report and an empty-ledger
+    /// failure unless they override this method with richer information.
+    ///
+    /// This method returns [`MaterializeFailure`] on error so callers can inspect
+    /// usage and attempts even when every retry fails. [`materialize`](Self::materialize)
+    /// and [`materialize_with_metadata`](Self::materialize_with_metadata) keep
+    /// returning the original final [`RStructorError`](crate::RStructorError).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use rstructor::{Instructor, LLMClient, OpenAIClient};
+    /// # use serde::{Deserialize, Serialize};
+    /// # #[derive(Instructor, Serialize, Deserialize)]
+    /// # struct Position { symbol: String, quantity: i64 }
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenAIClient::from_env()?;
+    /// let report = client
+    ///     .materialize_with_attempts::<Position>("AAPL: 1,000 shares")
+    ///     .await?;
+    ///
+    /// println!("Attempts: {}", report.attempts.len());
+    /// if let Some(usage) = report.cumulative_usage {
+    ///     println!("Total tokens: {}", usage.total_tokens());
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn materialize_with_attempts<T>(
+        &self,
+        prompt: &str,
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        self.materialize_with_metadata(prompt)
+            .await
+            .map(MaterializeReport::from_result)
+            .map_err(MaterializeFailure::from_error)
+    }
+
+    /// Materialize with media and retain cumulative usage and every provider attempt.
+    ///
+    /// Built-in providers use the same ledger semantics as
+    /// [`materialize_with_attempts`](Self::materialize_with_attempts). The
+    /// default implementation preserves compatibility for custom clients but
+    /// cannot recover per-attempt metadata hidden by their existing media method.
+    async fn materialize_with_media_and_attempts<T>(
+        &self,
+        prompt: &str,
+        media: &[MediaFile],
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        if media.is_empty() {
+            self.materialize_with_attempts(prompt).await
+        } else {
+            self.materialize_with_media(prompt, media)
+                .await
+                .map(|data| MaterializeReport::from_result(MaterializeResult::from_data(data)))
+                .map_err(MaterializeFailure::from_error)
+        }
+    }
 
     /// Raw completion without structure (returns plain text).
     ///

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -11,8 +11,8 @@ use crate::backend::{
     MaterializeFailure, MaterializeInternalOutput, MaterializeReport, MaterializeResult, ModelInfo,
     ThinkingLevel, TokenUsage, build_http_client, check_response_status,
     generate_with_retry_attempts_with_history, generate_with_retry_with_history, handle_http_error,
-    materialize_with_media_and_attempts_with_retry, materialize_with_media_with_retry,
-    parse_validate_and_create_output,
+    materialize_request_error, materialize_with_media_and_attempts_with_retry,
+    materialize_with_media_with_retry, parse_validate_and_create_output,
 };
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
@@ -181,10 +181,22 @@ struct UsageMetadata {
 
 #[derive(Debug, Deserialize)]
 struct GenerateContentResponse {
+    #[serde(
+        default,
+        deserialize_with = "crate::backend::utils::deserialize_or_default"
+    )]
     candidates: Vec<Candidate>,
-    #[serde(rename = "usageMetadata", default)]
+    #[serde(
+        rename = "usageMetadata",
+        default,
+        deserialize_with = "crate::backend::utils::deserialize_or_default"
+    )]
     usage_metadata: Option<UsageMetadata>,
-    #[serde(rename = "modelVersion", default)]
+    #[serde(
+        rename = "modelVersion",
+        default,
+        deserialize_with = "crate::backend::utils::deserialize_or_default"
+    )]
     model_version: Option<String>,
 }
 
@@ -426,9 +438,7 @@ impl GeminiClient {
             .json(&request)
             .send()
             .await
-            .map_err(|error| {
-                MaterializeAttemptError::transport(handle_http_error(error, "Gemini"))
-            })?;
+            .map_err(|error| materialize_request_error(error, "Gemini"))?;
 
         let response = check_response_status(response, "Gemini")
             .await

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -7,10 +7,12 @@ use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::backend::model_macro::define_model_enum;
 use crate::backend::{
-    ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient, MaterializeInternalOutput,
-    MaterializeResult, ModelInfo, ThinkingLevel, TokenUsage, ValidationFailureContext,
-    build_http_client, check_response_status, generate_with_retry_with_history, handle_http_error,
-    materialize_with_media_with_retry, parse_validate_and_create_output,
+    ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient, MaterializeAttemptError,
+    MaterializeFailure, MaterializeInternalOutput, MaterializeReport, MaterializeResult, ModelInfo,
+    ThinkingLevel, TokenUsage, build_http_client, check_response_status,
+    generate_with_retry_attempts_with_history, generate_with_retry_with_history, handle_http_error,
+    materialize_with_media_and_attempts_with_retry, materialize_with_media_with_retry,
+    parse_validate_and_create_output,
 };
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
@@ -352,10 +354,7 @@ impl GeminiClient {
     async fn materialize_internal<T>(
         &self,
         messages: &[ChatMessage],
-    ) -> std::result::Result<
-        MaterializeInternalOutput<T>,
-        (RStructorError, Option<ValidationFailureContext>),
-    >
+    ) -> std::result::Result<MaterializeInternalOutput<T>, MaterializeAttemptError>
     where
         T: Instructor + DeserializeOwned + Send + 'static,
     {
@@ -389,7 +388,7 @@ impl GeminiClient {
         // preserving supported typed-map constraints.
         let gemini_schema =
             crate::backend::utils::prepare_gemini_schema(&schema, "structured output")
-                .map_err(|error| (error, None))?;
+                .map_err(MaterializeAttemptError::preflight)?;
         let generation_config = GenerationConfig {
             temperature: self.config.temperature,
             max_output_tokens: self.config.max_tokens,
@@ -427,32 +426,22 @@ impl GeminiClient {
             .json(&request)
             .send()
             .await
-            .map_err(|e| (handle_http_error(e, "Gemini"), None))?;
+            .map_err(|error| {
+                MaterializeAttemptError::transport(handle_http_error(error, "Gemini"))
+            })?;
 
         let response = check_response_status(response, "Gemini")
             .await
-            .map_err(|e| (e, None))?;
+            .map_err(MaterializeAttemptError::transport)?;
 
         debug!("Successfully received response from Gemini API");
         let completion: GenerateContentResponse = response.json().await.map_err(|e| {
             error!(error = %e, "Failed to parse JSON response from Gemini API");
-            (RStructorError::from(e), None)
+            MaterializeAttemptError::transport(RStructorError::from(e))
         })?;
 
-        if completion.candidates.is_empty() {
-            error!("Gemini API returned empty candidates array");
-            return Err((
-                RStructorError::api_error(
-                    "Gemini",
-                    ApiErrorKind::UnexpectedResponse {
-                        details: "No completion candidates returned".to_string(),
-                    },
-                ),
-                None,
-            ));
-        }
-
-        // Extract usage info
+        // Extract usage before validating the envelope so protocol failures can
+        // still report provider-billed tokens.
         let model_name = completion
             .model_version
             .clone()
@@ -464,6 +453,19 @@ impl GeminiClient {
                 u.candidates_token_count,
             )
         });
+
+        if completion.candidates.is_empty() {
+            error!("Gemini API returned empty candidates array");
+            return Err(MaterializeAttemptError::transport_with_usage(
+                RStructorError::api_error(
+                    "Gemini",
+                    ApiErrorKind::UnexpectedResponse {
+                        details: "No completion candidates returned".to_string(),
+                    },
+                ),
+                usage,
+            ));
+        }
 
         let candidate = &completion.candidates[0];
         trace!(finish_reason = ?candidate.finish_reason, "Completion finish reason");
@@ -495,14 +497,14 @@ impl GeminiClient {
         }
 
         error!("No text content in Gemini response");
-        Err((
+        Err(MaterializeAttemptError::transport_with_usage(
             RStructorError::api_error(
                 "Gemini",
                 ApiErrorKind::UnexpectedResponse {
                     details: "No text content in response".to_string(),
                 },
             ),
-            None,
+            usage,
         ))
     }
 
@@ -867,6 +869,63 @@ impl LLMClient for GeminiClient {
         )
         .await?;
         Ok(MaterializeResult::new(output.data, output.usage))
+    }
+
+    #[instrument(
+        name = "gemini_materialize_with_attempts",
+        skip(self, prompt),
+        fields(
+            type_name = std::any::type_name::<T>(),
+            model = %self.config.model.as_str(),
+            prompt_len = prompt.len()
+        )
+    )]
+    async fn materialize_with_attempts<T>(
+        &self,
+        prompt: &str,
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        generate_with_retry_attempts_with_history(
+            |messages: Vec<ChatMessage>| {
+                let this = self;
+                async move { this.materialize_internal::<T>(&messages).await }
+            },
+            prompt,
+            self.config.max_retries,
+        )
+        .await
+    }
+
+    #[instrument(
+        name = "gemini_materialize_with_media_and_attempts",
+        skip(self, prompt, media),
+        fields(
+            type_name = std::any::type_name::<T>(),
+            model = %self.config.model.as_str(),
+            prompt_len = prompt.len(),
+            media_len = media.len()
+        )
+    )]
+    async fn materialize_with_media_and_attempts<T>(
+        &self,
+        prompt: &str,
+        media: &[super::MediaFile],
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        materialize_with_media_and_attempts_with_retry(
+            |messages: Vec<ChatMessage>| {
+                let this = self;
+                async move { this.materialize_internal::<T>(&messages).await }
+            },
+            prompt,
+            media,
+            self.config.max_retries,
+        )
+        .await
     }
 
     #[instrument(

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -181,22 +181,10 @@ struct UsageMetadata {
 
 #[derive(Debug, Deserialize)]
 struct GenerateContentResponse {
-    #[serde(
-        default,
-        deserialize_with = "crate::backend::utils::deserialize_or_default"
-    )]
     candidates: Vec<Candidate>,
-    #[serde(
-        rename = "usageMetadata",
-        default,
-        deserialize_with = "crate::backend::utils::deserialize_or_default"
-    )]
+    #[serde(rename = "usageMetadata")]
     usage_metadata: Option<UsageMetadata>,
-    #[serde(
-        rename = "modelVersion",
-        default,
-        deserialize_with = "crate::backend::utils::deserialize_or_default"
-    )]
+    #[serde(rename = "modelVersion")]
     model_version: Option<String>,
 }
 

--- a/src/backend/grok.rs
+++ b/src/backend/grok.rs
@@ -11,8 +11,8 @@ use crate::backend::{
     StrictSchemaProvider, TokenUsage, build_http_client, check_response_status,
     compile_strict_schema, convert_openai_compatible_chat_messages,
     generate_with_retry_attempts_with_history, generate_with_retry_with_history, handle_http_error,
-    materialize_with_media_and_attempts_with_retry, materialize_with_media_with_retry,
-    parse_validate_and_create_output,
+    materialize_request_error, materialize_with_media_and_attempts_with_retry,
+    materialize_with_media_with_retry, parse_validate_and_create_output,
 };
 #[cfg(feature = "streaming")]
 use crate::backend::{OpenAICompatibleChatMessage, OpenAICompatibleMessageContent};
@@ -239,9 +239,7 @@ impl GrokClient {
             .json(&request)
             .send()
             .await
-            .map_err(|error| {
-                MaterializeAttemptError::transport(handle_http_error(error, "Grok"))
-            })?;
+            .map_err(|error| materialize_request_error(error, "Grok"))?;
 
         let response = check_response_status(response, "Grok")
             .await

--- a/src/backend/grok.rs
+++ b/src/backend/grok.rs
@@ -5,12 +5,14 @@ use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::backend::model_macro::define_model_enum;
 use crate::backend::{
-    ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient, MaterializeInternalOutput,
-    MaterializeResult, ModelInfo, OpenAICompatibleChatCompletionRequest,
-    OpenAICompatibleChatCompletionResponse, ResponseFormat, StrictSchemaProvider, TokenUsage,
-    ValidationFailureContext, build_http_client, check_response_status, compile_strict_schema,
-    convert_openai_compatible_chat_messages, generate_with_retry_with_history, handle_http_error,
-    materialize_with_media_with_retry, parse_validate_and_create_output,
+    ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient, MaterializeAttemptError,
+    MaterializeFailure, MaterializeInternalOutput, MaterializeReport, MaterializeResult, ModelInfo,
+    OpenAICompatibleChatCompletionRequest, OpenAICompatibleChatCompletionResponse, ResponseFormat,
+    StrictSchemaProvider, TokenUsage, build_http_client, check_response_status,
+    compile_strict_schema, convert_openai_compatible_chat_messages,
+    generate_with_retry_attempts_with_history, generate_with_retry_with_history, handle_http_error,
+    materialize_with_media_and_attempts_with_retry, materialize_with_media_with_retry,
+    parse_validate_and_create_output,
 };
 #[cfg(feature = "streaming")]
 use crate::backend::{OpenAICompatibleChatMessage, OpenAICompatibleMessageContent};
@@ -184,10 +186,7 @@ impl GrokClient {
     async fn materialize_internal<T>(
         &self,
         messages: &[ChatMessage],
-    ) -> std::result::Result<
-        MaterializeInternalOutput<T>,
-        (RStructorError, Option<ValidationFailureContext>),
-    >
+    ) -> std::result::Result<MaterializeInternalOutput<T>, MaterializeAttemptError>
     where
         T: Instructor + DeserializeOwned + Send + 'static,
     {
@@ -202,12 +201,12 @@ impl GrokClient {
         // silently narrow them to empty objects.
         let schema_json =
             compile_strict_schema(&schema, StrictSchemaProvider::Grok, "structured output")
-                .map_err(|error| (error, None))?;
+                .map_err(MaterializeAttemptError::preflight)?;
 
         // Build API messages from conversation history
         // With native structured outputs, we don't need to include schema instructions in the prompt
-        let api_messages =
-            convert_openai_compatible_chat_messages(messages, "Grok").map_err(|e| (e, None))?;
+        let api_messages = convert_openai_compatible_chat_messages(messages, "Grok")
+            .map_err(MaterializeAttemptError::preflight)?;
 
         // Create response format for native structured outputs
         let response_format = ResponseFormat::json_schema(schema_name.clone(), schema_json, None);
@@ -240,33 +239,23 @@ impl GrokClient {
             .json(&request)
             .send()
             .await
-            .map_err(|e| (handle_http_error(e, "Grok"), None))?;
+            .map_err(|error| {
+                MaterializeAttemptError::transport(handle_http_error(error, "Grok"))
+            })?;
 
         let response = check_response_status(response, "Grok")
             .await
-            .map_err(|e| (e, None))?;
+            .map_err(MaterializeAttemptError::transport)?;
 
         debug!("Successfully received response from Grok API");
         let completion: OpenAICompatibleChatCompletionResponse =
             response.json().await.map_err(|e| {
                 error!(error = %e, "Failed to parse JSON response from Grok API");
-                (RStructorError::from(e), None)
+                MaterializeAttemptError::transport(RStructorError::from(e))
             })?;
 
-        if completion.choices.is_empty() {
-            error!("Grok API returned empty choices array");
-            return Err((
-                RStructorError::api_error(
-                    "Grok",
-                    ApiErrorKind::UnexpectedResponse {
-                        details: "No completion choices returned".to_string(),
-                    },
-                ),
-                None,
-            ));
-        }
-
-        // Extract usage info
+        // Extract usage before validating the envelope so protocol failures can
+        // still report provider-billed tokens.
         let model_name = completion
             .model
             .clone()
@@ -275,6 +264,19 @@ impl GrokClient {
             .usage
             .as_ref()
             .map(|u| TokenUsage::new(model_name.clone(), u.prompt_tokens, u.completion_tokens));
+
+        if completion.choices.is_empty() {
+            error!("Grok API returned empty choices array");
+            return Err(MaterializeAttemptError::transport_with_usage(
+                RStructorError::api_error(
+                    "Grok",
+                    ApiErrorKind::UnexpectedResponse {
+                        details: "No completion choices returned".to_string(),
+                    },
+                ),
+                usage,
+            ));
+        }
 
         let message = &completion.choices[0].message;
         trace!(finish_reason = %completion.choices[0].finish_reason, "Completion finish reason");
@@ -292,14 +294,14 @@ impl GrokClient {
             parse_validate_and_create_output(raw_response, usage)
         } else {
             error!("No content in Grok API response");
-            Err((
+            Err(MaterializeAttemptError::transport_with_usage(
                 RStructorError::api_error(
                     "Grok",
                     ApiErrorKind::UnexpectedResponse {
                         details: "No content in response".to_string(),
                     },
                 ),
-                None,
+                usage,
             ))
         }
     }
@@ -589,6 +591,63 @@ impl LLMClient for GrokClient {
         )
         .await?;
         Ok(MaterializeResult::new(output.data, output.usage))
+    }
+
+    #[instrument(
+        name = "grok_materialize_with_attempts",
+        skip(self, prompt),
+        fields(
+            type_name = std::any::type_name::<T>(),
+            model = %self.config.model.as_str(),
+            prompt_len = prompt.len()
+        )
+    )]
+    async fn materialize_with_attempts<T>(
+        &self,
+        prompt: &str,
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        generate_with_retry_attempts_with_history(
+            |messages: Vec<ChatMessage>| {
+                let this = self;
+                async move { this.materialize_internal::<T>(&messages).await }
+            },
+            prompt,
+            self.config.max_retries,
+        )
+        .await
+    }
+
+    #[instrument(
+        name = "grok_materialize_with_media_and_attempts",
+        skip(self, prompt, media),
+        fields(
+            type_name = std::any::type_name::<T>(),
+            model = %self.config.model.as_str(),
+            prompt_len = prompt.len(),
+            media_len = media.len()
+        )
+    )]
+    async fn materialize_with_media_and_attempts<T>(
+        &self,
+        prompt: &str,
+        media: &[super::MediaFile],
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        materialize_with_media_and_attempts_with_retry(
+            |messages: Vec<ChatMessage>| {
+                let this = self;
+                async move { this.materialize_internal::<T>(&messages).await }
+            },
+            prompt,
+            media,
+            self.config.max_retries,
+        )
+        .await
     }
 
     #[instrument(

--- a/src/backend/messages.rs
+++ b/src/backend/messages.rs
@@ -154,3 +154,58 @@ impl ValidationFailureContext {
         }
     }
 }
+
+/// Internal classification of one provider call before the retry policy is applied.
+#[cfg(feature = "_client")]
+#[derive(Debug)]
+pub(crate) enum MaterializeAttemptError {
+    /// Failure before any provider request was made.
+    Preflight(Box<crate::RStructorError>),
+    /// A provider request did not yield structured output suitable for validation.
+    Transport {
+        error: Box<crate::RStructorError>,
+        usage: Option<crate::backend::TokenUsage>,
+    },
+    /// Structured output reached decoding or custom validation and failed there.
+    Semantic {
+        error: Box<crate::RStructorError>,
+        context: ValidationFailureContext,
+        usage: Option<crate::backend::TokenUsage>,
+    },
+}
+
+#[cfg(feature = "_client")]
+impl MaterializeAttemptError {
+    pub(crate) fn preflight(error: crate::RStructorError) -> Self {
+        Self::Preflight(Box::new(error))
+    }
+
+    pub(crate) fn transport(error: crate::RStructorError) -> Self {
+        Self::Transport {
+            error: Box::new(error),
+            usage: None,
+        }
+    }
+
+    pub(crate) fn transport_with_usage(
+        error: crate::RStructorError,
+        usage: Option<crate::backend::TokenUsage>,
+    ) -> Self {
+        Self::Transport {
+            error: Box::new(error),
+            usage,
+        }
+    }
+
+    pub(crate) fn semantic(
+        error: crate::RStructorError,
+        context: ValidationFailureContext,
+        usage: Option<crate::backend::TokenUsage>,
+    ) -> Self {
+        Self::Semantic {
+            error: Box::new(error),
+            context,
+            usage,
+        }
+    }
+}

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -60,7 +60,7 @@ use crate::backend::ModelInfo;
 use crate::backend::client::{LLMClient, MediaFile};
 use crate::backend::usage::{
     AttemptKind, AttemptRecord, GenerateResult, MaterializeFailure, MaterializeReport,
-    MaterializeResult, RunUsage, TokenUsage,
+    MaterializeResult, RetryDisposition, RunUsage, TokenUsage,
 };
 use crate::error::{RStructorError, Result};
 use crate::model::Instructor;
@@ -196,6 +196,7 @@ impl ScriptedResponse {
 
 /// Which [`LLMClient`](crate::LLMClient) (or extension) method produced a
 /// [`RecordedRequest`].
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RequestKind {
     /// [`LLMClient::materialize`](crate::LLMClient::materialize)
@@ -669,15 +670,19 @@ impl MockClient {
                             ));
                         }
                         Err(error) => {
-                            let retried = attempt + 1 < attempts;
+                            let disposition = if attempt + 1 < attempts {
+                                RetryDisposition::Retried
+                            } else {
+                                RetryDisposition::BudgetExhausted
+                            };
                             ledger.push(AttemptRecord::failed(
                                 attempt + 1,
                                 AttemptKind::Semantic,
                                 &error,
-                                retried,
+                                disposition,
                                 usage,
                             ));
-                            if !retried {
+                            if disposition != RetryDisposition::Retried {
                                 return Err(MaterializeFailure::new(
                                     error,
                                     cumulative_usage,
@@ -701,7 +706,7 @@ impl MockClient {
                         attempt + 1,
                         AttemptKind::Transport,
                         &error,
-                        false,
+                        RetryDisposition::NonRetryable,
                         usage,
                     ));
                     return Err(MaterializeFailure::new(error, cumulative_usage, ledger));

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -58,7 +58,10 @@ use serde_json::Value;
 
 use crate::backend::ModelInfo;
 use crate::backend::client::{LLMClient, MediaFile};
-use crate::backend::usage::{GenerateResult, MaterializeResult, TokenUsage};
+use crate::backend::usage::{
+    AttemptKind, AttemptRecord, GenerateResult, MaterializeFailure, MaterializeReport,
+    MaterializeResult, RunUsage, TokenUsage,
+};
 use crate::error::{RStructorError, Result};
 use crate::model::Instructor;
 use crate::schema::SchemaType;
@@ -166,6 +169,31 @@ impl Clone for MockResponse {
     }
 }
 
+#[derive(Clone)]
+struct ScriptedResponse {
+    response: MockResponse,
+    usage: Option<TokenUsage>,
+    counts_as_attempt: bool,
+}
+
+impl ScriptedResponse {
+    fn new(response: MockResponse) -> Self {
+        Self {
+            response,
+            usage: None,
+            counts_as_attempt: true,
+        }
+    }
+
+    fn preflight(response: MockResponse) -> Self {
+        Self {
+            response,
+            usage: None,
+            counts_as_attempt: false,
+        }
+    }
+}
+
 /// Which [`LLMClient`](crate::LLMClient) (or extension) method produced a
 /// [`RecordedRequest`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -174,6 +202,10 @@ pub enum RequestKind {
     Materialize,
     /// [`LLMClient::materialize_with_metadata`](crate::LLMClient::materialize_with_metadata)
     MaterializeWithMetadata,
+    /// [`LLMClient::materialize_with_attempts`](crate::LLMClient::materialize_with_attempts)
+    MaterializeWithAttempts,
+    /// [`LLMClient::materialize_with_media_and_attempts`](crate::LLMClient::materialize_with_media_and_attempts)
+    MaterializeWithMediaAndAttempts,
     /// [`LLMClient::materialize_with_media`](crate::LLMClient::materialize_with_media)
     MaterializeWithMedia,
     /// [`LLMClient::generate`](crate::LLMClient::generate)
@@ -267,11 +299,11 @@ impl<'a> MockRequestView<'a> {
 type Responder = Box<dyn Fn(&MockRequestView) -> Option<MockResponse> + Send + Sync>;
 
 struct MockState {
-    queue: Mutex<VecDeque<MockResponse>>,
+    queue: Mutex<VecDeque<ScriptedResponse>>,
     responder: Mutex<Option<Responder>>,
     log: Mutex<Vec<RecordedRequest>>,
     models: Mutex<Vec<ModelInfo>>,
-    default_response: Mutex<MockResponse>,
+    default_response: Mutex<ScriptedResponse>,
     default_usage: Mutex<Option<TokenUsage>>,
     /// Extra parse+validate attempts on failure (simulates the provider re-ask
     /// loop): on a failed `materialize`, consume the next queued response.
@@ -292,9 +324,11 @@ impl Default for MockState {
                 name: Some("Mock Model".to_string()),
                 description: Some("In-memory mock model".to_string()),
             }]),
-            default_response: Mutex::new(MockResponse::Error(RStructorError::Unsupported(
-                "MockClient: no scripted response configured (use .with_response/.with_responder/.with_default_response)"
-                    .to_string(),
+            default_response: Mutex::new(ScriptedResponse::preflight(MockResponse::Error(
+                RStructorError::Unsupported(
+                    "MockClient: no scripted response configured (use .with_response/.with_responder/.with_default_response)"
+                        .to_string(),
+                ),
             ))),
             default_usage: Mutex::new(None),
             retries: Mutex::new(0),
@@ -351,7 +385,26 @@ impl MockClient {
     /// Queue a response (FIFO). Chainable.
     #[must_use]
     pub fn with_response(self, resp: impl Into<MockResponse>) -> Self {
-        self.inner.queue.lock().unwrap().push_back(resp.into());
+        self.inner
+            .queue
+            .lock()
+            .unwrap()
+            .push_back(ScriptedResponse::new(resp.into()));
+        self
+    }
+
+    /// Queue a response with usage specific to that provider attempt.
+    #[must_use]
+    pub fn with_response_and_usage(self, resp: impl Into<MockResponse>, usage: TokenUsage) -> Self {
+        self.inner
+            .queue
+            .lock()
+            .unwrap()
+            .push_back(ScriptedResponse {
+                response: resp.into(),
+                usage: Some(usage),
+                counts_as_attempt: true,
+            });
         self
     }
 
@@ -364,7 +417,7 @@ impl MockClient {
     {
         let mut q = self.inner.queue.lock().unwrap();
         for r in resps {
-            q.push_back(r.into());
+            q.push_back(ScriptedResponse::new(r.into()));
         }
         drop(q);
         self
@@ -389,7 +442,11 @@ impl MockClient {
 
     /// Queue a response after construction (e.g. on a shared `Arc<MockClient>` clone).
     pub fn push_response(&self, resp: impl Into<MockResponse>) {
-        self.inner.queue.lock().unwrap().push_back(resp.into());
+        self.inner
+            .queue
+            .lock()
+            .unwrap()
+            .push_back(ScriptedResponse::new(resp.into()));
     }
 
     /// Queue an error response after construction.
@@ -433,7 +490,7 @@ impl MockClient {
     /// Set the response used when the queue and responder are both empty.
     #[must_use]
     pub fn with_default_response(self, resp: impl Into<MockResponse>) -> Self {
-        *self.inner.default_response.lock().unwrap() = resp.into();
+        *self.inner.default_response.lock().unwrap() = ScriptedResponse::new(resp.into());
         self
     }
 
@@ -550,12 +607,16 @@ impl MockClient {
 
     /// Pick a response without recording: responder closure, then queue, then default.
     fn pick_response(&self, view: &MockRequestView) -> MockResponse {
+        self.pick_scripted_response(view).response
+    }
+
+    fn pick_scripted_response(&self, view: &MockRequestView) -> ScriptedResponse {
         {
             let guard = self.inner.responder.lock().unwrap();
             if let Some(f) = guard.as_ref()
                 && let Some(r) = f(view)
             {
-                return r;
+                return ScriptedResponse::new(r);
             }
         }
         if let Some(r) = self.inner.queue.lock().unwrap().pop_front() {
@@ -568,21 +629,87 @@ impl MockClient {
     where
         T: Instructor + DeserializeOwned,
     {
+        self.resolve_materialize_with_attempts(view)
+            .map(|report| report.data)
+            .map_err(MaterializeFailure::into_error)
+    }
+
+    fn resolve_materialize_with_attempts<T>(
+        &self,
+        view: &MockRequestView,
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned,
+    {
         let attempts = 1 + *self.inner.retries.lock().unwrap();
-        let mut last_err: Option<RStructorError> = None;
-        for _ in 0..attempts {
-            match self.pick_response(view) {
-                MockResponse::Text(s) => match parse_and_validate::<T>(&s) {
-                    Ok(v) => return Ok(v),
-                    Err(e) => last_err = Some(e),
-                },
+        let default_usage = self.inner.default_usage.lock().unwrap().clone();
+        let mut ledger = Vec::with_capacity(attempts);
+        let mut cumulative_usage: Option<RunUsage> = None;
+
+        for attempt in 0..attempts {
+            let scripted = self.pick_scripted_response(view);
+            let usage = scripted.usage.or_else(|| default_usage.clone());
+
+            match scripted.response {
+                MockResponse::Text(raw) => {
+                    if let Some(response_usage) = usage.clone() {
+                        cumulative_usage
+                            .get_or_insert_with(RunUsage::new)
+                            .record(response_usage);
+                    }
+
+                    match parse_and_validate::<T>(&raw) {
+                        Ok(data) => {
+                            ledger.push(AttemptRecord::succeeded(attempt + 1, usage.clone()));
+                            return Ok(MaterializeReport::new(
+                                data,
+                                usage,
+                                cumulative_usage,
+                                ledger,
+                            ));
+                        }
+                        Err(error) => {
+                            let retried = attempt + 1 < attempts;
+                            ledger.push(AttemptRecord::failed(
+                                attempt + 1,
+                                AttemptKind::Semantic,
+                                &error,
+                                retried,
+                                usage,
+                            ));
+                            if !retried {
+                                return Err(MaterializeFailure::new(
+                                    error,
+                                    cumulative_usage,
+                                    ledger,
+                                ));
+                            }
+                        }
+                    }
+                }
                 // An explicitly scripted error is returned verbatim (not retried).
-                MockResponse::Error(e) => return Err(e),
+                MockResponse::Error(error) => {
+                    if !scripted.counts_as_attempt {
+                        return Err(MaterializeFailure::new(error, cumulative_usage, ledger));
+                    }
+                    if let Some(response_usage) = usage.clone() {
+                        cumulative_usage
+                            .get_or_insert_with(RunUsage::new)
+                            .record(response_usage);
+                    }
+                    ledger.push(AttemptRecord::failed(
+                        attempt + 1,
+                        AttemptKind::Transport,
+                        &error,
+                        false,
+                        usage,
+                    ));
+                    return Err(MaterializeFailure::new(error, cumulative_usage, ledger));
+                }
             }
         }
-        Err(last_err.unwrap_or_else(|| {
-            RStructorError::Unsupported("MockClient: no scripted response configured".to_string())
-        }))
+
+        unreachable!("a mock materialization always returns within its configured attempt budget")
     }
 }
 
@@ -635,9 +762,43 @@ impl LLMClient for MockClient {
         view.schema = Some(&schema);
         view.schema_name = schema_name.as_deref();
         self.record(&view);
-        let data = self.resolve_materialize::<T>(&view)?;
-        let usage = self.inner.default_usage.lock().unwrap().clone();
-        Ok(MaterializeResult { data, usage })
+        self.resolve_materialize_with_attempts::<T>(&view)
+            .map(MaterializeReport::into_result)
+            .map_err(MaterializeFailure::into_error)
+    }
+
+    async fn materialize_with_attempts<T>(
+        &self,
+        prompt: &str,
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        let schema = <T as SchemaType>::schema().to_json();
+        let schema_name = <T as SchemaType>::schema_name();
+        let mut view = MockRequestView::bare(RequestKind::MaterializeWithAttempts, prompt);
+        view.schema = Some(&schema);
+        view.schema_name = schema_name.as_deref();
+        self.record(&view);
+        self.resolve_materialize_with_attempts::<T>(&view)
+    }
+
+    async fn materialize_with_media_and_attempts<T>(
+        &self,
+        prompt: &str,
+        media: &[MediaFile],
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        let schema = <T as SchemaType>::schema().to_json();
+        let schema_name = <T as SchemaType>::schema_name();
+        let mut view = MockRequestView::bare(RequestKind::MaterializeWithMediaAndAttempts, prompt);
+        view.schema = Some(&schema);
+        view.schema_name = schema_name.as_deref();
+        view.media = media;
+        self.record(&view);
+        self.resolve_materialize_with_attempts::<T>(&view)
     }
 
     async fn generate(&self, prompt: &str) -> Result<String> {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -49,7 +49,7 @@ pub use streaming::{ItemStream, ObjectStream, StreamedObject, TextStream};
 pub use tools::{DynTool, FnTool, Tool, ToolRunner, Toolbox};
 pub use usage::{
     AttemptKind, AttemptOutcome, AttemptRecord, GenerateResult, MaterializeFailure,
-    MaterializeReport, MaterializeResult, RunUsage, TokenUsage,
+    MaterializeReport, MaterializeResult, RetryDisposition, RunUsage, TokenUsage,
 };
 
 /// Information about an available model from an LLM provider.
@@ -100,8 +100,8 @@ pub use utils::{DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT};
 pub(crate) use utils::{
     ResponseFormat, build_http_client, check_response_status,
     generate_with_retry_attempts_with_history, generate_with_retry_with_history, handle_http_error,
-    materialize_with_media_and_attempts_with_retry, materialize_with_media_with_retry,
-    parse_validate_and_create_output,
+    materialize_request_error, materialize_with_media_and_attempts_with_retry,
+    materialize_with_media_with_retry, parse_validate_and_create_output,
 };
 
 /// Thinking level configuration for models that support extended reasoning.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -34,6 +34,8 @@ pub mod openai;
 #[cfg(feature = "_client")]
 pub use any_client::{AnyClient, Provider};
 pub use client::{LLMClient, MediaFile};
+#[cfg(feature = "_client")]
+pub(crate) use messages::MaterializeAttemptError;
 pub use messages::{ChatMessage, ChatRole};
 #[cfg(feature = "_client")]
 pub use messages::{MaterializeInternalOutput, ValidationFailureContext};
@@ -45,7 +47,10 @@ pub use request::{Request, RequestExt};
 pub use streaming::{ItemStream, ObjectStream, StreamedObject, TextStream};
 #[cfg(feature = "tools")]
 pub use tools::{DynTool, FnTool, Tool, ToolRunner, Toolbox};
-pub use usage::{GenerateResult, MaterializeResult, TokenUsage};
+pub use usage::{
+    AttemptKind, AttemptOutcome, AttemptRecord, GenerateResult, MaterializeFailure,
+    MaterializeReport, MaterializeResult, RunUsage, TokenUsage,
+};
 
 /// Information about an available model from an LLM provider.
 ///
@@ -93,8 +98,10 @@ pub(crate) use schema_compatibility::{StrictSchemaProvider, compile_strict_schem
 pub use utils::{DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT};
 #[cfg(feature = "_client")]
 pub(crate) use utils::{
-    ResponseFormat, build_http_client, check_response_status, generate_with_retry_with_history,
-    handle_http_error, materialize_with_media_with_retry, parse_validate_and_create_output,
+    ResponseFormat, build_http_client, check_response_status,
+    generate_with_retry_attempts_with_history, generate_with_retry_with_history, handle_http_error,
+    materialize_with_media_and_attempts_with_retry, materialize_with_media_with_retry,
+    parse_validate_and_create_output,
 };
 
 /// Thinking level configuration for models that support extended reasoning.

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -11,8 +11,8 @@ use crate::backend::{
     StrictSchemaProvider, ThinkingLevel, TokenUsage, build_http_client, check_response_status,
     compile_strict_schema, convert_openai_compatible_chat_messages,
     generate_with_retry_attempts_with_history, generate_with_retry_with_history, handle_http_error,
-    materialize_with_media_and_attempts_with_retry, materialize_with_media_with_retry,
-    parse_validate_and_create_output,
+    materialize_request_error, materialize_with_media_and_attempts_with_retry,
+    materialize_with_media_with_retry, parse_validate_and_create_output,
 };
 #[cfg(feature = "streaming")]
 use crate::backend::{OpenAICompatibleChatMessage, OpenAICompatibleMessageContent};
@@ -390,9 +390,7 @@ impl OpenAIClient {
             .json(&request)
             .send()
             .await
-            .map_err(|error| {
-                MaterializeAttemptError::transport(handle_http_error(error, "OpenAI"))
-            })?;
+            .map_err(|error| materialize_request_error(error, "OpenAI"))?;
 
         // Parse the response
         let response = check_response_status(response, "OpenAI")

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -5,12 +5,13 @@ use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::backend::model_macro::define_model_enum;
 use crate::backend::{
-    ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient, MaterializeInternalOutput,
-    MaterializeResult, ModelInfo, OpenAICompatibleChatCompletionRequest,
-    OpenAICompatibleChatCompletionResponse, ResponseFormat, StrictSchemaProvider, ThinkingLevel,
-    TokenUsage, ValidationFailureContext, build_http_client, check_response_status,
+    ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient, MaterializeAttemptError,
+    MaterializeFailure, MaterializeInternalOutput, MaterializeReport, MaterializeResult, ModelInfo,
+    OpenAICompatibleChatCompletionRequest, OpenAICompatibleChatCompletionResponse, ResponseFormat,
+    StrictSchemaProvider, ThinkingLevel, TokenUsage, build_http_client, check_response_status,
     compile_strict_schema, convert_openai_compatible_chat_messages,
-    generate_with_retry_with_history, handle_http_error, materialize_with_media_with_retry,
+    generate_with_retry_attempts_with_history, generate_with_retry_with_history, handle_http_error,
+    materialize_with_media_and_attempts_with_retry, materialize_with_media_with_retry,
     parse_validate_and_create_output,
 };
 #[cfg(feature = "streaming")]
@@ -313,10 +314,7 @@ impl OpenAIClient {
     async fn materialize_internal<T>(
         &self,
         messages: &[ChatMessage],
-    ) -> std::result::Result<
-        MaterializeInternalOutput<T>,
-        (RStructorError, Option<ValidationFailureContext>),
-    >
+    ) -> std::result::Result<MaterializeInternalOutput<T>, MaterializeAttemptError>
     where
         T: Instructor + DeserializeOwned + Send + 'static,
     {
@@ -332,7 +330,7 @@ impl OpenAIClient {
         // silently narrow them to empty objects.
         let schema_json =
             compile_strict_schema(&schema, StrictSchemaProvider::OpenAI, "structured output")
-                .map_err(|error| (error, None))?;
+                .map_err(MaterializeAttemptError::preflight)?;
 
         // Create response format with JSON schema (strict mode)
         let response_format = ResponseFormat::json_schema(
@@ -359,8 +357,8 @@ impl OpenAIClient {
         };
 
         // Convert ChatMessage to OpenAI's format
-        let api_messages =
-            convert_openai_compatible_chat_messages(messages, "OpenAI").map_err(|e| (e, None))?;
+        let api_messages = convert_openai_compatible_chat_messages(messages, "OpenAI")
+            .map_err(MaterializeAttemptError::preflight)?;
 
         // Build the request with native structured outputs
         debug!(
@@ -392,34 +390,24 @@ impl OpenAIClient {
             .json(&request)
             .send()
             .await
-            .map_err(|e| (handle_http_error(e, "OpenAI"), None))?;
+            .map_err(|error| {
+                MaterializeAttemptError::transport(handle_http_error(error, "OpenAI"))
+            })?;
 
         // Parse the response
         let response = check_response_status(response, "OpenAI")
             .await
-            .map_err(|e| (e, None))?;
+            .map_err(MaterializeAttemptError::transport)?;
 
         debug!("Successfully received response from OpenAI");
         let completion: OpenAICompatibleChatCompletionResponse =
             response.json().await.map_err(|e| {
                 error!(error = %e, "Failed to parse JSON response from OpenAI");
-                (RStructorError::from(e), None)
+                MaterializeAttemptError::transport(RStructorError::from(e))
             })?;
 
-        if completion.choices.is_empty() {
-            error!("OpenAI returned empty choices array");
-            return Err((
-                RStructorError::api_error(
-                    "OpenAI",
-                    ApiErrorKind::UnexpectedResponse {
-                        details: "No completion choices returned".to_string(),
-                    },
-                ),
-                None,
-            ));
-        }
-
-        // Extract usage info
+        // Extract usage before validating the envelope so protocol failures can
+        // still report provider-billed tokens.
         let model_name = completion
             .model
             .clone()
@@ -428,6 +416,19 @@ impl OpenAIClient {
             .usage
             .as_ref()
             .map(|u| TokenUsage::new(model_name.clone(), u.prompt_tokens, u.completion_tokens));
+
+        if completion.choices.is_empty() {
+            error!("OpenAI returned empty choices array");
+            return Err(MaterializeAttemptError::transport_with_usage(
+                RStructorError::api_error(
+                    "OpenAI",
+                    ApiErrorKind::UnexpectedResponse {
+                        details: "No completion choices returned".to_string(),
+                    },
+                ),
+                usage,
+            ));
+        }
 
         let message = &completion.choices[0].message;
         trace!(finish_reason = %completion.choices[0].finish_reason, "Completion finish reason");
@@ -444,14 +445,14 @@ impl OpenAIClient {
             parse_validate_and_create_output(raw_response, usage)
         } else {
             error!("No content in OpenAI response");
-            Err((
+            Err(MaterializeAttemptError::transport_with_usage(
                 RStructorError::api_error(
                     "OpenAI",
                     ApiErrorKind::UnexpectedResponse {
                         details: "No content in response".to_string(),
                     },
                 ),
-                None,
+                usage,
             ))
         }
     }
@@ -759,6 +760,63 @@ impl LLMClient for OpenAIClient {
         )
         .await?;
         Ok(MaterializeResult::new(output.data, output.usage))
+    }
+
+    #[instrument(
+        name = "openai_materialize_with_attempts",
+        skip(self, prompt),
+        fields(
+            type_name = std::any::type_name::<T>(),
+            model = %self.config.model.as_str(),
+            prompt_len = prompt.len()
+        )
+    )]
+    async fn materialize_with_attempts<T>(
+        &self,
+        prompt: &str,
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        generate_with_retry_attempts_with_history(
+            |messages: Vec<ChatMessage>| {
+                let this = self;
+                async move { this.materialize_internal::<T>(&messages).await }
+            },
+            prompt,
+            self.config.max_retries,
+        )
+        .await
+    }
+
+    #[instrument(
+        name = "openai_materialize_with_media_and_attempts",
+        skip(self, prompt, media),
+        fields(
+            type_name = std::any::type_name::<T>(),
+            model = %self.config.model.as_str(),
+            prompt_len = prompt.len(),
+            media_len = media.len()
+        )
+    )]
+    async fn materialize_with_media_and_attempts<T>(
+        &self,
+        prompt: &str,
+        media: &[super::MediaFile],
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        materialize_with_media_and_attempts_with_retry(
+            |messages: Vec<ChatMessage>| {
+                let this = self;
+                async move { this.materialize_internal::<T>(&messages).await }
+            },
+            prompt,
+            media,
+            self.config.max_retries,
+        )
+        .await
     }
 
     #[instrument(

--- a/src/backend/openai_compatible.rs
+++ b/src/backend/openai_compatible.rs
@@ -67,9 +67,20 @@ pub(crate) struct OpenAICompatibleUsageInfo {
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct OpenAICompatibleChatCompletionResponse {
+    #[serde(
+        default,
+        deserialize_with = "crate::backend::utils::deserialize_or_default"
+    )]
     pub choices: Vec<OpenAICompatibleChatCompletionChoice>,
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::backend::utils::deserialize_or_default"
+    )]
     pub usage: Option<OpenAICompatibleUsageInfo>,
+    #[serde(
+        default,
+        deserialize_with = "crate::backend::utils::deserialize_or_default"
+    )]
     pub model: Option<String>,
 }
 

--- a/src/backend/openai_compatible.rs
+++ b/src/backend/openai_compatible.rs
@@ -67,20 +67,8 @@ pub(crate) struct OpenAICompatibleUsageInfo {
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct OpenAICompatibleChatCompletionResponse {
-    #[serde(
-        default,
-        deserialize_with = "crate::backend::utils::deserialize_or_default"
-    )]
     pub choices: Vec<OpenAICompatibleChatCompletionChoice>,
-    #[serde(
-        default,
-        deserialize_with = "crate::backend::utils::deserialize_or_default"
-    )]
     pub usage: Option<OpenAICompatibleUsageInfo>,
-    #[serde(
-        default,
-        deserialize_with = "crate::backend::utils::deserialize_or_default"
-    )]
     pub model: Option<String>,
 }
 

--- a/src/backend/request.rs
+++ b/src/backend/request.rs
@@ -23,7 +23,7 @@
 
 use serde::de::DeserializeOwned;
 
-use crate::backend::{LLMClient, MediaFile};
+use crate::backend::{LLMClient, MaterializeFailure, MaterializeReport, MediaFile};
 #[cfg(feature = "streaming")]
 use crate::error::RStructorError;
 use crate::error::Result;
@@ -113,6 +113,24 @@ impl<C: LLMClient + Sync + ?Sized> Request<'_, C> {
         } else {
             self.client
                 .materialize_with_media(&prompt, &self.media)
+                .await
+        }
+    }
+
+    /// Materialize a structured `T` with cumulative usage and every provider attempt.
+    pub async fn materialize_with_attempts<T>(
+        self,
+        prompt: &str,
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        let prompt = self.combined(prompt);
+        if self.media.is_empty() {
+            self.client.materialize_with_attempts(&prompt).await
+        } else {
+            self.client
+                .materialize_with_media_and_attempts(&prompt, &self.media)
                 .await
         }
     }

--- a/src/backend/usage.rs
+++ b/src/backend/usage.rs
@@ -1,3 +1,8 @@
+use std::collections::BTreeMap;
+use std::fmt;
+
+use crate::error::RStructorError;
+
 /// Token usage information from an LLM API call.
 ///
 /// This struct contains the token counts returned by LLM providers,
@@ -6,17 +11,12 @@
 /// # Example
 ///
 /// ```no_run
-/// use rstructor::{LLMClient, OpenAIClient, Instructor};
-/// use serde::{Serialize, Deserialize};
-///
-/// #[derive(Instructor, Serialize, Deserialize)]
-/// struct Movie { title: String }
+/// use rstructor::{LLMClient, OpenAIClient};
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = OpenAIClient::from_env()?;
-/// let result = client.materialize_with_metadata::<Movie>("Describe Inception").await?;
+/// let result = client.generate_with_metadata("Describe Inception").await?;
 ///
-/// println!("Movie: {}", result.data.title);
 /// if let Some(usage) = &result.usage {
 ///     println!("Model: {}", usage.model);
 ///     println!("Input tokens: {}", usage.input_tokens);
@@ -51,10 +51,248 @@ impl TokenUsage {
     }
 }
 
+/// Cumulative token usage across every provider response in one materialization run.
+///
+/// Providers normally use one model for the whole run, but `by_model` preserves
+/// exact accounting if a provider reports different concrete model versions
+/// across retries.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RunUsage {
+    /// Number of attempts whose provider response included token usage.
+    ///
+    /// This can be lower than the number of attempts when a transport error
+    /// occurs or a provider omits usage metadata.
+    pub reported_attempts: usize,
+    /// Cumulative input tokens across all reported responses.
+    pub input_tokens: u64,
+    /// Cumulative output tokens across all reported responses.
+    pub output_tokens: u64,
+    /// Cumulative usage grouped by the exact model identifier reported.
+    pub by_model: BTreeMap<String, TokenUsage>,
+}
+
+impl RunUsage {
+    /// Create an empty cumulative usage record.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create cumulative usage from one provider response.
+    #[must_use]
+    pub fn from_response(usage: TokenUsage) -> Self {
+        let mut total = Self::new();
+        total.record(usage);
+        total
+    }
+
+    /// Add one provider response to the cumulative totals.
+    pub fn record(&mut self, usage: TokenUsage) {
+        self.reported_attempts += 1;
+        self.input_tokens += usage.input_tokens;
+        self.output_tokens += usage.output_tokens;
+
+        let model_usage = self
+            .by_model
+            .entry(usage.model.clone())
+            .or_insert_with(|| TokenUsage::new(usage.model, 0, 0));
+        model_usage.input_tokens += usage.input_tokens;
+        model_usage.output_tokens += usage.output_tokens;
+    }
+
+    /// Total known tokens used across the run.
+    #[must_use]
+    pub fn total_tokens(&self) -> u64 {
+        self.input_tokens + self.output_tokens
+    }
+}
+
+/// Whether an attempt reached structured-output validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttemptKind {
+    /// A structured response reached decoding and custom validation.
+    Semantic,
+    /// A provider request did not produce a usable structured response.
+    Transport,
+}
+
+/// Outcome of one materialization attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AttemptOutcome {
+    /// Structured output decoded and validated successfully.
+    Succeeded,
+    /// The attempt failed.
+    Failed {
+        /// Human-readable error message.
+        message: String,
+        /// Whether another attempt was actually made after this failure.
+        retried: bool,
+    },
+}
+
+/// Immutable record of one materialization attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttemptRecord {
+    /// One-indexed attempt number.
+    pub number: usize,
+    /// Whether this was a semantic or transport attempt.
+    pub kind: AttemptKind,
+    /// Success or categorized failure information.
+    pub outcome: AttemptOutcome,
+    /// Per-response token usage, when reported by the provider.
+    pub usage: Option<TokenUsage>,
+}
+
+impl AttemptRecord {
+    pub(crate) fn succeeded(number: usize, usage: Option<TokenUsage>) -> Self {
+        Self {
+            number,
+            kind: AttemptKind::Semantic,
+            outcome: AttemptOutcome::Succeeded,
+            usage,
+        }
+    }
+
+    pub(crate) fn failed(
+        number: usize,
+        kind: AttemptKind,
+        error: &RStructorError,
+        retried: bool,
+        usage: Option<TokenUsage>,
+    ) -> Self {
+        Self {
+            number,
+            kind,
+            outcome: AttemptOutcome::Failed {
+                message: error.to_string(),
+                retried,
+            },
+            usage,
+        }
+    }
+}
+
+/// Successful structured-output run with its complete attempt ledger.
+#[derive(Debug, Clone)]
+pub struct MaterializeReport<T> {
+    /// Deserialized and validated data.
+    pub data: T,
+    /// Usage from the final successful provider response.
+    pub final_usage: Option<TokenUsage>,
+    /// Cumulative known usage across every provider response in this run.
+    pub cumulative_usage: Option<RunUsage>,
+    /// Ordered, one-indexed attempt ledger.
+    pub attempts: Vec<AttemptRecord>,
+}
+
+impl<T> MaterializeReport<T> {
+    pub(crate) fn new(
+        data: T,
+        final_usage: Option<TokenUsage>,
+        cumulative_usage: Option<RunUsage>,
+        attempts: Vec<AttemptRecord>,
+    ) -> Self {
+        Self {
+            data,
+            final_usage,
+            cumulative_usage,
+            attempts,
+        }
+    }
+
+    /// Build a one-attempt report from a client's existing metadata result.
+    ///
+    /// This is used by the default [`LLMClient`](crate::LLMClient)
+    /// implementation for custom clients that do not expose per-attempt
+    /// responses. Built-in clients override that method with the full ledger.
+    #[must_use]
+    pub fn from_result(result: MaterializeResult<T>) -> Self {
+        let final_usage = result.usage;
+        let cumulative_usage = final_usage.clone().map(RunUsage::from_response);
+        Self::new(
+            result.data,
+            final_usage.clone(),
+            cumulative_usage,
+            vec![AttemptRecord::succeeded(1, final_usage)],
+        )
+    }
+
+    /// Map the successful data while preserving usage and attempt metadata.
+    pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> MaterializeReport<U> {
+        MaterializeReport {
+            data: f(self.data),
+            final_usage: self.final_usage,
+            cumulative_usage: self.cumulative_usage,
+            attempts: self.attempts,
+        }
+    }
+
+    /// Discard the attempt ledger and keep the successful data and final usage.
+    #[must_use]
+    pub fn into_result(self) -> MaterializeResult<T> {
+        MaterializeResult::new(self.data, self.final_usage)
+    }
+}
+
+/// Failed structured-output run with cumulative usage and every attempt.
+#[derive(Debug)]
+pub struct MaterializeFailure {
+    /// Final error returned by the last or non-retryable attempt.
+    error: Box<RStructorError>,
+    /// Cumulative known token usage across every provider response.
+    pub cumulative_usage: Option<RunUsage>,
+    /// Ordered, one-indexed attempt ledger.
+    pub attempts: Vec<AttemptRecord>,
+}
+
+impl MaterializeFailure {
+    pub(crate) fn new(
+        error: RStructorError,
+        cumulative_usage: Option<RunUsage>,
+        attempts: Vec<AttemptRecord>,
+    ) -> Self {
+        Self {
+            error: Box::new(error),
+            cumulative_usage,
+            attempts,
+        }
+    }
+
+    /// Create an empty-ledger failure when a client cannot expose attempt metadata.
+    #[must_use]
+    pub fn from_error(error: RStructorError) -> Self {
+        Self::new(error, None, Vec::new())
+    }
+
+    /// Return the original final error.
+    #[must_use]
+    pub fn error(&self) -> &RStructorError {
+        &self.error
+    }
+
+    /// Consume the report and return the original final error.
+    #[must_use]
+    pub fn into_error(self) -> RStructorError {
+        *self.error
+    }
+}
+
+impl fmt::Display for MaterializeFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.error().fmt(formatter)
+    }
+}
+
+impl std::error::Error for MaterializeFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.error())
+    }
+}
+
 /// Result of a materialize call, containing both the data and optional usage information.
 ///
 /// This struct wraps the deserialized data along with token usage metadata
-/// from the LLM API call.
+/// from the final successful LLM API call.
 ///
 /// # Example
 ///
@@ -120,5 +358,55 @@ impl GenerateResult {
     /// Create a new GenerateResult with text and usage
     pub fn new(text: String, usage: Option<TokenUsage>) -> Self {
         Self { text, usage }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_usage_groups_exact_provider_model_versions() {
+        let mut usage = RunUsage::new();
+        usage.record(TokenUsage::new("gpt-5.6-2026-07-01", 120, 30));
+        usage.record(TokenUsage::new("gpt-5.6-2026-07-01", 180, 45));
+        usage.record(TokenUsage::new("gpt-5.6-2026-07-15", 200, 50));
+
+        assert_eq!(usage.reported_attempts, 3);
+        assert_eq!(usage.input_tokens, 500);
+        assert_eq!(usage.output_tokens, 125);
+        assert_eq!(usage.total_tokens(), 625);
+        assert_eq!(
+            usage.by_model["gpt-5.6-2026-07-01"],
+            TokenUsage::new("gpt-5.6-2026-07-01", 300, 75)
+        );
+        assert_eq!(
+            usage.by_model["gpt-5.6-2026-07-15"],
+            TokenUsage::new("gpt-5.6-2026-07-15", 200, 50)
+        );
+    }
+
+    #[test]
+    fn custom_client_result_becomes_one_successful_semantic_attempt() {
+        let final_usage = TokenUsage::new("mock-risk-model", 42, 11);
+        let report =
+            MaterializeReport::from_result(MaterializeResult::new("portfolio", Some(final_usage)));
+
+        assert_eq!(report.data, "portfolio");
+        assert_eq!(report.final_usage.as_ref().unwrap().total_tokens(), 53);
+        assert_eq!(report.cumulative_usage.as_ref().unwrap().total_tokens(), 53);
+        assert_eq!(report.attempts.len(), 1);
+        assert_eq!(report.attempts[0].kind, AttemptKind::Semantic);
+        assert_eq!(report.attempts[0].outcome, AttemptOutcome::Succeeded);
+    }
+
+    #[test]
+    fn unknown_custom_client_failure_does_not_invent_a_provider_attempt() {
+        let failure =
+            MaterializeFailure::from_error(RStructorError::SchemaError("bad schema".into()));
+
+        assert!(failure.attempts.is_empty());
+        assert!(failure.cumulative_usage.is_none());
+        assert!(matches!(failure.error(), RStructorError::SchemaError(_)));
     }
 }

--- a/src/backend/usage.rs
+++ b/src/backend/usage.rs
@@ -54,9 +54,11 @@ impl TokenUsage {
 /// Cumulative token usage across every provider response in one materialization run.
 ///
 /// Providers normally use one model for the whole run, but `by_model` preserves
-/// exact accounting if a provider reports different concrete model versions
-/// across retries.
+/// accounting if a provider reports different concrete model versions across
+/// retries. Keys use the response's model identifier when present and the
+/// configured model as a fallback.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub struct RunUsage {
     /// Number of attempts whose provider response included token usage.
     ///
@@ -67,8 +69,13 @@ pub struct RunUsage {
     pub input_tokens: u64,
     /// Cumulative output tokens across all reported responses.
     pub output_tokens: u64,
-    /// Cumulative usage grouped by the exact model identifier reported.
+    /// Cumulative usage grouped by reported model, or configured-model fallback.
     pub by_model: BTreeMap<String, TokenUsage>,
+    /// Whether any cumulative counter exceeded its representable range.
+    ///
+    /// When this is `true`, affected counters and `total_tokens()` saturate at
+    /// their maximum value rather than panicking or wrapping.
+    pub overflowed: bool,
 }
 
 impl RunUsage {
@@ -88,26 +95,65 @@ impl RunUsage {
 
     /// Add one provider response to the cumulative totals.
     pub fn record(&mut self, usage: TokenUsage) {
-        self.reported_attempts += 1;
-        self.input_tokens += usage.input_tokens;
-        self.output_tokens += usage.output_tokens;
+        self.reported_attempts = match self.reported_attempts.checked_add(1) {
+            Some(attempts) => attempts,
+            None => {
+                self.overflowed = true;
+                usize::MAX
+            }
+        };
+        self.input_tokens =
+            saturating_add(&mut self.overflowed, self.input_tokens, usage.input_tokens);
+        self.output_tokens = saturating_add(
+            &mut self.overflowed,
+            self.output_tokens,
+            usage.output_tokens,
+        );
 
         let model_usage = self
             .by_model
             .entry(usage.model.clone())
             .or_insert_with(|| TokenUsage::new(usage.model, 0, 0));
-        model_usage.input_tokens += usage.input_tokens;
-        model_usage.output_tokens += usage.output_tokens;
+        model_usage.input_tokens = saturating_add(
+            &mut self.overflowed,
+            model_usage.input_tokens,
+            usage.input_tokens,
+        );
+        model_usage.output_tokens = saturating_add(
+            &mut self.overflowed,
+            model_usage.output_tokens,
+            usage.output_tokens,
+        );
+
+        if self.input_tokens.checked_add(self.output_tokens).is_none()
+            || model_usage
+                .input_tokens
+                .checked_add(model_usage.output_tokens)
+                .is_none()
+        {
+            self.overflowed = true;
+        }
     }
 
     /// Total known tokens used across the run.
     #[must_use]
     pub fn total_tokens(&self) -> u64 {
-        self.input_tokens + self.output_tokens
+        self.input_tokens.saturating_add(self.output_tokens)
+    }
+}
+
+fn saturating_add(overflowed: &mut bool, left: u64, right: u64) -> u64 {
+    match left.checked_add(right) {
+        Some(total) => total,
+        None => {
+            *overflowed = true;
+            u64::MAX
+        }
     }
 }
 
 /// Whether an attempt reached structured-output validation.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AttemptKind {
     /// A structured response reached decoding and custom validation.
@@ -116,7 +162,20 @@ pub enum AttemptKind {
     Transport,
 }
 
+/// Why execution did or did not continue after a failed attempt.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetryDisposition {
+    /// Another provider attempt was made.
+    Retried,
+    /// The error was retryable, but the configured attempt budget was exhausted.
+    BudgetExhausted,
+    /// The active retry policy did not permit another attempt for this error.
+    NonRetryable,
+}
+
 /// Outcome of one materialization attempt.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AttemptOutcome {
     /// Structured output decoded and validated successfully.
@@ -125,13 +184,14 @@ pub enum AttemptOutcome {
     Failed {
         /// Human-readable error message.
         message: String,
-        /// Whether another attempt was actually made after this failure.
-        retried: bool,
+        /// Whether execution continued, exhausted its budget, or stopped early.
+        disposition: RetryDisposition,
     },
 }
 
 /// Immutable record of one materialization attempt.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct AttemptRecord {
     /// One-indexed attempt number.
     pub number: usize,
@@ -144,6 +204,7 @@ pub struct AttemptRecord {
 }
 
 impl AttemptRecord {
+    #[cfg(any(feature = "_client", feature = "mock"))]
     pub(crate) fn succeeded(number: usize, usage: Option<TokenUsage>) -> Self {
         Self {
             number,
@@ -153,11 +214,12 @@ impl AttemptRecord {
         }
     }
 
+    #[cfg(any(feature = "_client", feature = "mock"))]
     pub(crate) fn failed(
         number: usize,
         kind: AttemptKind,
         error: &RStructorError,
-        retried: bool,
+        disposition: RetryDisposition,
         usage: Option<TokenUsage>,
     ) -> Self {
         Self {
@@ -165,14 +227,15 @@ impl AttemptRecord {
             kind,
             outcome: AttemptOutcome::Failed {
                 message: error.to_string(),
-                retried,
+                disposition,
             },
             usage,
         }
     }
 }
 
-/// Successful structured-output run with its complete attempt ledger.
+/// Successful structured-output run with usage and available attempt metadata.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct MaterializeReport<T> {
     /// Deserialized and validated data.
@@ -183,9 +246,16 @@ pub struct MaterializeReport<T> {
     pub cumulative_usage: Option<RunUsage>,
     /// Ordered, one-indexed attempt ledger.
     pub attempts: Vec<AttemptRecord>,
+    /// Whether `attempts` and `cumulative_usage` cover the complete run.
+    ///
+    /// This is `true` for built-in providers and `MockClient`. It is `false`
+    /// for the default implementation used by custom clients, whose existing
+    /// materialization methods do not expose their internal attempts.
+    pub attempts_complete: bool,
 }
 
 impl<T> MaterializeReport<T> {
+    #[cfg(any(feature = "_client", feature = "mock"))]
     pub(crate) fn new(
         data: T,
         final_usage: Option<TokenUsage>,
@@ -197,24 +267,25 @@ impl<T> MaterializeReport<T> {
             final_usage,
             cumulative_usage,
             attempts,
+            attempts_complete: true,
         }
     }
 
-    /// Build a one-attempt report from a client's existing metadata result.
+    /// Build a report from final-only metadata with unavailable attempt history.
     ///
     /// This is used by the default [`LLMClient`](crate::LLMClient)
     /// implementation for custom clients that do not expose per-attempt
-    /// responses. Built-in clients override that method with the full ledger.
+    /// responses. `final_usage` remains available, but `cumulative_usage` and
+    /// `attempts` are empty and `attempts_complete` is `false`.
     #[must_use]
     pub fn from_result(result: MaterializeResult<T>) -> Self {
-        let final_usage = result.usage;
-        let cumulative_usage = final_usage.clone().map(RunUsage::from_response);
-        Self::new(
-            result.data,
-            final_usage.clone(),
-            cumulative_usage,
-            vec![AttemptRecord::succeeded(1, final_usage)],
-        )
+        Self {
+            data: result.data,
+            final_usage: result.usage,
+            cumulative_usage: None,
+            attempts: Vec::new(),
+            attempts_complete: false,
+        }
     }
 
     /// Map the successful data while preserving usage and attempt metadata.
@@ -224,6 +295,7 @@ impl<T> MaterializeReport<T> {
             final_usage: self.final_usage,
             cumulative_usage: self.cumulative_usage,
             attempts: self.attempts,
+            attempts_complete: self.attempts_complete,
         }
     }
 
@@ -234,7 +306,8 @@ impl<T> MaterializeReport<T> {
     }
 }
 
-/// Failed structured-output run with cumulative usage and every attempt.
+/// Failed structured-output run with available usage and attempt metadata.
+#[non_exhaustive]
 #[derive(Debug)]
 pub struct MaterializeFailure {
     /// Final error returned by the last or non-retryable attempt.
@@ -243,9 +316,12 @@ pub struct MaterializeFailure {
     pub cumulative_usage: Option<RunUsage>,
     /// Ordered, one-indexed attempt ledger.
     pub attempts: Vec<AttemptRecord>,
+    /// Whether `attempts` and `cumulative_usage` cover the complete run.
+    pub attempts_complete: bool,
 }
 
 impl MaterializeFailure {
+    #[cfg(any(feature = "_client", feature = "mock"))]
     pub(crate) fn new(
         error: RStructorError,
         cumulative_usage: Option<RunUsage>,
@@ -255,13 +331,19 @@ impl MaterializeFailure {
             error: Box::new(error),
             cumulative_usage,
             attempts,
+            attempts_complete: true,
         }
     }
 
     /// Create an empty-ledger failure when a client cannot expose attempt metadata.
     #[must_use]
     pub fn from_error(error: RStructorError) -> Self {
-        Self::new(error, None, Vec::new())
+        Self {
+            error: Box::new(error),
+            cumulative_usage: None,
+            attempts: Vec::new(),
+            attempts_complete: false,
+        }
     }
 
     /// Return the original final error.
@@ -376,6 +458,7 @@ mod tests {
         assert_eq!(usage.input_tokens, 500);
         assert_eq!(usage.output_tokens, 125);
         assert_eq!(usage.total_tokens(), 625);
+        assert!(!usage.overflowed);
         assert_eq!(
             usage.by_model["gpt-5.6-2026-07-01"],
             TokenUsage::new("gpt-5.6-2026-07-01", 300, 75)
@@ -387,17 +470,37 @@ mod tests {
     }
 
     #[test]
-    fn custom_client_result_becomes_one_successful_semantic_attempt() {
+    fn run_usage_saturates_and_flags_untrusted_counter_overflow() {
+        let mut usage = RunUsage::new();
+        usage.record(TokenUsage::new("hostile-compatible-endpoint", u64::MAX, 1));
+        usage.record(TokenUsage::new("hostile-compatible-endpoint", 1, u64::MAX));
+
+        assert!(usage.overflowed);
+        assert_eq!(usage.reported_attempts, 2);
+        assert_eq!(usage.input_tokens, u64::MAX);
+        assert_eq!(usage.output_tokens, u64::MAX);
+        assert_eq!(usage.total_tokens(), u64::MAX);
+        assert_eq!(
+            usage.by_model["hostile-compatible-endpoint"].input_tokens,
+            u64::MAX
+        );
+        assert_eq!(
+            usage.by_model["hostile-compatible-endpoint"].output_tokens,
+            u64::MAX
+        );
+    }
+
+    #[test]
+    fn custom_client_result_preserves_final_usage_without_inventing_attempts() {
         let final_usage = TokenUsage::new("mock-risk-model", 42, 11);
         let report =
             MaterializeReport::from_result(MaterializeResult::new("portfolio", Some(final_usage)));
 
         assert_eq!(report.data, "portfolio");
         assert_eq!(report.final_usage.as_ref().unwrap().total_tokens(), 53);
-        assert_eq!(report.cumulative_usage.as_ref().unwrap().total_tokens(), 53);
-        assert_eq!(report.attempts.len(), 1);
-        assert_eq!(report.attempts[0].kind, AttemptKind::Semantic);
-        assert_eq!(report.attempts[0].outcome, AttemptOutcome::Succeeded);
+        assert!(report.cumulative_usage.is_none());
+        assert!(report.attempts.is_empty());
+        assert!(!report.attempts_complete);
     }
 
     #[test]
@@ -407,6 +510,7 @@ mod tests {
 
         assert!(failure.attempts.is_empty());
         assert!(failure.cumulative_usage.is_none());
+        assert!(!failure.attempts_complete);
         assert!(matches!(failure.error(), RStructorError::SchemaError(_)));
     }
 }

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -1,5 +1,6 @@
 use crate::backend::{
-    ChatMessage, MaterializeInternalOutput, TokenUsage, ValidationFailureContext,
+    AttemptKind, AttemptRecord, ChatMessage, MaterializeAttemptError, MaterializeFailure,
+    MaterializeInternalOutput, MaterializeReport, RunUsage, TokenUsage, ValidationFailureContext,
 };
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
@@ -1034,16 +1035,20 @@ where
 pub fn parse_validate_and_create_output<T>(
     raw_response: String,
     usage: Option<TokenUsage>,
-) -> std::result::Result<
-    MaterializeInternalOutput<T>,
-    (RStructorError, Option<ValidationFailureContext>),
->
+) -> std::result::Result<MaterializeInternalOutput<T>, MaterializeAttemptError>
 where
     T: Instructor + DeserializeOwned,
 {
-    let result = parse_and_validate_response::<T>(&raw_response)?;
-    info!("Successfully generated and validated structured data");
-    Ok(MaterializeInternalOutput::new(result, raw_response, usage))
+    match parse_and_validate_response::<T>(&raw_response) {
+        Ok(result) => {
+            info!("Successfully generated and validated structured data");
+            Ok(MaterializeInternalOutput::new(result, raw_response, usage))
+        }
+        Err((error, Some(context))) => {
+            Err(MaterializeAttemptError::semantic(error, context, usage))
+        }
+        Err((error, None)) => Err(MaterializeAttemptError::transport_with_usage(error, usage)),
+    }
 }
 
 /// Convert a reqwest error to a RStructorError, handling timeout errors specially.
@@ -1264,10 +1269,7 @@ pub async fn generate_with_retry_with_history<F, Fut, T>(
 where
     F: FnMut(Vec<ChatMessage>) -> Fut,
     Fut: std::future::Future<
-            Output = std::result::Result<
-                MaterializeInternalOutput<T>,
-                (RStructorError, Option<ValidationFailureContext>),
-            >,
+            Output = std::result::Result<MaterializeInternalOutput<T>, MaterializeAttemptError>,
         >,
 {
     generate_with_retry_with_initial_messages(
@@ -1284,28 +1286,89 @@ where
 /// This is primarily used for multimodal prompts where the initial user message
 /// may contain attached media in addition to text.
 pub async fn generate_with_retry_with_initial_messages<F, Fut, T>(
-    mut generate_fn: F,
+    generate_fn: F,
     initial_messages: Vec<ChatMessage>,
     max_retries: Option<usize>,
 ) -> Result<MaterializeInternalOutput<T>>
 where
     F: FnMut(Vec<ChatMessage>) -> Fut,
     Fut: std::future::Future<
-            Output = std::result::Result<
-                MaterializeInternalOutput<T>,
-                (RStructorError, Option<ValidationFailureContext>),
-            >,
+            Output = std::result::Result<MaterializeInternalOutput<T>, MaterializeAttemptError>,
         >,
 {
-    let Some(max_retries) = max_retries.filter(|&n| n > 0) else {
-        // No retries configured - just run once with the provided initial messages
-        return generate_fn(initial_messages).await.map_err(|(err, _)| err);
-    };
+    let successful_run = run_materialize_attempts(generate_fn, initial_messages, max_retries)
+        .await
+        .map_err(MaterializeFailure::into_error)?;
+    Ok(MaterializeInternalOutput::new(
+        successful_run.report.data,
+        successful_run.raw_response,
+        successful_run.report.final_usage,
+    ))
+}
 
-    let max_attempts = max_retries + 1; // +1 for initial attempt
+/// Execute structured generation and retain the complete retry ledger.
+///
+/// Unlike [`generate_with_retry_with_history`], exhaustion returns a
+/// [`MaterializeFailure`] containing cumulative usage and every failed attempt.
+pub async fn generate_with_retry_attempts_with_history<F, Fut, T>(
+    generate_fn: F,
+    prompt: &str,
+    max_retries: Option<usize>,
+) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+where
+    F: FnMut(Vec<ChatMessage>) -> Fut,
+    Fut: std::future::Future<
+            Output = std::result::Result<MaterializeInternalOutput<T>, MaterializeAttemptError>,
+        >,
+{
+    run_materialize_attempts(generate_fn, vec![ChatMessage::user(prompt)], max_retries)
+        .await
+        .map(|success| success.report)
+}
 
-    // Initialize conversation history with the provided starting messages.
+/// Execute structured generation with media and retain the complete retry ledger.
+pub async fn materialize_with_media_and_attempts_with_retry<F, Fut, T>(
+    generate_fn: F,
+    prompt: &str,
+    media: &[crate::backend::client::MediaFile],
+    max_retries: Option<usize>,
+) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+where
+    F: FnMut(Vec<ChatMessage>) -> Fut,
+    Fut: std::future::Future<
+            Output = std::result::Result<MaterializeInternalOutput<T>, MaterializeAttemptError>,
+        >,
+{
+    run_materialize_attempts(
+        generate_fn,
+        vec![ChatMessage::user_with_media(prompt, media.to_vec())],
+        max_retries,
+    )
+    .await
+    .map(|success| success.report)
+}
+
+struct MaterializeRunSuccess<T> {
+    report: MaterializeReport<T>,
+    raw_response: String,
+}
+
+async fn run_materialize_attempts<F, Fut, T>(
+    mut generate_fn: F,
+    initial_messages: Vec<ChatMessage>,
+    max_retries: Option<usize>,
+) -> std::result::Result<MaterializeRunSuccess<T>, MaterializeFailure>
+where
+    F: FnMut(Vec<ChatMessage>) -> Fut,
+    Fut: std::future::Future<
+            Output = std::result::Result<MaterializeInternalOutput<T>, MaterializeAttemptError>,
+        >,
+{
+    let max_attempts = max_retries.unwrap_or(0).saturating_add(1);
+
     let mut messages = initial_messages;
+    let mut attempts = Vec::with_capacity(max_attempts.min(16));
+    let mut cumulative_usage: Option<RunUsage> = None;
 
     trace!(
         "Starting structured generation with conversation history: max_attempts={}",
@@ -1321,9 +1384,16 @@ where
             "Generation attempt with conversation history"
         );
 
-        // Attempt to generate structured data
         match generate_fn(messages.clone()).await {
             Ok(result) => {
+                let final_usage = result.usage;
+                if let Some(usage) = final_usage.clone() {
+                    cumulative_usage
+                        .get_or_insert_with(RunUsage::new)
+                        .record(usage);
+                }
+                attempts.push(AttemptRecord::succeeded(attempt + 1, final_usage.clone()));
+
                 if attempt > 0 {
                     info!(
                         attempts_used = attempt + 1,
@@ -1333,78 +1403,118 @@ where
                 } else {
                     debug!("Successfully generated on first attempt");
                 }
-                return Ok(result);
+                return Ok(MaterializeRunSuccess {
+                    report: MaterializeReport::new(
+                        result.data,
+                        final_usage,
+                        cumulative_usage,
+                        attempts,
+                    ),
+                    raw_response: result.raw_response,
+                });
             }
-            Err((err, validation_ctx)) => {
+            Err(MaterializeAttemptError::Preflight(error)) => {
+                return Err(MaterializeFailure::new(*error, cumulative_usage, attempts));
+            }
+            Err(MaterializeAttemptError::Semantic {
+                error: attempt_error,
+                context,
+                usage,
+            }) => {
                 let is_last_attempt = attempt >= max_attempts - 1;
-
-                // A validation failure — whether a schema/parse error or a custom
-                // validator returning ANY error variant — carries a
-                // `ValidationFailureContext` with the raw response. Reask with
-                // feedback whenever that context is present, rather than keying off
-                // a specific error variant (a validator that returns, say, a
-                // `SchemaError` should still trigger a retry).
-                if let Some(ctx) = validation_ctx {
-                    if !is_last_attempt {
-                        warn!(
-                            attempt = attempt + 1,
-                            error = %ctx.error_message,
-                            "Validation error in generation attempt"
-                        );
-
-                        // Build conversation history for retry with error feedback.
-                        // Add the failed assistant response to history.
-                        messages.push(ChatMessage::assistant(&ctx.raw_response));
-
-                        // Add user message with error feedback
-                        let error_feedback = validation_retry_feedback(&ctx.error_message);
-                        messages.push(ChatMessage::user(error_feedback));
-
-                        debug!(
-                            history_len = messages.len(),
-                            "Updated conversation history for retry"
-                        );
-
-                        // Wait briefly before retrying
-                        sleep(Duration::from_millis(500)).await;
-                        continue;
-                    } else {
-                        error!(
-                            attempts = max_attempts,
-                            error = %ctx.error_message,
-                            "Failed after maximum retry attempts with validation errors"
-                        );
-                    }
+                let retried = !is_last_attempt;
+                if let Some(response_usage) = usage.clone() {
+                    cumulative_usage
+                        .get_or_insert_with(RunUsage::new)
+                        .record(response_usage);
                 }
-                // Handle retryable API errors (rate limits, transient failures)
-                else if err.is_retryable() && !is_last_attempt {
-                    let delay = err.retry_delay().unwrap_or(Duration::from_secs(1));
+                attempts.push(AttemptRecord::failed(
+                    attempt + 1,
+                    AttemptKind::Semantic,
+                    &attempt_error,
+                    retried,
+                    usage,
+                ));
+
+                if retried {
                     warn!(
                         attempt = attempt + 1,
-                        error = ?err,
+                        error = %context.error_message,
+                        "Validation error in generation attempt"
+                    );
+                    messages.push(ChatMessage::assistant(&context.raw_response));
+                    messages.push(ChatMessage::user(validation_retry_feedback(
+                        &context.error_message,
+                    )));
+                    debug!(
+                        history_len = messages.len(),
+                        "Updated conversation history for retry"
+                    );
+                    sleep(Duration::from_millis(500)).await;
+                    continue;
+                }
+
+                error!(
+                    attempts = max_attempts,
+                    error = %context.error_message,
+                    "Failed after maximum retry attempts with validation errors"
+                );
+                return Err(MaterializeFailure::new(
+                    *attempt_error,
+                    cumulative_usage,
+                    attempts,
+                ));
+            }
+            Err(MaterializeAttemptError::Transport {
+                error: attempt_error,
+                usage,
+            }) => {
+                let is_last_attempt = attempt >= max_attempts - 1;
+                let retried = attempt_error.is_retryable() && !is_last_attempt;
+                if let Some(response_usage) = usage.clone() {
+                    cumulative_usage
+                        .get_or_insert_with(RunUsage::new)
+                        .record(response_usage);
+                }
+                attempts.push(AttemptRecord::failed(
+                    attempt + 1,
+                    AttemptKind::Transport,
+                    &attempt_error,
+                    retried,
+                    usage,
+                ));
+
+                if retried {
+                    let delay = attempt_error
+                        .retry_delay()
+                        .unwrap_or(Duration::from_secs(1));
+                    warn!(
+                        attempt = attempt + 1,
+                        error = ?attempt_error,
                         delay_ms = delay.as_millis(),
                         "Retryable API error, waiting before retry"
                     );
-                    // For API errors, we don't modify the conversation history
-                    // Just retry with the same messages
                     sleep(delay).await;
                     continue;
                 }
-                // Non-retryable errors or last attempt
-                else if is_last_attempt {
+
+                if is_last_attempt {
                     error!(
                         attempts = max_attempts,
-                        error = ?err,
+                        error = ?attempt_error,
                         "Failed after maximum retry attempts"
                     );
                 } else {
                     error!(
-                        error = ?err,
+                        error = ?attempt_error,
                         "Non-retryable error occurred during generation"
                     );
                 }
-
-                return Err(err);
+                return Err(MaterializeFailure::new(
+                    *attempt_error,
+                    cumulative_usage,
+                    attempts,
+                ));
             }
         }
     }
@@ -1425,10 +1535,7 @@ pub async fn materialize_with_media_with_retry<F, Fut, T>(
 where
     F: FnMut(Vec<ChatMessage>) -> Fut,
     Fut: std::future::Future<
-            Output = std::result::Result<
-                MaterializeInternalOutput<T>,
-                (RStructorError, Option<ValidationFailureContext>),
-            >,
+            Output = std::result::Result<MaterializeInternalOutput<T>, MaterializeAttemptError>,
         >,
 {
     let initial_messages = vec![ChatMessage::user_with_media(prompt, media.to_vec())];
@@ -1585,6 +1692,14 @@ macro_rules! impl_client_builder_methods {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    type ScriptedAttempts<T> = std::sync::Arc<
+        std::sync::Mutex<
+            std::collections::VecDeque<
+                std::result::Result<MaterializeInternalOutput<T>, MaterializeAttemptError>,
+            >,
+        >,
+    >;
 
     #[test]
     fn test_add_additional_properties_simple_object() {
@@ -2575,12 +2690,13 @@ mod tests {
                 attempts += 1;
                 async move {
                     if attempts == 1 {
-                        Err((
+                        Err(MaterializeAttemptError::semantic(
                             RStructorError::ValidationError("schema validation failed".to_string()),
-                            Some(ValidationFailureContext::new(
+                            ValidationFailureContext::new(
                                 "missing required field: summary",
                                 "{\"subject\":\"rust\"}",
-                            )),
+                            ),
+                            None,
                         ))
                     } else {
                         assert_eq!(messages.len(), 3);
@@ -2618,13 +2734,11 @@ mod tests {
                 attempts += 1;
                 async move {
                     if attempts == 1 {
-                        Err((
+                        Err(MaterializeAttemptError::semantic(
                             // NOT a ValidationError on purpose.
                             RStructorError::SchemaError("custom validator rejected".to_string()),
-                            Some(ValidationFailureContext::new(
-                                "value out of range",
-                                "{\"n\":-1}",
-                            )),
+                            ValidationFailureContext::new("value out of range", "{\"n\":-1}"),
+                            None,
                         ))
                     } else {
                         // Reask appended the failed response + feedback to history.
@@ -3129,12 +3243,13 @@ mod tests {
             |_messages: Vec<ChatMessage>| {
                 attempts += 1;
                 async move {
-                    Err((
+                    Err(MaterializeAttemptError::semantic(
                         RStructorError::ValidationError(format!("error #{}", attempts)),
-                        Some(ValidationFailureContext::new(
+                        ValidationFailureContext::new(
                             format!("context #{}", attempts),
                             "{\"partial\":true}",
-                        )),
+                        ),
+                        None,
                     ))
                 }
             },
@@ -3160,14 +3275,13 @@ mod tests {
             |_messages: Vec<ChatMessage>| {
                 attempts += 1;
                 async move {
-                    Err((
+                    Err(MaterializeAttemptError::transport(
                         RStructorError::api_error(
                             "TestProvider",
                             ApiErrorKind::RateLimited {
                                 retry_after: Some(Duration::from_secs(0)),
                             },
                         ),
-                        None,
                     ))
                 }
             },
@@ -3203,14 +3317,13 @@ mod tests {
                 attempts += 1;
                 async move {
                     match attempts {
-                        1 => Err((
+                        1 => Err(MaterializeAttemptError::transport(
                             RStructorError::api_error(
                                 "TestProvider",
                                 ApiErrorKind::RateLimited {
                                     retry_after: Some(Duration::from_secs(0)),
                                 },
                             ),
-                            None,
                         )),
                         2 => {
                             // 429 must not have grown the history.
@@ -3220,12 +3333,13 @@ mod tests {
                                 "retryable error should not modify conversation history"
                             );
                             assert_eq!(messages[0].role, crate::backend::ChatRole::User);
-                            Err((
+                            Err(MaterializeAttemptError::semantic(
                                 RStructorError::ValidationError("missing field".to_string()),
-                                Some(ValidationFailureContext::new(
+                                ValidationFailureContext::new(
                                     "missing required field: name",
                                     "{\"partial\":true}",
-                                )),
+                                ),
+                                None,
                             ))
                         }
                         _ => {
@@ -3951,5 +4065,217 @@ mod tests {
         let value = serde_json::to_value(&rf).expect("serialize ResponseFormat");
         assert_eq!(value["json_schema"]["description"], "A movie");
         assert_eq!(value["json_schema"]["strict"], serde_json::json!(true));
+    }
+
+    #[tokio::test]
+    async fn attempt_ledger_preserves_mixed_retry_order_history_and_usage() {
+        use std::collections::VecDeque;
+        use std::sync::{Arc, Mutex};
+
+        let responses: ScriptedAttempts<String> = Arc::new(Mutex::new(VecDeque::from([
+            Err(MaterializeAttemptError::semantic(
+                RStructorError::SchemaError("position quantity was textual".into()),
+                ValidationFailureContext::new(
+                    "position quantity was textual",
+                    r#"{"portfolio_id":"HF-ALPHA-001","positions":[{"symbol":"ESU6","quantity":"short 240"}]}"#,
+                ),
+                Some(TokenUsage::new("risk-model-v1", 100, 20)),
+            )),
+            Err(MaterializeAttemptError::transport(
+                RStructorError::api_error(
+                    "OpenAI",
+                    ApiErrorKind::RateLimited {
+                        retry_after: Some(Duration::ZERO),
+                    },
+                ),
+            )),
+            Ok(MaterializeInternalOutput::new(
+                "HF-ALPHA-001".to_string(),
+                r#"{"portfolio_id":"HF-ALPHA-001","positions":[{"symbol":"ESU6","quantity":-240}]}"#
+                    .to_string(),
+                Some(TokenUsage::new("risk-model-v2", 140, 30)),
+            )),
+        ])));
+        let history_lengths = Arc::new(Mutex::new(Vec::new()));
+
+        let report = generate_with_retry_attempts_with_history(
+            {
+                let responses = Arc::clone(&responses);
+                let history_lengths = Arc::clone(&history_lengths);
+                move |messages| {
+                    history_lengths.lock().unwrap().push(messages.len());
+                    let response = responses.lock().unwrap().pop_front().unwrap();
+                    async move { response }
+                }
+            },
+            "reconcile the futures book",
+            Some(2),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(report.data, "HF-ALPHA-001");
+        assert_eq!(*history_lengths.lock().unwrap(), vec![1, 3, 3]);
+        assert_eq!(report.attempts.len(), 3);
+        assert_eq!(report.attempts[0].kind, AttemptKind::Semantic);
+        assert_eq!(report.attempts[1].kind, AttemptKind::Transport);
+        assert_eq!(report.attempts[2].kind, AttemptKind::Semantic);
+        assert!(matches!(
+            report.attempts[0].outcome,
+            crate::AttemptOutcome::Failed { retried: true, .. }
+        ));
+        assert!(matches!(
+            report.attempts[1].outcome,
+            crate::AttemptOutcome::Failed { retried: true, .. }
+        ));
+        assert_eq!(report.attempts[2].outcome, crate::AttemptOutcome::Succeeded);
+
+        let usage = report.cumulative_usage.unwrap();
+        assert_eq!(usage.reported_attempts, 2);
+        assert_eq!(usage.total_tokens(), 290);
+        assert_eq!(usage.by_model["risk-model-v1"].total_tokens(), 120);
+        assert_eq!(usage.by_model["risk-model-v2"].total_tokens(), 170);
+    }
+
+    #[tokio::test]
+    async fn semantic_exhaustion_preserves_every_attempt_and_exact_final_error() {
+        use std::collections::VecDeque;
+        use std::sync::{Arc, Mutex};
+
+        let responses: ScriptedAttempts<()> = Arc::new(Mutex::new(VecDeque::from([
+            Err(MaterializeAttemptError::semantic(
+                RStructorError::ValidationError("gross exposure too high".into()),
+                ValidationFailureContext::new(
+                    "gross exposure too high",
+                    r#"{"gross_exposure":2.7}"#,
+                ),
+                Some(TokenUsage::new("risk-model", 80, 10)),
+            )),
+            Err(MaterializeAttemptError::semantic(
+                RStructorError::SchemaError("missing net exposure".into()),
+                ValidationFailureContext::new("missing net exposure", r#"{"gross_exposure":1.4}"#),
+                Some(TokenUsage::new("risk-model", 110, 12)),
+            )),
+        ])));
+
+        let failure = generate_with_retry_attempts_with_history(
+            {
+                let responses = Arc::clone(&responses);
+                move |_| {
+                    let response = responses.lock().unwrap().pop_front().unwrap();
+                    async move { response }
+                }
+            },
+            "calculate exposure",
+            Some(1),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            failure.error(),
+            RStructorError::SchemaError(message) if message == "missing net exposure"
+        ));
+        assert_eq!(failure.attempts.len(), 2);
+        assert!(matches!(
+            failure.attempts[0].outcome,
+            crate::AttemptOutcome::Failed { retried: true, .. }
+        ));
+        assert!(matches!(
+            failure.attempts[1].outcome,
+            crate::AttemptOutcome::Failed { retried: false, .. }
+        ));
+        assert_eq!(
+            failure.cumulative_usage.as_ref().unwrap().total_tokens(),
+            212
+        );
+    }
+
+    #[tokio::test]
+    async fn preflight_failure_records_no_provider_attempt() {
+        let failure = generate_with_retry_attempts_with_history(
+            |_| async {
+                Err::<MaterializeInternalOutput<()>, _>(MaterializeAttemptError::preflight(
+                    RStructorError::SchemaError("unsupported recursive dialect".into()),
+                ))
+            },
+            "extract",
+            Some(3),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(failure.attempts.is_empty());
+        assert!(failure.cumulative_usage.is_none());
+        assert!(matches!(failure.error(), RStructorError::SchemaError(_)));
+    }
+
+    #[tokio::test]
+    async fn zero_retry_budget_records_one_unretried_transport_attempt() {
+        let failure = generate_with_retry_attempts_with_history(
+            |_| async {
+                Err::<MaterializeInternalOutput<()>, _>(MaterializeAttemptError::transport(
+                    RStructorError::Timeout,
+                ))
+            },
+            "extract",
+            Some(0),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(failure.attempts.len(), 1);
+        assert_eq!(failure.attempts[0].number, 1);
+        assert_eq!(failure.attempts[0].kind, AttemptKind::Transport);
+        assert!(matches!(
+            failure.attempts[0].outcome,
+            crate::AttemptOutcome::Failed { retried: false, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn missing_usage_and_non_retryable_transport_stop_are_accounted_conservatively() {
+        use std::collections::VecDeque;
+        use std::sync::{Arc, Mutex};
+
+        let responses: ScriptedAttempts<()> = Arc::new(Mutex::new(VecDeque::from([
+            Err(MaterializeAttemptError::semantic(
+                RStructorError::ValidationError("missing strategy id".into()),
+                ValidationFailureContext::new("missing strategy id", r#"{"nav":125000000}"#),
+                None,
+            )),
+            Err(MaterializeAttemptError::transport_with_usage(
+                RStructorError::api_error("OpenAI", ApiErrorKind::AuthenticationFailed),
+                Some(TokenUsage::new("risk-model", 50, 0)),
+            )),
+        ])));
+
+        let failure = generate_with_retry_attempts_with_history(
+            {
+                let responses = Arc::clone(&responses);
+                move |_| {
+                    let response = responses.lock().unwrap().pop_front().unwrap();
+                    async move { response }
+                }
+            },
+            "extract the NAV",
+            Some(3),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(failure.attempts.len(), 2);
+        assert!(matches!(
+            failure.attempts[0].outcome,
+            crate::AttemptOutcome::Failed { retried: true, .. }
+        ));
+        assert!(matches!(
+            failure.attempts[1].outcome,
+            crate::AttemptOutcome::Failed { retried: false, .. }
+        ));
+        let usage = failure.cumulative_usage.unwrap();
+        assert_eq!(usage.reported_attempts, 1);
+        assert_eq!(usage.total_tokens(), 50);
+        assert!(responses.lock().unwrap().is_empty());
     }
 }

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -1,12 +1,13 @@
 use crate::backend::{
     AttemptKind, AttemptRecord, ChatMessage, MaterializeAttemptError, MaterializeFailure,
-    MaterializeInternalOutput, MaterializeReport, RunUsage, TokenUsage, ValidationFailureContext,
+    MaterializeInternalOutput, MaterializeReport, RetryDisposition, RunUsage, TokenUsage,
+    ValidationFailureContext,
 };
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
 use reqwest::Response;
-use serde::Serialize;
 use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -46,6 +47,21 @@ pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
 /// assert_eq!(DEFAULT_CONNECT_TIMEOUT, Duration::from_secs(30));
 /// ```
 pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Deserialize a provider-envelope field conservatively.
+///
+/// A malformed envelope should not prevent other independently valid fields,
+/// especially provider-reported usage, from being accounted for. Invalid or
+/// missing fields are treated as their default and validated by the caller as
+/// a protocol failure.
+pub(crate) fn deserialize_or_default<'de, D, T>(deserializer: D) -> std::result::Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: DeserializeOwned + Default,
+{
+    let value = Value::deserialize(deserializer)?;
+    Ok(serde_json::from_value(value).unwrap_or_default())
+}
 
 /// Build the reqwest client used by all provider clients.
 ///
@@ -1066,6 +1082,23 @@ pub fn handle_http_error(e: reqwest::Error, provider_name: &str) -> RStructorErr
     }
 }
 
+/// Classify an error returned while sending a materialization request.
+///
+/// Reqwest builder errors happen before a request can reach the network, so
+/// they are preflight failures rather than provider attempts.
+pub(crate) fn materialize_request_error(
+    error: reqwest::Error,
+    provider_name: &str,
+) -> MaterializeAttemptError {
+    let is_builder_error = error.is_builder();
+    let error = handle_http_error(error, provider_name);
+    if is_builder_error {
+        MaterializeAttemptError::preflight(error)
+    } else {
+        MaterializeAttemptError::transport(error)
+    }
+}
+
 /// Parse retry-after header value to Duration.
 fn parse_retry_after(value: &str) -> Option<Duration> {
     // Try parsing as seconds (most common)
@@ -1422,7 +1455,11 @@ where
                 usage,
             }) => {
                 let is_last_attempt = attempt >= max_attempts - 1;
-                let retried = !is_last_attempt;
+                let disposition = if is_last_attempt {
+                    RetryDisposition::BudgetExhausted
+                } else {
+                    RetryDisposition::Retried
+                };
                 if let Some(response_usage) = usage.clone() {
                     cumulative_usage
                         .get_or_insert_with(RunUsage::new)
@@ -1432,11 +1469,11 @@ where
                     attempt + 1,
                     AttemptKind::Semantic,
                     &attempt_error,
-                    retried,
+                    disposition,
                     usage,
                 ));
 
-                if retried {
+                if disposition == RetryDisposition::Retried {
                     warn!(
                         attempt = attempt + 1,
                         error = %context.error_message,
@@ -1470,7 +1507,14 @@ where
                 usage,
             }) => {
                 let is_last_attempt = attempt >= max_attempts - 1;
-                let retried = attempt_error.is_retryable() && !is_last_attempt;
+                let retryable = attempt_error.is_retryable();
+                let disposition = if !retryable {
+                    RetryDisposition::NonRetryable
+                } else if is_last_attempt {
+                    RetryDisposition::BudgetExhausted
+                } else {
+                    RetryDisposition::Retried
+                };
                 if let Some(response_usage) = usage.clone() {
                     cumulative_usage
                         .get_or_insert_with(RunUsage::new)
@@ -1480,11 +1524,11 @@ where
                     attempt + 1,
                     AttemptKind::Transport,
                     &attempt_error,
-                    retried,
+                    disposition,
                     usage,
                 ));
 
-                if retried {
+                if disposition == RetryDisposition::Retried {
                     let delay = attempt_error
                         .retry_delay()
                         .unwrap_or(Duration::from_secs(1));
@@ -1629,12 +1673,14 @@ macro_rules! impl_client_builder_methods {
                 self
             }
 
-            /// Set the maximum number of retry attempts for validation errors.
+            /// Set the shared materialization retry budget.
             ///
-            /// When `materialize` encounters a validation error, it will automatically
-            /// retry up to this many times, including the validation error message in subsequent attempts.
+            /// Semantic decode/validation failures re-ask with error feedback.
+            /// Retryable transport/provider failures retry the same history
+            /// after their classified delay. Both consume this one budget.
             ///
-            /// The default is 3 retries. Use `.no_retries()` to disable retries entirely.
+            /// The default is 3 retries (4 total attempts). Use
+            /// `.no_retries()` to make exactly one attempt.
             ///
             /// # Arguments
             ///
@@ -1661,10 +1707,11 @@ macro_rules! impl_client_builder_methods {
                 self
             }
 
-            /// Disable automatic retries on validation errors.
+            /// Disable automatic materialization retries.
             ///
-            /// By default, the client retries up to 3 times when validation errors occur.
-            /// Use this method to disable retries and fail immediately on the first error.
+            /// By default, the client retries semantic and retryable transport
+            /// failures up to 3 times. Use this method to stop after the first
+            /// failed attempt.
             ///
             /// # Examples
             ///
@@ -1672,7 +1719,7 @@ macro_rules! impl_client_builder_methods {
             /// # use rstructor::OpenAIClient;
             /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
             /// let client = OpenAIClient::new("api-key")?
-            ///     .no_retries();  // Fail immediately on validation errors
+            ///     .no_retries();  // Stop after the first failed attempt
             /// # Ok(())
             /// # }
             /// ```
@@ -4122,11 +4169,17 @@ mod tests {
         assert_eq!(report.attempts[2].kind, AttemptKind::Semantic);
         assert!(matches!(
             report.attempts[0].outcome,
-            crate::AttemptOutcome::Failed { retried: true, .. }
+            crate::AttemptOutcome::Failed {
+                disposition: crate::RetryDisposition::Retried,
+                ..
+            }
         ));
         assert!(matches!(
             report.attempts[1].outcome,
-            crate::AttemptOutcome::Failed { retried: true, .. }
+            crate::AttemptOutcome::Failed {
+                disposition: crate::RetryDisposition::Retried,
+                ..
+            }
         ));
         assert_eq!(report.attempts[2].outcome, crate::AttemptOutcome::Succeeded);
 
@@ -4179,11 +4232,17 @@ mod tests {
         assert_eq!(failure.attempts.len(), 2);
         assert!(matches!(
             failure.attempts[0].outcome,
-            crate::AttemptOutcome::Failed { retried: true, .. }
+            crate::AttemptOutcome::Failed {
+                disposition: crate::RetryDisposition::Retried,
+                ..
+            }
         ));
         assert!(matches!(
             failure.attempts[1].outcome,
-            crate::AttemptOutcome::Failed { retried: false, .. }
+            crate::AttemptOutcome::Failed {
+                disposition: crate::RetryDisposition::BudgetExhausted,
+                ..
+            }
         ));
         assert_eq!(
             failure.cumulative_usage.as_ref().unwrap().total_tokens(),
@@ -4229,7 +4288,10 @@ mod tests {
         assert_eq!(failure.attempts[0].kind, AttemptKind::Transport);
         assert!(matches!(
             failure.attempts[0].outcome,
-            crate::AttemptOutcome::Failed { retried: false, .. }
+            crate::AttemptOutcome::Failed {
+                disposition: crate::RetryDisposition::BudgetExhausted,
+                ..
+            }
         ));
     }
 
@@ -4267,11 +4329,17 @@ mod tests {
         assert_eq!(failure.attempts.len(), 2);
         assert!(matches!(
             failure.attempts[0].outcome,
-            crate::AttemptOutcome::Failed { retried: true, .. }
+            crate::AttemptOutcome::Failed {
+                disposition: crate::RetryDisposition::Retried,
+                ..
+            }
         ));
         assert!(matches!(
             failure.attempts[1].outcome,
-            crate::AttemptOutcome::Failed { retried: false, .. }
+            crate::AttemptOutcome::Failed {
+                disposition: crate::RetryDisposition::NonRetryable,
+                ..
+            }
         ));
         let usage = failure.cumulative_usage.unwrap();
         assert_eq!(usage.reported_attempts, 1);

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -6,8 +6,8 @@ use crate::backend::{
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
 use reqwest::Response;
+use serde::Serialize;
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -47,21 +47,6 @@ pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
 /// assert_eq!(DEFAULT_CONNECT_TIMEOUT, Duration::from_secs(30));
 /// ```
 pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
-
-/// Deserialize a provider-envelope field conservatively.
-///
-/// A malformed envelope should not prevent other independently valid fields,
-/// especially provider-reported usage, from being accounted for. Invalid or
-/// missing fields are treated as their default and validated by the caller as
-/// a protocol failure.
-pub(crate) fn deserialize_or_default<'de, D, T>(deserializer: D) -> std::result::Result<T, D::Error>
-where
-    D: serde::Deserializer<'de>,
-    T: DeserializeOwned + Default,
-{
-    let value = Value::deserialize(deserializer)?;
-    Ok(serde_json::from_value(value).unwrap_or_default())
-}
 
 /// Build the reqwest client used by all provider clients.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,8 @@ pub use backend::ThinkingLevel;
 pub use backend::{AnyClient, Provider, Request, RequestExt};
 pub use backend::{
     AttemptKind, AttemptOutcome, AttemptRecord, ChatMessage, ChatRole, GenerateResult,
-    MaterializeFailure, MaterializeReport, MaterializeResult, MediaFile, RunUsage, TokenUsage,
+    MaterializeFailure, MaterializeReport, MaterializeResult, MediaFile, RetryDisposition,
+    RunUsage, TokenUsage,
 };
 #[cfg(feature = "_client")]
 pub use backend::{DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,8 @@ pub use backend::ThinkingLevel;
 #[cfg(feature = "_client")]
 pub use backend::{AnyClient, Provider, Request, RequestExt};
 pub use backend::{
-    ChatMessage, ChatRole, GenerateResult, MaterializeResult, MediaFile, TokenUsage,
+    AttemptKind, AttemptOutcome, AttemptRecord, ChatMessage, ChatRole, GenerateResult,
+    MaterializeFailure, MaterializeReport, MaterializeResult, MediaFile, RunUsage, TokenUsage,
 };
 #[cfg(feature = "_client")]
 pub use backend::{DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT};

--- a/tests/attempt_ledger_provider_tests.rs
+++ b/tests/attempt_ledger_provider_tests.rs
@@ -19,6 +19,8 @@ struct Position {
 }
 
 const POSITION_JSON: &str = r#"{"fund_id":"HF-ALPHA-001","symbol":"ESU6","quantity":-240}"#;
+const INVALID_POSITION_JSON: &str =
+    r#"{"fund_id":"HF-ALPHA-001","symbol":"ESU6","quantity":"short 240"}"#;
 
 fn assert_single_success(
     report: MaterializeReport<Position>,
@@ -43,7 +45,10 @@ fn assert_usage_bearing_protocol_failure(failure: MaterializeFailure, expected_t
     assert_eq!(failure.attempts[0].kind, AttemptKind::Transport);
     assert!(matches!(
         failure.attempts[0].outcome,
-        AttemptOutcome::Failed { retried: false, .. }
+        AttemptOutcome::Failed {
+            disposition: rstructor::RetryDisposition::NonRetryable,
+            ..
+        }
     ));
     assert_eq!(
         failure.attempts[0].usage.as_ref().unwrap().total_tokens(),
@@ -51,6 +56,34 @@ fn assert_usage_bearing_protocol_failure(failure: MaterializeFailure, expected_t
     );
     assert_eq!(
         failure.cumulative_usage.as_ref().unwrap().total_tokens(),
+        expected_tokens
+    );
+}
+
+fn assert_semantic_retry_success(
+    report: MaterializeReport<Position>,
+    expected_final_model: &str,
+    expected_tokens: u64,
+) {
+    assert_eq!(report.data.quantity, -240);
+    assert!(report.attempts_complete);
+    assert_eq!(report.attempts.len(), 2);
+    assert_eq!(report.attempts[0].kind, AttemptKind::Semantic);
+    assert_eq!(report.attempts[1].kind, AttemptKind::Semantic);
+    assert!(matches!(
+        report.attempts[0].outcome,
+        AttemptOutcome::Failed {
+            disposition: rstructor::RetryDisposition::Retried,
+            ..
+        }
+    ));
+    assert_eq!(report.attempts[1].outcome, AttemptOutcome::Succeeded);
+    assert_eq!(
+        report.final_usage.as_ref().unwrap().model,
+        expected_final_model
+    );
+    assert_eq!(
+        report.cumulative_usage.as_ref().unwrap().total_tokens(),
         expected_tokens
     );
 }
@@ -89,6 +122,54 @@ async fn anthropic_attempt_report_parses_usage() {
 
 #[cfg(feature = "anthropic")]
 #[tokio::test]
+async fn anthropic_semantic_retry_preserves_native_history_and_usage() {
+    let mut server = mockito::Server::new_async().await;
+    let bad = server
+        .mock("POST", "/messages")
+        .with_status(200)
+        .with_body(
+            json!({
+                "content": [{ "type": "text", "text": INVALID_POSITION_JSON }],
+                "model": "claude-risk-router-v1",
+                "usage": { "input_tokens": 30, "output_tokens": 5 },
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+    let good = server
+        .mock("POST", "/messages")
+        .match_body(mockito::Matcher::Regex("short 240".to_string()))
+        .with_status(200)
+        .with_body(
+            json!({
+                "content": [{ "type": "text", "text": POSITION_JSON }],
+                "model": "claude-risk-router-v2",
+                "usage": { "input_tokens": 40, "output_tokens": 6 },
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let report = rstructor::AnthropicClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("test-model")
+        .max_retries(1)
+        .materialize_with_attempts::<Position>("reconcile")
+        .await
+        .unwrap();
+
+    assert_semantic_retry_success(report, "claude-risk-router-v2", 81);
+    bad.assert_async().await;
+    good.assert_async().await;
+}
+
+#[cfg(feature = "anthropic")]
+#[tokio::test]
 async fn anthropic_protocol_failure_keeps_reported_usage() {
     let mut server = mockito::Server::new_async().await;
     let request = server
@@ -97,7 +178,7 @@ async fn anthropic_protocol_failure_keeps_reported_usage() {
         .with_header("content-type", "application/json")
         .with_body(
             json!({
-                "content": [],
+                "content": { "unexpected": "object instead of array" },
                 "model": "claude-risk-router",
                 "usage": { "input_tokens": 50, "output_tokens": 2 },
             })
@@ -163,6 +244,74 @@ async fn gemini_attempt_report_parses_usage() {
 
 #[cfg(feature = "gemini")]
 #[tokio::test]
+async fn gemini_semantic_retry_preserves_native_history_and_usage() {
+    let mut server = mockito::Server::new_async().await;
+    let bad = server
+        .mock("POST", "/models/test-model:generateContent")
+        .match_query(mockito::Matcher::UrlEncoded(
+            "key".to_string(),
+            "test-key".to_string(),
+        ))
+        .with_status(200)
+        .with_body(
+            json!({
+                "candidates": [{
+                    "content": { "parts": [{ "text": INVALID_POSITION_JSON }] },
+                    "finishReason": "STOP",
+                }],
+                "usageMetadata": {
+                    "promptTokenCount": 25,
+                    "candidatesTokenCount": 4,
+                },
+                "modelVersion": "gemini-risk-router-v1",
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+    let good = server
+        .mock("POST", "/models/test-model:generateContent")
+        .match_query(mockito::Matcher::UrlEncoded(
+            "key".to_string(),
+            "test-key".to_string(),
+        ))
+        .match_body(mockito::Matcher::Regex("short 240".to_string()))
+        .with_status(200)
+        .with_body(
+            json!({
+                "candidates": [{
+                    "content": { "parts": [{ "text": POSITION_JSON }] },
+                    "finishReason": "STOP",
+                }],
+                "usageMetadata": {
+                    "promptTokenCount": 35,
+                    "candidatesTokenCount": 6,
+                },
+                "modelVersion": "gemini-risk-router-v2",
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let report = rstructor::GeminiClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("test-model")
+        .max_retries(1)
+        .materialize_with_attempts::<Position>("reconcile")
+        .await
+        .unwrap();
+
+    assert_semantic_retry_success(report, "gemini-risk-router-v2", 70);
+    bad.assert_async().await;
+    good.assert_async().await;
+}
+
+#[cfg(feature = "gemini")]
+#[tokio::test]
 async fn gemini_protocol_failure_keeps_reported_usage() {
     let mut server = mockito::Server::new_async().await;
     let request = server
@@ -175,7 +324,7 @@ async fn gemini_protocol_failure_keeps_reported_usage() {
         .with_header("content-type", "application/json")
         .with_body(
             json!({
-                "candidates": [],
+                "candidates": { "unexpected": "object instead of array" },
                 "usageMetadata": {
                     "promptTokenCount": 45,
                     "candidatesTokenCount": 3,
@@ -241,6 +390,68 @@ async fn grok_attempt_report_parses_usage() {
 
 #[cfg(feature = "grok")]
 #[tokio::test]
+async fn grok_semantic_retry_preserves_native_history_and_usage() {
+    let mut server = mockito::Server::new_async().await;
+    let bad = server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_body(
+            json!({
+                "choices": [{
+                    "message": { "role": "assistant", "content": INVALID_POSITION_JSON },
+                    "finish_reason": "stop",
+                }],
+                "usage": {
+                    "prompt_tokens": 28,
+                    "completion_tokens": 5,
+                    "total_tokens": 33,
+                },
+                "model": "grok-risk-router-v1",
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+    let good = server
+        .mock("POST", "/chat/completions")
+        .match_body(mockito::Matcher::Regex("short 240".to_string()))
+        .with_status(200)
+        .with_body(
+            json!({
+                "choices": [{
+                    "message": { "role": "assistant", "content": POSITION_JSON },
+                    "finish_reason": "stop",
+                }],
+                "usage": {
+                    "prompt_tokens": 38,
+                    "completion_tokens": 7,
+                    "total_tokens": 45,
+                },
+                "model": "grok-risk-router-v2",
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let report = rstructor::GrokClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("test-model")
+        .max_retries(1)
+        .materialize_with_attempts::<Position>("reconcile")
+        .await
+        .unwrap();
+
+    assert_semantic_retry_success(report, "grok-risk-router-v2", 78);
+    bad.assert_async().await;
+    good.assert_async().await;
+}
+
+#[cfg(feature = "grok")]
+#[tokio::test]
 async fn grok_protocol_failure_keeps_reported_usage() {
     let mut server = mockito::Server::new_async().await;
     let request = server
@@ -249,7 +460,7 @@ async fn grok_protocol_failure_keeps_reported_usage() {
         .with_header("content-type", "application/json")
         .with_body(
             json!({
-                "choices": [],
+                "choices": { "unexpected": "object instead of array" },
                 "usage": {
                     "prompt_tokens": 40,
                     "completion_tokens": 4,

--- a/tests/attempt_ledger_provider_tests.rs
+++ b/tests/attempt_ledger_provider_tests.rs
@@ -178,7 +178,7 @@ async fn anthropic_protocol_failure_keeps_reported_usage() {
         .with_header("content-type", "application/json")
         .with_body(
             json!({
-                "content": { "unexpected": "object instead of array" },
+                "content": [],
                 "model": "claude-risk-router",
                 "usage": { "input_tokens": 50, "output_tokens": 2 },
             })
@@ -324,7 +324,7 @@ async fn gemini_protocol_failure_keeps_reported_usage() {
         .with_header("content-type", "application/json")
         .with_body(
             json!({
-                "candidates": { "unexpected": "object instead of array" },
+                "candidates": [],
                 "usageMetadata": {
                     "promptTokenCount": 45,
                     "candidatesTokenCount": 3,
@@ -460,7 +460,7 @@ async fn grok_protocol_failure_keeps_reported_usage() {
         .with_header("content-type", "application/json")
         .with_body(
             json!({
-                "choices": { "unexpected": "object instead of array" },
+                "choices": [],
                 "usage": {
                     "prompt_tokens": 40,
                     "completion_tokens": 4,

--- a/tests/attempt_ledger_provider_tests.rs
+++ b/tests/attempt_ledger_provider_tests.rs
@@ -1,0 +1,276 @@
+//! Provider-envelope coverage for the additive materialization attempt ledger.
+//!
+//! These tests drive each concrete client through a local HTTP server. The
+//! fixtures use a realistic fund position so provider-specific response and
+//! usage parsing are tested without paid network calls.
+#![cfg(any(feature = "anthropic", feature = "gemini", feature = "grok"))]
+
+use rstructor::{
+    AttemptKind, AttemptOutcome, Instructor, LLMClient, MaterializeFailure, MaterializeReport,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(Debug, Instructor, Serialize, Deserialize, PartialEq)]
+struct Position {
+    fund_id: String,
+    symbol: String,
+    quantity: i64,
+}
+
+const POSITION_JSON: &str = r#"{"fund_id":"HF-ALPHA-001","symbol":"ESU6","quantity":-240}"#;
+
+fn assert_single_success(
+    report: MaterializeReport<Position>,
+    expected_model: &str,
+    expected_tokens: u64,
+) {
+    assert_eq!(report.data.fund_id, "HF-ALPHA-001");
+    assert_eq!(report.data.symbol, "ESU6");
+    assert_eq!(report.data.quantity, -240);
+    assert_eq!(report.attempts.len(), 1);
+    assert_eq!(report.attempts[0].kind, AttemptKind::Semantic);
+    assert_eq!(report.attempts[0].outcome, AttemptOutcome::Succeeded);
+    assert_eq!(report.final_usage.as_ref().unwrap().model, expected_model);
+    assert_eq!(
+        report.cumulative_usage.as_ref().unwrap().total_tokens(),
+        expected_tokens
+    );
+}
+
+fn assert_usage_bearing_protocol_failure(failure: MaterializeFailure, expected_tokens: u64) {
+    assert_eq!(failure.attempts.len(), 1);
+    assert_eq!(failure.attempts[0].kind, AttemptKind::Transport);
+    assert!(matches!(
+        failure.attempts[0].outcome,
+        AttemptOutcome::Failed { retried: false, .. }
+    ));
+    assert_eq!(
+        failure.attempts[0].usage.as_ref().unwrap().total_tokens(),
+        expected_tokens
+    );
+    assert_eq!(
+        failure.cumulative_usage.as_ref().unwrap().total_tokens(),
+        expected_tokens
+    );
+}
+
+#[cfg(feature = "anthropic")]
+#[tokio::test]
+async fn anthropic_attempt_report_parses_usage() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/messages")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "content": [{ "type": "text", "text": POSITION_JSON }],
+                "model": "claude-risk-router-2026-07-15",
+                "usage": { "input_tokens": 70, "output_tokens": 14 },
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let report = rstructor::AnthropicClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("test-model")
+        .materialize_with_attempts::<Position>("reconcile the futures position")
+        .await
+        .unwrap();
+
+    assert_single_success(report, "claude-risk-router-2026-07-15", 84);
+    request.assert_async().await;
+}
+
+#[cfg(feature = "anthropic")]
+#[tokio::test]
+async fn anthropic_protocol_failure_keeps_reported_usage() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/messages")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "content": [],
+                "model": "claude-risk-router",
+                "usage": { "input_tokens": 50, "output_tokens": 2 },
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let failure = rstructor::AnthropicClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("test-model")
+        .materialize_with_attempts::<Position>("reconcile")
+        .await
+        .unwrap_err();
+
+    assert_usage_bearing_protocol_failure(failure, 52);
+    request.assert_async().await;
+}
+
+#[cfg(feature = "gemini")]
+#[tokio::test]
+async fn gemini_attempt_report_parses_usage() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/models/test-model:generateContent")
+        .match_query(mockito::Matcher::UrlEncoded(
+            "key".to_string(),
+            "test-key".to_string(),
+        ))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "candidates": [{
+                    "content": { "parts": [{ "text": POSITION_JSON }] },
+                    "finishReason": "STOP",
+                }],
+                "usageMetadata": {
+                    "promptTokenCount": 60,
+                    "candidatesTokenCount": 12,
+                },
+                "modelVersion": "gemini-risk-router-2026-07-15",
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let report = rstructor::GeminiClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("test-model")
+        .materialize_with_attempts::<Position>("reconcile the futures position")
+        .await
+        .unwrap();
+
+    assert_single_success(report, "gemini-risk-router-2026-07-15", 72);
+    request.assert_async().await;
+}
+
+#[cfg(feature = "gemini")]
+#[tokio::test]
+async fn gemini_protocol_failure_keeps_reported_usage() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/models/test-model:generateContent")
+        .match_query(mockito::Matcher::UrlEncoded(
+            "key".to_string(),
+            "test-key".to_string(),
+        ))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "candidates": [],
+                "usageMetadata": {
+                    "promptTokenCount": 45,
+                    "candidatesTokenCount": 3,
+                },
+                "modelVersion": "gemini-risk-router",
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let failure = rstructor::GeminiClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("test-model")
+        .materialize_with_attempts::<Position>("reconcile")
+        .await
+        .unwrap_err();
+
+    assert_usage_bearing_protocol_failure(failure, 48);
+    request.assert_async().await;
+}
+
+#[cfg(feature = "grok")]
+#[tokio::test]
+async fn grok_attempt_report_parses_usage() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "choices": [{
+                    "message": { "role": "assistant", "content": POSITION_JSON },
+                    "finish_reason": "stop",
+                }],
+                "usage": {
+                    "prompt_tokens": 65,
+                    "completion_tokens": 13,
+                    "total_tokens": 78,
+                },
+                "model": "grok-risk-router-2026-07-15",
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let report = rstructor::GrokClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("test-model")
+        .materialize_with_attempts::<Position>("reconcile the futures position")
+        .await
+        .unwrap();
+
+    assert_single_success(report, "grok-risk-router-2026-07-15", 78);
+    request.assert_async().await;
+}
+
+#[cfg(feature = "grok")]
+#[tokio::test]
+async fn grok_protocol_failure_keeps_reported_usage() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 40,
+                    "completion_tokens": 4,
+                    "total_tokens": 44,
+                },
+                "model": "grok-risk-router",
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let failure = rstructor::GrokClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("test-model")
+        .materialize_with_attempts::<Position>("reconcile")
+        .await
+        .unwrap_err();
+
+    assert_usage_bearing_protocol_failure(failure, 44);
+    request.assert_async().await;
+}

--- a/tests/core_ergonomics_test.rs
+++ b/tests/core_ergonomics_test.rs
@@ -85,6 +85,22 @@ async fn media_default_errors_instead_of_silently_dropping() {
     );
 }
 
+#[tokio::test]
+async fn custom_client_attempt_defaults_add_no_required_trait_methods_or_fake_attempts() {
+    let client = NoMediaClient;
+    let failure = client
+        .materialize_with_attempts::<Dummy>("hi")
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error(),
+        RStructorError::ValidationError(message) if message == "materialize-called"
+    ));
+    assert!(failure.attempts.is_empty());
+    assert!(failure.cumulative_usage.is_none());
+}
+
 /// Fluent `Request` builder routing, exercised with the first-party `MockClient`.
 ///
 /// These assert *how the builder composes and dispatches* by reading back the
@@ -165,6 +181,32 @@ mod builder {
         assert_eq!(req.kind, RequestKind::MaterializeWithMedia);
         assert_eq!(req.prompt, "describe");
         assert_eq!(req.media.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn attempt_terminal_preserves_system_and_media_routing() {
+        let client = MockClient::new().with_response(r#"{"value":"risk chart"}"#);
+        let media = [MediaFile::new(
+            "https://example.com/risk-chart.png",
+            "image/png",
+        )];
+
+        let report = client
+            .with_system("Use the fund's base currency.")
+            .media(media.to_vec())
+            .materialize_with_attempts::<Dummy>("read the chart")
+            .await
+            .unwrap();
+
+        assert_eq!(report.data.value, "risk chart");
+        assert_eq!(report.attempts.len(), 1);
+        let request = client.last_request().unwrap();
+        assert_eq!(request.kind, RequestKind::MaterializeWithMediaAndAttempts);
+        assert_eq!(
+            request.prompt,
+            "Use the fund's base currency.\n\nread the chart"
+        );
+        assert_eq!(request.media.len(), 1);
     }
 
     #[cfg(feature = "streaming")]

--- a/tests/core_ergonomics_test.rs
+++ b/tests/core_ergonomics_test.rs
@@ -99,6 +99,7 @@ async fn custom_client_attempt_defaults_add_no_required_trait_methods_or_fake_at
     ));
     assert!(failure.attempts.is_empty());
     assert!(failure.cumulative_usage.is_none());
+    assert!(!failure.attempts_complete);
 }
 
 /// Fluent `Request` builder routing, exercised with the first-party `MockClient`.

--- a/tests/http_mock_tests.rs
+++ b/tests/http_mock_tests.rs
@@ -475,7 +475,7 @@ async fn retryable_provider_error_is_a_transport_attempt_without_history_mutatio
 }
 
 #[tokio::test]
-async fn malformed_envelope_retains_usage_as_an_unretried_transport_attempt() {
+async fn empty_envelope_retains_usage_as_an_unretried_transport_attempt() {
     let mut server = mockito::Server::new_async().await;
     let malformed = server
         .mock("POST", "/chat/completions")
@@ -483,7 +483,7 @@ async fn malformed_envelope_retains_usage_as_an_unretried_transport_attempt() {
         .with_header("content-type", "application/json")
         .with_body(
             json!({
-                "choices": { "unexpected": "object instead of array" },
+                "choices": [],
                 "usage": {
                     "prompt_tokens": 55,
                     "completion_tokens": 3,
@@ -524,6 +524,75 @@ async fn malformed_envelope_retains_usage_as_an_unretried_transport_attempt() {
         58
     );
     malformed.assert_async().await;
+}
+
+#[tokio::test]
+async fn malformed_usage_with_valid_content_preserves_legacy_fail_fast_error() {
+    let mut server = mockito::Server::new_async().await;
+    let response = server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": r#"{"title":"Dune","year":2021}"#,
+                    },
+                    "finish_reason": "stop",
+                }],
+                "usage": "not-an-object",
+                "model": "gpt-4o-mini",
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let error = client(&server)
+        .materialize::<Movie>("a film")
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, RStructorError::HttpError(_)));
+    response.assert_async().await;
+}
+
+#[tokio::test]
+async fn malformed_usage_with_invalid_content_is_not_reclassified_as_retryable() {
+    let mut server = mockito::Server::new_async().await;
+    let invalid = include_str!("fixtures/structured/portfolio_invalid_quantity.json");
+    let response = server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": invalid,
+                    },
+                    "finish_reason": "stop",
+                }],
+                "usage": "not-an-object",
+                "model": "risk-router",
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let error = client(&server)
+        .materialize::<Portfolio>("reconcile the futures book")
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, RStructorError::HttpError(_)));
+    response.assert_async().await;
 }
 
 #[tokio::test]

--- a/tests/http_mock_tests.rs
+++ b/tests/http_mock_tests.rs
@@ -7,7 +7,10 @@
 //! shaping and the retry loop it drives are shared by the OpenAI-compatible path.
 #![cfg(feature = "openai")]
 
-use rstructor::{ApiErrorKind, Instructor, LLMClient, OpenAIClient, RStructorError};
+use rstructor::{
+    AnyClient, ApiErrorKind, AttemptKind, AttemptOutcome, Instructor, LLMClient, OpenAIClient,
+    RStructorError,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
@@ -51,6 +54,27 @@ fn chat_completion(content: &str) -> String {
     .to_string()
 }
 
+fn chat_completion_with_usage(
+    content: Option<&str>,
+    model: &str,
+    input_tokens: u64,
+    output_tokens: u64,
+) -> String {
+    json!({
+        "choices": [{
+            "message": { "role": "assistant", "content": content },
+            "finish_reason": "stop",
+        }],
+        "usage": {
+            "prompt_tokens": input_tokens,
+            "completion_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+        },
+        "model": model,
+    })
+    .to_string()
+}
+
 fn client(server: &mockito::Server) -> OpenAIClient {
     OpenAIClient::new("test-key")
         .unwrap()
@@ -82,6 +106,34 @@ async fn materialize_parses_a_real_response() {
         }
     );
     m.assert_async().await;
+}
+
+#[tokio::test]
+async fn any_client_dispatches_attempt_reports_to_the_concrete_provider() {
+    let mut server = mockito::Server::new_async().await;
+    let response = server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_body(chat_completion_with_usage(
+            Some(r#"{"title":"Margin Call","year":2011}"#),
+            "gpt-4o-mini",
+            30,
+            9,
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+    let any: AnyClient = client(&server).into();
+
+    let report = any
+        .materialize_with_attempts::<Movie>("a finance film")
+        .await
+        .unwrap();
+
+    assert_eq!(report.data.title, "Margin Call");
+    assert_eq!(report.attempts.len(), 1);
+    assert_eq!(report.cumulative_usage.as_ref().unwrap().total_tokens(), 39);
+    response.assert_async().await;
 }
 
 #[tokio::test]
@@ -169,6 +221,298 @@ async fn retryable_status_is_retried() {
     assert_eq!(movie.title, "Dune");
     rate_limited.assert_async().await;
     ok.assert_async().await;
+}
+
+#[tokio::test]
+async fn attempt_report_accumulates_semantic_retry_usage_by_model() {
+    let mut server = mockito::Server::new_async().await;
+    let invalid = include_str!("fixtures/structured/portfolio_invalid_quantity.json");
+    let valid = include_str!("fixtures/structured/portfolio_valid.json");
+
+    let bad = server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(chat_completion_with_usage(
+            Some(invalid),
+            "risk-router-2026-07-01",
+            210,
+            35,
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+    let good = server
+        .mock("POST", "/chat/completions")
+        .match_body(mockito::Matcher::Regex(
+            r"\$\.positions\[1\]\.quantity".to_string(),
+        ))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(chat_completion_with_usage(
+            Some(valid),
+            "risk-router-2026-07-15",
+            280,
+            42,
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let report = client(&server)
+        .materialize_with_attempts::<Portfolio>("reconcile the futures book")
+        .await
+        .unwrap();
+
+    assert_eq!(report.data.portfolio_id, "HF-ALPHA-001");
+    assert_eq!(report.attempts.len(), 2);
+    assert_eq!(report.attempts[0].kind, AttemptKind::Semantic);
+    assert_eq!(report.attempts[1].kind, AttemptKind::Semantic);
+    assert!(matches!(
+        report.attempts[0].outcome,
+        AttemptOutcome::Failed { retried: true, .. }
+    ));
+    assert_eq!(report.attempts[1].outcome, AttemptOutcome::Succeeded);
+    assert_eq!(
+        report.final_usage.as_ref().unwrap().model,
+        "risk-router-2026-07-15"
+    );
+
+    let cumulative = report.cumulative_usage.unwrap();
+    assert_eq!(cumulative.reported_attempts, 2);
+    assert_eq!(cumulative.input_tokens, 490);
+    assert_eq!(cumulative.output_tokens, 77);
+    assert_eq!(
+        cumulative.by_model["risk-router-2026-07-01"].total_tokens(),
+        245
+    );
+    assert_eq!(
+        cumulative.by_model["risk-router-2026-07-15"].total_tokens(),
+        322
+    );
+    bad.assert_async().await;
+    good.assert_async().await;
+}
+
+#[tokio::test]
+async fn existing_metadata_keeps_final_response_usage_after_reask() {
+    let mut server = mockito::Server::new_async().await;
+    let invalid = include_str!("fixtures/structured/portfolio_invalid_quantity.json");
+    let valid = include_str!("fixtures/structured/portfolio_valid.json");
+
+    let bad = server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_body(chat_completion_with_usage(
+            Some(invalid),
+            "risk-router",
+            210,
+            35,
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+    let good = server
+        .mock("POST", "/chat/completions")
+        .match_body(mockito::Matcher::Regex(
+            r"\$\.positions\[1\]\.quantity".to_string(),
+        ))
+        .with_status(200)
+        .with_body(chat_completion_with_usage(
+            Some(valid),
+            "risk-router",
+            280,
+            42,
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let result = client(&server)
+        .materialize_with_metadata::<Portfolio>("reconcile the futures book")
+        .await
+        .unwrap();
+
+    let usage = result.usage.unwrap();
+    assert_eq!(usage.input_tokens, 280);
+    assert_eq!(usage.output_tokens, 42);
+    bad.assert_async().await;
+    good.assert_async().await;
+}
+
+#[tokio::test]
+async fn retryable_provider_error_is_a_transport_attempt_without_history_mutation() {
+    let mut server = mockito::Server::new_async().await;
+    let rate_limited = server
+        .mock("POST", "/chat/completions")
+        .with_status(429)
+        .with_header("retry-after", "0")
+        .with_body("{}")
+        .expect(1)
+        .create_async()
+        .await;
+    let ok = server
+        .mock("POST", "/chat/completions")
+        .match_body(mockito::Matcher::Regex(
+            r#""messages":\[\{"role":"user""#.to_string(),
+        ))
+        .with_status(200)
+        .with_body(chat_completion_with_usage(
+            Some(r#"{"title":"Dune","year":2021}"#),
+            "gpt-4o-mini",
+            25,
+            8,
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let report = client(&server)
+        .materialize_with_attempts::<Movie>("a film")
+        .await
+        .unwrap();
+
+    assert_eq!(report.attempts.len(), 2);
+    assert_eq!(report.attempts[0].kind, AttemptKind::Transport);
+    assert!(matches!(
+        report.attempts[0].outcome,
+        AttemptOutcome::Failed { retried: true, .. }
+    ));
+    assert_eq!(report.attempts[1].kind, AttemptKind::Semantic);
+    assert_eq!(
+        report.cumulative_usage.as_ref().unwrap().reported_attempts,
+        1
+    );
+    rate_limited.assert_async().await;
+    ok.assert_async().await;
+}
+
+#[tokio::test]
+async fn malformed_envelope_retains_usage_as_an_unretried_transport_attempt() {
+    let mut server = mockito::Server::new_async().await;
+    let malformed = server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 55,
+                    "completion_tokens": 3,
+                    "total_tokens": 58,
+                },
+                "model": "gpt-4o-mini",
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let failure = client(&server)
+        .materialize_with_attempts::<Movie>("a film")
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error().api_error_kind(),
+        Some(ApiErrorKind::UnexpectedResponse { .. })
+    ));
+    assert_eq!(failure.attempts.len(), 1);
+    assert_eq!(failure.attempts[0].kind, AttemptKind::Transport);
+    assert!(matches!(
+        failure.attempts[0].outcome,
+        AttemptOutcome::Failed { retried: false, .. }
+    ));
+    assert_eq!(
+        failure.attempts[0].usage.as_ref().unwrap().total_tokens(),
+        58
+    );
+    assert_eq!(
+        failure.cumulative_usage.as_ref().unwrap().total_tokens(),
+        58
+    );
+    malformed.assert_async().await;
+}
+
+#[tokio::test]
+async fn semantic_exhaustion_exposes_usage_while_legacy_api_keeps_bare_error() {
+    let mut report_server = mockito::Server::new_async().await;
+    let invalid = include_str!("fixtures/structured/portfolio_invalid_quantity.json");
+
+    let first = report_server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_body(chat_completion_with_usage(
+            Some(invalid),
+            "risk-router",
+            120,
+            20,
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+    let second = report_server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_body(chat_completion_with_usage(
+            Some(invalid),
+            "risk-router",
+            160,
+            25,
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let failure = client(&report_server)
+        .max_retries(1)
+        .materialize_with_attempts::<Portfolio>("reconcile")
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error(),
+        RStructorError::OutputDecodeError { path, .. }
+            if path == "$.positions[1].quantity"
+    ));
+    assert_eq!(failure.attempts.len(), 2);
+    assert_eq!(
+        failure.cumulative_usage.as_ref().unwrap().total_tokens(),
+        325
+    );
+    first.assert_async().await;
+    second.assert_async().await;
+
+    let mut legacy_server = mockito::Server::new_async().await;
+    let legacy_first = legacy_server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_body(chat_completion(invalid))
+        .expect(1)
+        .create_async()
+        .await;
+    let legacy_second = legacy_server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_body(chat_completion(invalid))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let error = client(&legacy_server)
+        .max_retries(1)
+        .materialize::<Portfolio>("reconcile")
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        RStructorError::OutputDecodeError { ref path, .. }
+            if path == "$.positions[1].quantity"
+    ));
+    legacy_first.assert_async().await;
+    legacy_second.assert_async().await;
 }
 
 #[tokio::test]

--- a/tests/http_mock_tests.rs
+++ b/tests/http_mock_tests.rs
@@ -270,7 +270,10 @@ async fn attempt_report_accumulates_semantic_retry_usage_by_model() {
     assert_eq!(report.attempts[1].kind, AttemptKind::Semantic);
     assert!(matches!(
         report.attempts[0].outcome,
-        AttemptOutcome::Failed { retried: true, .. }
+        AttemptOutcome::Failed {
+            disposition: rstructor::RetryDisposition::Retried,
+            ..
+        }
     ));
     assert_eq!(report.attempts[1].outcome, AttemptOutcome::Succeeded);
     assert_eq!(
@@ -341,6 +344,87 @@ async fn existing_metadata_keeps_final_response_usage_after_reask() {
 }
 
 #[tokio::test]
+async fn earlier_usage_survives_when_success_omits_usage_but_legacy_metadata_stays_final_only() {
+    let invalid = include_str!("fixtures/structured/portfolio_invalid_quantity.json");
+    let valid = include_str!("fixtures/structured/portfolio_valid.json");
+
+    let mut report_server = mockito::Server::new_async().await;
+    let report_bad = report_server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_body(chat_completion_with_usage(
+            Some(invalid),
+            "risk-router",
+            90,
+            15,
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+    let report_good = report_server
+        .mock("POST", "/chat/completions")
+        .match_body(mockito::Matcher::Regex(
+            r"\$\.positions\[1\]\.quantity".to_string(),
+        ))
+        .with_status(200)
+        .with_body(chat_completion(valid))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let report = client(&report_server)
+        .max_retries(1)
+        .materialize_with_attempts::<Portfolio>("reconcile the futures book")
+        .await
+        .unwrap();
+
+    assert!(report.attempts_complete);
+    assert_eq!(report.attempts.len(), 2);
+    assert!(report.final_usage.is_none());
+    assert!(report.attempts[1].usage.is_none());
+    assert_eq!(
+        report.cumulative_usage.as_ref().unwrap().total_tokens(),
+        105
+    );
+    report_bad.assert_async().await;
+    report_good.assert_async().await;
+
+    let mut legacy_server = mockito::Server::new_async().await;
+    let legacy_bad = legacy_server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_body(chat_completion_with_usage(
+            Some(invalid),
+            "risk-router",
+            90,
+            15,
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+    let legacy_good = legacy_server
+        .mock("POST", "/chat/completions")
+        .match_body(mockito::Matcher::Regex(
+            r"\$\.positions\[1\]\.quantity".to_string(),
+        ))
+        .with_status(200)
+        .with_body(chat_completion(valid))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let legacy = client(&legacy_server)
+        .max_retries(1)
+        .materialize_with_metadata::<Portfolio>("reconcile the futures book")
+        .await
+        .unwrap();
+
+    assert!(legacy.usage.is_none());
+    legacy_bad.assert_async().await;
+    legacy_good.assert_async().await;
+}
+
+#[tokio::test]
 async fn retryable_provider_error_is_a_transport_attempt_without_history_mutation() {
     let mut server = mockito::Server::new_async().await;
     let rate_limited = server
@@ -376,7 +460,10 @@ async fn retryable_provider_error_is_a_transport_attempt_without_history_mutatio
     assert_eq!(report.attempts[0].kind, AttemptKind::Transport);
     assert!(matches!(
         report.attempts[0].outcome,
-        AttemptOutcome::Failed { retried: true, .. }
+        AttemptOutcome::Failed {
+            disposition: rstructor::RetryDisposition::Retried,
+            ..
+        }
     ));
     assert_eq!(report.attempts[1].kind, AttemptKind::Semantic);
     assert_eq!(
@@ -396,7 +483,7 @@ async fn malformed_envelope_retains_usage_as_an_unretried_transport_attempt() {
         .with_header("content-type", "application/json")
         .with_body(
             json!({
-                "choices": [],
+                "choices": { "unexpected": "object instead of array" },
                 "usage": {
                     "prompt_tokens": 55,
                     "completion_tokens": 3,
@@ -423,7 +510,10 @@ async fn malformed_envelope_retains_usage_as_an_unretried_transport_attempt() {
     assert_eq!(failure.attempts[0].kind, AttemptKind::Transport);
     assert!(matches!(
         failure.attempts[0].outcome,
-        AttemptOutcome::Failed { retried: false, .. }
+        AttemptOutcome::Failed {
+            disposition: rstructor::RetryDisposition::NonRetryable,
+            ..
+        }
     ));
     assert_eq!(
         failure.attempts[0].usage.as_ref().unwrap().total_tokens(),
@@ -434,6 +524,73 @@ async fn malformed_envelope_retains_usage_as_an_unretried_transport_attempt() {
         58
     );
     malformed.assert_async().await;
+}
+
+#[tokio::test]
+async fn invalid_request_url_is_preflight_and_records_no_provider_attempt() {
+    let failure = OpenAIClient::new("test-key")
+        .unwrap()
+        .base_url("://invalid-url")
+        .materialize_with_attempts::<Movie>("a film")
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error(),
+        RStructorError::HttpError(error) if error.is_builder()
+    ));
+    assert!(failure.attempts.is_empty());
+    assert!(failure.cumulative_usage.is_none());
+}
+
+#[tokio::test]
+async fn media_attempt_report_uses_provider_path_and_retains_usage() {
+    use rstructor::MediaFile;
+
+    let mut server = mockito::Server::new_async().await;
+    let valid = include_str!("fixtures/structured/portfolio_valid.json");
+    let request = server
+        .mock("POST", "/chat/completions")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "messages": [{
+                "role": "user",
+                "content": [
+                    { "type": "text", "text": "reconcile the chart" },
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "data:image/png;base64,YWJj",
+                            "detail": "auto",
+                        },
+                    },
+                ],
+            }],
+        })))
+        .with_status(200)
+        .with_body(chat_completion_with_usage(
+            Some(valid),
+            "vision-risk-router",
+            75,
+            12,
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let media = [MediaFile::from_bytes(b"abc", "image/png")];
+    let report = client(&server)
+        .materialize_with_media_and_attempts::<Portfolio>("reconcile the chart", &media)
+        .await
+        .unwrap();
+
+    assert!(report.attempts_complete);
+    assert_eq!(report.attempts.len(), 1);
+    assert_eq!(
+        report.final_usage.as_ref().unwrap().model,
+        "vision-risk-router"
+    );
+    assert_eq!(report.cumulative_usage.as_ref().unwrap().total_tokens(), 87);
+    request.assert_async().await;
 }
 
 #[tokio::test]

--- a/tests/map_fidelity_tests.rs
+++ b/tests/map_fidelity_tests.rs
@@ -91,6 +91,22 @@ async fn openai_rejects_dynamic_maps_before_http() {
     assert_map_compatibility_error(error, "OpenAI", "structured output");
 }
 
+#[cfg(feature = "openai")]
+#[tokio::test]
+async fn openai_attempt_report_keeps_preflight_failure_out_of_provider_ledger() {
+    let server = mockito::Server::new_async().await;
+    let failure = rstructor::OpenAIClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .materialize_with_attempts::<MappedPortfolio>("reconcile the portfolio")
+        .await
+        .unwrap_err();
+
+    assert!(failure.attempts.is_empty());
+    assert!(failure.cumulative_usage.is_none());
+    assert_map_compatibility_error(failure.into_error(), "OpenAI", "structured output");
+}
+
 #[cfg(feature = "anthropic")]
 #[tokio::test]
 async fn anthropic_rejects_dynamic_maps_before_http() {

--- a/tests/mock_client_tests.rs
+++ b/tests/mock_client_tests.rs
@@ -96,7 +96,10 @@ async fn attempt_report_uses_per_response_usage_for_realistic_reask_fixture() {
     assert_eq!(report.attempts[0].kind, AttemptKind::Semantic);
     assert!(matches!(
         report.attempts[0].outcome,
-        AttemptOutcome::Failed { retried: true, .. }
+        AttemptOutcome::Failed {
+            disposition: rstructor::RetryDisposition::Retried,
+            ..
+        }
     ));
     assert_eq!(report.attempts[1].outcome, AttemptOutcome::Succeeded);
     assert_eq!(
@@ -137,11 +140,53 @@ async fn attempt_exhaustion_keeps_usage_and_final_decode_error() {
     assert_eq!(failure.attempts.len(), 2);
     assert!(matches!(
         failure.attempts[1].outcome,
-        AttemptOutcome::Failed { retried: false, .. }
+        AttemptOutcome::Failed {
+            disposition: rstructor::RetryDisposition::BudgetExhausted,
+            ..
+        }
     ));
     assert_eq!(
         failure.cumulative_usage.as_ref().unwrap().total_tokens(),
         202
+    );
+}
+
+#[tokio::test]
+async fn scripted_transport_error_retains_usage_without_retrying() {
+    use rstructor::{ApiErrorKind, AttemptKind, AttemptOutcome, RetryDisposition, TokenUsage};
+
+    let client = MockClient::new()
+        .with_response_and_usage(
+            MockResponse::Error(RStructorError::api_error(
+                "MockProvider",
+                ApiErrorKind::AuthenticationFailed,
+            )),
+            TokenUsage::new("mock-risk-router", 22, 3),
+        )
+        .with_retries(3);
+
+    let failure = client
+        .materialize_with_attempts::<Portfolio>("reconcile positions")
+        .await
+        .unwrap_err();
+
+    assert!(failure.attempts_complete);
+    assert_eq!(failure.attempts.len(), 1);
+    assert_eq!(failure.attempts[0].kind, AttemptKind::Transport);
+    assert!(matches!(
+        failure.attempts[0].outcome,
+        AttemptOutcome::Failed {
+            disposition: RetryDisposition::NonRetryable,
+            ..
+        }
+    ));
+    assert_eq!(
+        failure.attempts[0].usage.as_ref().unwrap().total_tokens(),
+        25
+    );
+    assert_eq!(
+        failure.cumulative_usage.as_ref().unwrap().total_tokens(),
+        25
     );
 }
 

--- a/tests/mock_client_tests.rs
+++ b/tests/mock_client_tests.rs
@@ -72,6 +72,80 @@ async fn metadata_usage_can_be_configured() {
 }
 
 #[tokio::test]
+async fn attempt_report_uses_per_response_usage_for_realistic_reask_fixture() {
+    use rstructor::{AttemptKind, AttemptOutcome, TokenUsage};
+
+    let client = MockClient::new()
+        .with_response_and_usage(
+            include_str!("fixtures/structured/portfolio_invalid_quantity.json"),
+            TokenUsage::new("mock-risk-router-v1", 90, 15),
+        )
+        .with_response_and_usage(
+            include_str!("fixtures/structured/portfolio_valid.json"),
+            TokenUsage::new("mock-risk-router-v2", 120, 18),
+        )
+        .with_retries(1);
+
+    let report = client
+        .materialize_with_attempts::<Portfolio>("reconcile positions")
+        .await
+        .unwrap();
+
+    assert_eq!(report.data.positions[1].quantity, -240);
+    assert_eq!(report.attempts.len(), 2);
+    assert_eq!(report.attempts[0].kind, AttemptKind::Semantic);
+    assert!(matches!(
+        report.attempts[0].outcome,
+        AttemptOutcome::Failed { retried: true, .. }
+    ));
+    assert_eq!(report.attempts[1].outcome, AttemptOutcome::Succeeded);
+    assert_eq!(
+        report.cumulative_usage.as_ref().unwrap().total_tokens(),
+        243
+    );
+    assert_eq!(
+        report.final_usage.as_ref().unwrap().model,
+        "mock-risk-router-v2"
+    );
+    assert_eq!(
+        client.last_request().unwrap().kind,
+        RequestKind::MaterializeWithAttempts
+    );
+    assert_eq!(client.request_count(), 1);
+}
+
+#[tokio::test]
+async fn attempt_exhaustion_keeps_usage_and_final_decode_error() {
+    use rstructor::{AttemptOutcome, TokenUsage};
+
+    let invalid = include_str!("fixtures/structured/portfolio_invalid_quantity.json");
+    let client = MockClient::new()
+        .with_response_and_usage(invalid, TokenUsage::new("mock-risk-router", 80, 10))
+        .with_response_and_usage(invalid, TokenUsage::new("mock-risk-router", 100, 12))
+        .with_retries(1);
+
+    let failure = client
+        .materialize_with_attempts::<Portfolio>("reconcile positions")
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error(),
+        RStructorError::OutputDecodeError { path, .. }
+            if path == "$.positions[1].quantity"
+    ));
+    assert_eq!(failure.attempts.len(), 2);
+    assert!(matches!(
+        failure.attempts[1].outcome,
+        AttemptOutcome::Failed { retried: false, .. }
+    ));
+    assert_eq!(
+        failure.cumulative_usage.as_ref().unwrap().total_tokens(),
+        202
+    );
+}
+
+#[tokio::test]
 async fn queue_is_fifo() {
     let client = MockClient::new()
         .with_response(r#"{"title":"First","year":2001}"#)


### PR DESCRIPTION
## Summary

- add an ordered materialization attempt ledger for built-in providers, `AnyClient`, and `MockClient`
- aggregate known token usage across semantic retries and retryable transport failures, grouped by exact provider-reported model
- preserve final errors and attempt metadata after retry exhaustion
- add fluent/media terminals, conservative custom-client fallbacks, documentation, and a complete runnable example

Existing behavior is unchanged:

- `materialize` still returns the final bare `RStructorError`
- `materialize_with_metadata` still reports usage only for the final successful response
- retry budgets and retry classification are unchanged
- malformed provider envelopes remain strict, fail-fast errors
- local preflight failures do not count as provider attempts

## Usage

Inspect cumulative usage on a successful run:

```rust
let report = client
    .materialize_with_attempts::<Portfolio>("Reconcile the fund book")
    .await?;

println!("attempts: {}", report.attempts.len());
if let Some(usage) = report.cumulative_usage {
    println!("known tokens: {}", usage.total_tokens());
    for (model, model_usage) in usage.by_model {
        println!("{model}: {}", model_usage.total_tokens());
    }
}
```

Retain the ledger and known cost after exhaustion:

```rust
match client
    .max_retries(2)
    .materialize_with_attempts::<Portfolio>("Reconcile the fund book")
    .await
{
    Ok(report) => println!("{:?}", report.data),
    Err(failure) => {
        eprintln!("final error: {}", failure.error());
        for attempt in &failure.attempts {
            eprintln!(
                "#{} {:?}: {:?}, usage={:?}",
                attempt.number,
                attempt.kind,
                attempt.outcome,
                attempt.usage
            );
        }
        eprintln!("known run usage: {:?}", failure.cumulative_usage);
    }
}
```

The fluent builder preserves system context and media routing:

```rust
let report = client
    .request()
    .system("Use the prime broker's signed quantities.")
    .media(files)
    .materialize_with_attempts::<Portfolio>("Reconcile this statement")
    .await?;
```

See `examples/retry_attempt_ledger.rs` for the full success-and-failure example.

## API notes

- new public types: `MaterializeReport`, `MaterializeFailure`, `AttemptRecord`, `AttemptKind`, `AttemptOutcome`, `RetryDisposition`, and `RunUsage`
- new terminals: `materialize_with_attempts` and `materialize_with_media_and_attempts`
- built-in providers and `MockClient` set `attempts_complete = true`
- the default implementation for custom `LLMClient`s preserves final usage but sets `attempts_complete = false` instead of inventing hidden attempts
- `RequestKind` gains attempt-ledger variants and is now `#[non_exhaustive]`; downstream exhaustive matches need a wildcard arm

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --no-default-features -- -D warnings`
- `cargo clippy --no-default-features --features "derive,mock" -- -D warnings`
- schema-only builds with `derive` and `derive,mock`
- `cargo build --all-features --examples`
- `cargo test --all-features --no-fail-fast`

Coverage includes mixed semantic/transport retries, retry exhaustion, zero retry budgets, missing usage, usage grouped across model versions, counter overflow, preflight failures, media routing, custom clients, `AnyClient`, realistic `MockClient` fixtures, all four built-in providers, strict malformed-envelope compatibility, and legacy final-only metadata/error behavior.
