### PR TITLE
Add provider-string client routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 Describe the shape you want as plain Rust types, then turn a line of free-form text into a fully-typed, validated value:
 
 ```rust
-use rstructor::{Instructor, LLMClient, OpenAIClient};
+use rstructor::{Instructor, LLMClient};
 use serde::{Deserialize, Serialize};
 
 #[derive(Instructor, Serialize, Deserialize, Debug)]
@@ -58,14 +58,10 @@ struct Ticket {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = OpenAIClient::from_env()?.temperature(0.0);
-
-    let ticket: Ticket = client
-        .materialize(
-            "Hey, the login page is throwing 500s for half our users since the deploy. \
-             Sarah (sarah@acme.io) is on it but we need this fixed before the demo at 3pm!",
-        )
-        .await?;
+    let text = "Hey, the login page is throwing 500s for half our users since the deploy. \
+                Sarah (sarah@acme.io) is on it but we need this fixed before the demo at 3pm!";
+    let ticket: Ticket = rstructor::client("openai/gpt-5.6-sol")?
+        .materialize(text).await?;
 
     println!("{ticket:#?}");
     // Ticket {
@@ -79,6 +75,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 Every field is *inferred*, not transcribed: the urgency is read from the tone and deadline, the email is plucked out of mid-sentence text, and the tags are synthesized — all parsed into the exact types you declared.
+
+If you want provider-specific configuration, use the explicit client form:
+
+```rust
+use rstructor::{LLMClient, OpenAIClient};
+
+let client = OpenAIClient::from_env()?.temperature(0.0);
+let ticket: Ticket = client.materialize(text).await?;
+```
 
 ## Request Builder
 
@@ -140,12 +145,19 @@ let client = OpenAIClient::new("key")?
 ```rust
 use rstructor::{AnyClient, Provider, LLMClient};
 
+// Parse a case-insensitive "provider/model" string.
+let client = rstructor::client("anthropic/claude-sonnet-5")?;
+let movie: Movie = client.materialize("Describe Inception").await?;
+
+// Or auto-detect in deterministic environment-key order:
+let client = rstructor::client_from_env()?;
+
 // Pick a provider dynamically, reading its key from the environment.
 let provider = Provider::Anthropic; // e.g. parsed from a config file
 let client = AnyClient::from_env_for(provider)?;
 let movie: Movie = client.materialize("Describe Inception").await?;
 
-// Or auto-detect from whichever API key is set:
+// The equivalent trait-level constructor is also available:
 let client = AnyClient::from_env()?;
 
 // Or wrap a pre-configured client:

--- a/src/backend/any_client.rs
+++ b/src/backend/any_client.rs
@@ -9,6 +9,8 @@
 
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
+use std::fmt;
+use std::str::FromStr;
 
 use crate::backend::usage::{
     GenerateResult, MaterializeFailure, MaterializeReport, MaterializeResult,
@@ -37,12 +39,95 @@ pub enum Provider {
     /// Anthropic (reads `ANTHROPIC_API_KEY`).
     #[cfg(feature = "anthropic")]
     Anthropic,
+    /// Google Gemini (reads `GEMINI_API_KEY`, then `GOOGLE_API_KEY`).
+    #[cfg(feature = "gemini")]
+    Gemini,
     /// xAI / Grok (reads `XAI_API_KEY`).
     #[cfg(feature = "grok")]
     Grok,
-    /// Google Gemini (reads `GEMINI_API_KEY`).
-    #[cfg(feature = "gemini")]
-    Gemini,
+}
+
+impl FromStr for Provider {
+    type Err = RStructorError;
+
+    /// Parse a case-insensitive provider name.
+    ///
+    /// `xai` is accepted as an alias for `grok`. A recognized provider whose
+    /// Cargo feature is disabled returns an error naming the feature to enable.
+    fn from_str(name: &str) -> Result<Self> {
+        match name.to_ascii_lowercase().as_str() {
+            "openai" => {
+                #[cfg(feature = "openai")]
+                {
+                    Ok(Self::OpenAI)
+                }
+                #[cfg(not(feature = "openai"))]
+                {
+                    Err(provider_feature_disabled("openai", "openai"))
+                }
+            }
+            "anthropic" => {
+                #[cfg(feature = "anthropic")]
+                {
+                    Ok(Self::Anthropic)
+                }
+                #[cfg(not(feature = "anthropic"))]
+                {
+                    Err(provider_feature_disabled("anthropic", "anthropic"))
+                }
+            }
+            "gemini" => {
+                #[cfg(feature = "gemini")]
+                {
+                    Ok(Self::Gemini)
+                }
+                #[cfg(not(feature = "gemini"))]
+                {
+                    Err(provider_feature_disabled("gemini", "gemini"))
+                }
+            }
+            "grok" | "xai" => {
+                #[cfg(feature = "grok")]
+                {
+                    Ok(Self::Grok)
+                }
+                #[cfg(not(feature = "grok"))]
+                {
+                    Err(provider_feature_disabled(name, "grok"))
+                }
+            }
+            _ => Err(RStructorError::Unsupported(format!(
+                "unknown provider `{name}`; valid providers: openai, anthropic, gemini, grok (alias: xai)"
+            ))),
+        }
+    }
+}
+
+impl fmt::Display for Provider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            #[cfg(feature = "openai")]
+            Self::OpenAI => formatter.write_str("openai"),
+            #[cfg(feature = "anthropic")]
+            Self::Anthropic => formatter.write_str("anthropic"),
+            #[cfg(feature = "gemini")]
+            Self::Gemini => formatter.write_str("gemini"),
+            #[cfg(feature = "grok")]
+            Self::Grok => formatter.write_str("grok"),
+        }
+    }
+}
+
+#[cfg(any(
+    not(feature = "openai"),
+    not(feature = "anthropic"),
+    not(feature = "gemini"),
+    not(feature = "grok")
+))]
+fn provider_feature_disabled(provider: &str, feature: &str) -> RStructorError {
+    RStructorError::Unsupported(format!(
+        "provider `{provider}` is disabled; enable the `{feature}` Cargo feature"
+    ))
 }
 
 /// A provider-agnostic client chosen at runtime.
@@ -242,8 +327,9 @@ impl LLMClient for AnyClient {
 
     /// Auto-detect a provider from the environment.
     ///
-    /// Enabled providers are tried in order (OpenAI, Anthropic, Grok, Gemini)
-    /// and the first one whose API-key variable is set is used. For deterministic
+    /// Enabled providers are tried in order: `OPENAI_API_KEY`,
+    /// `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` / `GOOGLE_API_KEY`, then
+    /// `XAI_API_KEY`. The first configured provider wins. For deterministic
     /// selection, prefer [`AnyClient::from_env_for`].
     ///
     /// # Errors
@@ -259,13 +345,13 @@ impl LLMClient for AnyClient {
         if std::env::var("ANTHROPIC_API_KEY").is_ok() {
             return Ok(Self::Anthropic(AnthropicClient::from_env()?));
         }
+        #[cfg(feature = "gemini")]
+        if std::env::var("GEMINI_API_KEY").is_ok() || std::env::var("GOOGLE_API_KEY").is_ok() {
+            return Ok(Self::Gemini(GeminiClient::from_env()?));
+        }
         #[cfg(feature = "grok")]
         if std::env::var("XAI_API_KEY").is_ok() {
             return Ok(Self::Grok(GrokClient::from_env()?));
-        }
-        #[cfg(feature = "gemini")]
-        if std::env::var("GEMINI_API_KEY").is_ok() {
-            return Ok(Self::Gemini(GeminiClient::from_env()?));
         }
         Err(RStructorError::api_error(
             "AnyClient",

--- a/src/backend/any_client.rs
+++ b/src/backend/any_client.rs
@@ -7,10 +7,11 @@
 //! ("choose a provider at runtime and keep it in a single type") by wrapping each
 //! concrete client in an enum that itself implements [`LLMClient`].
 
-use async_trait::async_trait;
-use serde::de::DeserializeOwned;
 use std::fmt;
 use std::str::FromStr;
+
+use async_trait::async_trait;
+use serde::de::DeserializeOwned;
 
 use crate::backend::usage::{
     GenerateResult, MaterializeFailure, MaterializeReport, MaterializeResult,

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -297,11 +297,13 @@ impl GeminiClient {
         Ok(Self { config, client })
     }
 
-    /// Create a new Gemini client by reading the API key from the `GEMINI_API_KEY` environment variable.
+    /// Create a new Gemini client by reading an API key from the environment.
+    ///
+    /// `GEMINI_API_KEY` takes precedence over the `GOOGLE_API_KEY` alias.
     ///
     /// # Errors
     ///
-    /// Returns an error if `GEMINI_API_KEY` is not set.
+    /// Returns an error if neither `GEMINI_API_KEY` nor `GOOGLE_API_KEY` is set.
     ///
     /// # Examples
     ///
@@ -315,6 +317,7 @@ impl GeminiClient {
     #[instrument(name = "gemini_client_from_env", fields(model = ?Model::Gemini35Flash))]
     pub fn from_env() -> Result<Self> {
         let api_key = std::env::var("GEMINI_API_KEY")
+            .or_else(|_| std::env::var("GOOGLE_API_KEY"))
             .map_err(|_| RStructorError::api_error("Gemini", ApiErrorKind::AuthenticationFailed))?;
 
         let config = GeminiConfig {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -13,6 +13,8 @@ mod openai_compatible;
 #[cfg(feature = "_client")]
 mod request;
 #[cfg(feature = "_client")]
+mod routing;
+#[cfg(feature = "_client")]
 mod schema_compatibility;
 #[cfg(feature = "streaming")]
 pub mod streaming;
@@ -43,6 +45,8 @@ pub use messages::{MaterializeInternalOutput, ValidationFailureContext};
 pub use mock::{MockClient, MockRequestView, MockResponse, RecordedRequest, RequestKind};
 #[cfg(feature = "_client")]
 pub use request::{Request, RequestExt};
+#[cfg(feature = "_client")]
+pub use routing::{client, client_from_env, parse_client_spec};
 #[cfg(feature = "streaming")]
 pub use streaming::{ItemStream, ObjectStream, StreamedObject, TextStream};
 #[cfg(feature = "tools")]

--- a/src/backend/routing.rs
+++ b/src/backend/routing.rs
@@ -1,0 +1,260 @@
+//! Provider-string routing for runtime client construction.
+
+use std::str::FromStr;
+
+use crate::backend::{AnyClient, LLMClient, Provider};
+use crate::error::Result;
+
+/// How a routed provider obtains its API key.
+///
+/// Item 12 can add provider prefixes with optional or prefix-specific key
+/// policies without changing the public `provider/model` parser contract.
+#[derive(Debug, Clone, Copy)]
+enum KeyPolicy {
+    ProviderDefault,
+}
+
+/// Internal routing metadata kept separate from the public parser result.
+///
+/// The `base_url` and `key_policy` fields are intentionally present before any
+/// compatible-provider prefixes use them. Adding `ollama/`, `openrouter/`, or
+/// similar routes can therefore remain a table/parser extension.
+#[derive(Debug, Clone, Copy)]
+struct ClientRoute<'a> {
+    provider: Provider,
+    model: Option<&'a str>,
+    base_url: Option<&'static str>,
+    key_policy: KeyPolicy,
+}
+
+fn parse_route(spec: &str) -> Result<ClientRoute<'_>> {
+    let (provider_name, model) = match spec.split_once('/') {
+        Some((provider, model)) => (provider, Some(model)),
+        None => (spec, None),
+    };
+
+    Ok(ClientRoute {
+        provider: Provider::from_str(provider_name)?,
+        model,
+        base_url: None,
+        key_policy: KeyPolicy::ProviderDefault,
+    })
+}
+
+/// Parse a `provider/model` client specification without reading the environment.
+///
+/// The first `/` separates the provider from the model. Any additional `/`
+/// characters remain part of the model identifier. Omitting the slash selects
+/// the provider's default model.
+///
+/// Provider names are case-insensitive. Supported names are `openai`,
+/// `anthropic`, `gemini`, and `grok`; `xai` is an alias for `grok`.
+///
+/// # Examples
+///
+/// ```
+/// use rstructor::{Provider, parse_client_spec};
+///
+/// let (provider, model) = parse_client_spec("OpenAI/org/some-model")?;
+/// assert_eq!(provider, Provider::OpenAI);
+/// assert_eq!(model, Some("org/some-model"));
+///
+/// let (_, default_model) = parse_client_spec("openai")?;
+/// assert_eq!(default_model, None);
+/// # Ok::<(), rstructor::RStructorError>(())
+/// ```
+///
+/// # Errors
+///
+/// Returns an error when the provider is unknown or its Cargo feature is
+/// disabled. Disabled-provider errors name the feature to enable.
+pub fn parse_client_spec(spec: &str) -> Result<(Provider, Option<&str>)> {
+    let route = parse_route(spec)?;
+    Ok((route.provider, route.model))
+}
+
+/// Build a client from a `provider/model` string.
+///
+/// The provider's API key is read from its standard environment variable.
+/// Unknown model identifiers are preserved and sent as custom model strings.
+/// Leave off `/model` to use the provider's default model.
+///
+/// # Examples
+///
+/// ```no_run
+/// use rstructor::{Instructor, LLMClient};
+/// use serde::{Deserialize, Serialize};
+///
+/// #[derive(Debug, Deserialize, Serialize, Instructor)]
+/// struct Ticket {
+///     title: String,
+/// }
+///
+/// # async fn example() -> rstructor::Result<()> {
+/// let client = rstructor::client("openai/gpt-5.6-sol")?;
+/// let ticket: Ticket = client.materialize("Customer cannot sign in").await?;
+/// # let _ = ticket;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Errors
+///
+/// Returns an error when the specification is invalid, the provider feature is
+/// disabled, or the provider's API key environment variable is unavailable.
+pub fn client(spec: &str) -> Result<AnyClient> {
+    let route = parse_route(spec)?;
+    let client = match route.key_policy {
+        KeyPolicy::ProviderDefault => AnyClient::from_env_for(route.provider)?,
+    };
+
+    Ok(configure_client(client, route.model, route.base_url))
+}
+
+/// Build a client for the first provider whose API key is configured.
+///
+/// Detection is deterministic. The first available key wins in this order:
+/// `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` /
+/// `GOOGLE_API_KEY`, then `XAI_API_KEY`.
+///
+/// # Examples
+///
+/// ```no_run
+/// use rstructor::{Instructor, LLMClient};
+/// use serde::{Deserialize, Serialize};
+///
+/// #[derive(Debug, Deserialize, Serialize, Instructor)]
+/// struct Ticket {
+///     title: String,
+/// }
+///
+/// # async fn example() -> rstructor::Result<()> {
+/// let client = rstructor::client_from_env()?;
+/// let ticket: Ticket = client.materialize("Customer cannot sign in").await?;
+/// # let _ = ticket;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Errors
+///
+/// Returns an authentication error when none of the enabled providers has an
+/// API key configured.
+pub fn client_from_env() -> Result<AnyClient> {
+    <AnyClient as LLMClient>::from_env()
+}
+
+fn configure_client(client: AnyClient, model: Option<&str>, base_url: Option<&str>) -> AnyClient {
+    macro_rules! configure {
+        ($client:ident, $variant:path) => {{
+            let client = match model {
+                Some(model) => $client.model(model),
+                None => $client,
+            };
+            let client = match base_url {
+                Some(base_url) => client.base_url(base_url),
+                None => client,
+            };
+            $variant(client)
+        }};
+    }
+
+    match client {
+        #[cfg(feature = "openai")]
+        AnyClient::OpenAI(client) => configure!(client, AnyClient::OpenAI),
+        #[cfg(feature = "anthropic")]
+        AnyClient::Anthropic(client) => configure!(client, AnyClient::Anthropic),
+        #[cfg(feature = "gemini")]
+        AnyClient::Gemini(client) => configure!(client, AnyClient::Gemini),
+        #[cfg(feature = "grok")]
+        AnyClient::Grok(client) => configure!(client, AnyClient::Grok),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_client_spec;
+    #[cfg(any(
+        feature = "openai",
+        feature = "anthropic",
+        feature = "gemini",
+        feature = "grok"
+    ))]
+    use crate::Provider;
+
+    #[cfg(feature = "openai")]
+    #[test]
+    fn parses_model_default_and_embedded_slashes() {
+        assert_eq!(
+            parse_client_spec("openai/gpt-5.6-sol").unwrap(),
+            (Provider::OpenAI, Some("gpt-5.6-sol"))
+        );
+        assert_eq!(
+            parse_client_spec("openai").unwrap(),
+            (Provider::OpenAI, None)
+        );
+        assert_eq!(
+            parse_client_spec("openai/vendor/model/version").unwrap(),
+            (Provider::OpenAI, Some("vendor/model/version"))
+        );
+    }
+
+    #[cfg(feature = "grok")]
+    #[test]
+    fn provider_names_are_case_insensitive_and_xai_is_an_alias() {
+        assert_eq!(
+            parse_client_spec("GrOk/grok-4.5").unwrap(),
+            (Provider::Grok, Some("grok-4.5"))
+        );
+        assert_eq!(
+            parse_client_spec("XAI/grok-new").unwrap(),
+            (Provider::Grok, Some("grok-new"))
+        );
+    }
+
+    #[test]
+    fn every_enabled_provider_name_is_accepted_case_insensitively() {
+        #[cfg(feature = "openai")]
+        assert_eq!(
+            parse_client_spec("OpEnAi/model").unwrap(),
+            (Provider::OpenAI, Some("model"))
+        );
+        #[cfg(feature = "anthropic")]
+        assert_eq!(
+            parse_client_spec("AnThRoPiC/model").unwrap(),
+            (Provider::Anthropic, Some("model"))
+        );
+        #[cfg(feature = "gemini")]
+        assert_eq!(
+            parse_client_spec("GeMiNi/model").unwrap(),
+            (Provider::Gemini, Some("model"))
+        );
+        #[cfg(feature = "grok")]
+        assert_eq!(
+            parse_client_spec("GrOk/model").unwrap(),
+            (Provider::Grok, Some("model"))
+        );
+    }
+
+    #[test]
+    fn unknown_provider_error_lists_every_valid_name() {
+        let error = parse_client_spec("mystery/model").unwrap_err().to_string();
+        assert!(error.contains("unknown provider `mystery`"));
+        for valid_name in ["openai", "anthropic", "gemini", "grok", "xai"] {
+            assert!(
+                error.contains(valid_name),
+                "error should list `{valid_name}`: {error}"
+            );
+        }
+    }
+
+    #[cfg(not(feature = "anthropic"))]
+    #[test]
+    fn disabled_provider_error_names_the_required_feature() {
+        let error = parse_client_spec("anthropic/claude-custom")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("provider `anthropic` is disabled"));
+        assert!(error.contains("`anthropic` Cargo feature"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,9 @@ pub use backend::LLMClient;
 pub use backend::ModelInfo;
 pub use backend::ThinkingLevel;
 #[cfg(feature = "_client")]
-pub use backend::{AnyClient, Provider, Request, RequestExt};
+pub use backend::{
+    AnyClient, Provider, Request, RequestExt, client, client_from_env, parse_client_spec,
+};
 pub use backend::{
     AttemptKind, AttemptOutcome, AttemptRecord, ChatMessage, ChatRole, GenerateResult,
     MaterializeFailure, MaterializeReport, MaterializeResult, MediaFile, RetryDisposition,

--- a/tests/anyclient_env_tests.rs
+++ b/tests/anyclient_env_tests.rs
@@ -26,14 +26,14 @@ const ENV_KEYS: [&str; 5] = [
 /// assertion panics partway through, so a failure here cannot poison other test
 /// binaries or the developer's shell session.
 struct EnvGuard {
-    saved: Vec<(&'static str, Option<String>)>,
+    saved: Vec<(&'static str, Option<std::ffi::OsString>)>,
 }
 
 impl EnvGuard {
     fn capture() -> Self {
         let saved = ENV_KEYS
             .iter()
-            .map(|&key| (key, std::env::var(key).ok()))
+            .map(|&key| (key, std::env::var_os(key)))
             .collect();
         EnvGuard { saved }
     }

--- a/tests/anyclient_env_tests.rs
+++ b/tests/anyclient_env_tests.rs
@@ -4,22 +4,23 @@
 //! Environment variables are process-global, and tests within a single binary
 //! share that process. If these scenarios were split across multiple `#[test]`
 //! functions, the default parallel test runner would interleave their mutations
-//! of the same four keys and produce flaky, order-dependent failures. To keep the
+//! of the same five keys and produce flaky, order-dependent failures. To keep the
 //! behavior deterministic, **all** environment manipulation lives in this single
 //! test. The original values of every key are saved on entry and restored on exit
 //! (even on panic, via a drop guard).
 
 use rstructor::{AnyClient, ApiErrorKind, LLMClient, Provider, RStructorError};
 
-/// The four provider API-key environment variables, in detection-precedence order.
-const ENV_KEYS: [&str; 4] = [
+/// Provider API-key environment variables, in detection-precedence order.
+const ENV_KEYS: [&str; 5] = [
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
-    "XAI_API_KEY",
     "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "XAI_API_KEY",
 ];
 
-/// Snapshot of the four keys captured at test start; restores them when dropped.
+/// Snapshot of the five keys captured at test start; restores them when dropped.
 ///
 /// Using a drop guard guarantees the original environment is reinstated even if an
 /// assertion panics partway through, so a failure here cannot poison other test
@@ -69,62 +70,85 @@ fn set_only(present: &[&str]) {
     }
 }
 
+fn assert_detected(provider: Provider, context: &str) {
+    assert_eq!(
+        AnyClient::from_env().unwrap().provider(),
+        provider,
+        "AnyClient::from_env: {context}"
+    );
+    assert_eq!(
+        rstructor::client_from_env().unwrap().provider(),
+        provider,
+        "rstructor::client_from_env: {context}"
+    );
+}
+
 #[test]
 fn anyclient_from_env_detection_precedence_and_per_provider() {
     let _guard = EnvGuard::capture();
 
-    // --- from_env precedence: OpenAI > Anthropic > Grok > Gemini ---
+    // --- from_env precedence: OpenAI > Anthropic > Gemini/Google > Grok ---
 
     // OpenAI + Anthropic both set -> OpenAI wins (highest precedence).
     set_only(&["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]);
-    assert_eq!(
-        AnyClient::from_env().unwrap().provider(),
+    assert_detected(
         Provider::OpenAI,
-        "OpenAI must outrank Anthropic when both keys are present"
+        "OpenAI must outrank Anthropic when both keys are present",
     );
 
-    // All four set -> still OpenAI.
+    // All five set -> still OpenAI.
     set_only(&ENV_KEYS);
-    assert_eq!(
-        AnyClient::from_env().unwrap().provider(),
+    assert_detected(
         Provider::OpenAI,
-        "OpenAI must win when every key is present"
+        "OpenAI must win when every key is present",
     );
 
     // Remove OpenAI -> Anthropic wins over Grok and Gemini.
     set_only(&["ANTHROPIC_API_KEY", "XAI_API_KEY", "GEMINI_API_KEY"]);
-    assert_eq!(
-        AnyClient::from_env().unwrap().provider(),
+    assert_detected(
         Provider::Anthropic,
-        "Anthropic must outrank Grok and Gemini once OpenAI is absent"
+        "Anthropic must outrank Grok and Gemini once OpenAI is absent",
     );
 
-    // Only Grok + Gemini -> Grok wins.
+    // Only Grok + Gemini -> Gemini wins.
     set_only(&["XAI_API_KEY", "GEMINI_API_KEY"]);
-    assert_eq!(
-        AnyClient::from_env().unwrap().provider(),
-        Provider::Grok,
-        "Grok must outrank Gemini"
+    assert_detected(
+        Provider::Gemini,
+        "Gemini must outrank Grok when both keys are present",
+    );
+
+    // The GOOGLE_API_KEY alias has the same precedence as GEMINI_API_KEY.
+    set_only(&["XAI_API_KEY", "GOOGLE_API_KEY"]);
+    assert_detected(
+        Provider::Gemini,
+        "Google's Gemini key alias must outrank Grok",
     );
 
     // Only Grok (XAI) set -> Grok.
     set_only(&["XAI_API_KEY"]);
-    assert_eq!(AnyClient::from_env().unwrap().provider(), Provider::Grok);
+    assert_detected(Provider::Grok, "XAI_API_KEY selects Grok");
 
-    // Only Gemini set -> Gemini (lowest precedence, but the only one present).
+    // Either Gemini key works.
     set_only(&["GEMINI_API_KEY"]);
-    assert_eq!(AnyClient::from_env().unwrap().provider(), Provider::Gemini);
+    assert_detected(Provider::Gemini, "GEMINI_API_KEY selects Gemini");
+
+    set_only(&["GOOGLE_API_KEY"]);
+    assert_detected(Provider::Gemini, "GOOGLE_API_KEY selects Gemini");
 
     // Only Anthropic set -> Anthropic.
     set_only(&["ANTHROPIC_API_KEY"]);
-    assert_eq!(
-        AnyClient::from_env().unwrap().provider(),
-        Provider::Anthropic
-    );
+    assert_detected(Provider::Anthropic, "ANTHROPIC_API_KEY selects Anthropic");
 
     // Only OpenAI set -> OpenAI.
     set_only(&["OPENAI_API_KEY"]);
-    assert_eq!(AnyClient::from_env().unwrap().provider(), Provider::OpenAI);
+    assert_detected(Provider::OpenAI, "OPENAI_API_KEY selects OpenAI");
+
+    // GEMINI_API_KEY remains the preferred alias when both Gemini keys are set.
+    set_only(&["GEMINI_API_KEY", "GOOGLE_API_KEY"]);
+    assert_detected(
+        Provider::Gemini,
+        "either Gemini key selects the same provider",
+    );
 
     // --- from_env_for: deterministic per-provider construction ---
     // With its key present each provider builds; once its key is removed it errors
@@ -165,6 +189,15 @@ fn anyclient_from_env_detection_precedence_and_per_provider() {
         }
     }
 
+    set_only(&["GOOGLE_API_KEY"]);
+    assert_eq!(
+        AnyClient::from_env_for(Provider::Gemini)
+            .unwrap()
+            .provider(),
+        Provider::Gemini,
+        "from_env_for(Gemini) must accept GOOGLE_API_KEY"
+    );
+
     // --- from_env with NO key set -> AuthenticationFailed, provider label "AnyClient" ---
 
     set_only(&[]);
@@ -190,6 +223,18 @@ fn anyclient_from_env_detection_precedence_and_per_provider() {
         }
         other => panic!("expected ApiError, got {other:?}"),
     }
+
+    let routed_err = match rstructor::client_from_env() {
+        Ok(_) => panic!("client_from_env must fail when no provider key is set"),
+        Err(err) => err,
+    };
+    assert!(
+        matches!(
+            routed_err.api_error_kind(),
+            Some(ApiErrorKind::AuthenticationFailed)
+        ),
+        "top-level no-key client_from_env should yield AuthenticationFailed, got {routed_err:?}"
+    );
 
     // --- provider() reporting via From<ConcreteClient> ---
     // Build each concrete client (its key is present), convert with `.into()`, and

--- a/tests/http_mock_tests.rs
+++ b/tests/http_mock_tests.rs
@@ -14,6 +14,33 @@ use rstructor::{
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
+struct OpenAiEnvGuard(Option<std::ffi::OsString>);
+
+impl OpenAiEnvGuard {
+    fn set_for_test() -> Self {
+        let saved = std::env::var_os("OPENAI_API_KEY");
+        // SAFETY: no other test in this integration-test binary reads or writes
+        // OPENAI_API_KEY.
+        unsafe {
+            std::env::set_var("OPENAI_API_KEY", "routed-client-test-key");
+        }
+        Self(saved)
+    }
+}
+
+impl Drop for OpenAiEnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: restores the key after the only test in this binary that
+        // mutates it.
+        unsafe {
+            match self.0.take() {
+                Some(value) => std::env::set_var("OPENAI_API_KEY", value),
+                None => std::env::remove_var("OPENAI_API_KEY"),
+            }
+        }
+    }
+}
+
 #[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
 #[llm(validate = "validate_movie")]
 struct Movie {
@@ -106,6 +133,39 @@ async fn materialize_parses_a_real_response() {
         }
     );
     m.assert_async().await;
+}
+
+#[tokio::test]
+async fn routed_client_sends_the_full_custom_model_string() {
+    let _env = OpenAiEnvGuard::set_for_test();
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/chat/completions")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "model": "vendor/some-model",
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(chat_completion(
+            r#"{"title":"Provider Routing","year":2026}"#,
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let routed = rstructor::client("openai/vendor/some-model").unwrap();
+    let client = match routed {
+        AnyClient::OpenAI(client) => client.base_url(server.url()).no_retries(),
+        _ => panic!("openai prefix should construct the OpenAI AnyClient variant"),
+    };
+
+    let movie: Movie = client
+        .materialize("Describe provider routing")
+        .await
+        .unwrap();
+
+    assert_eq!(movie.title, "Provider Routing");
+    request.assert_async().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- add top-level `rstructor::client("provider/model")` and `rstructor::client_from_env()` constructors backed by `AnyClient`
- add the pure `parse_client_spec` helper and case-insensitive `Provider::from_str`, including the `xai` alias and actionable disabled-feature errors
- preserve the full model remainder after the first slash so aggregator-style identifiers such as `vendor/model/version` round-trip unchanged
- detect environment keys in the documented order: OpenAI, Anthropic, Gemini/Google, then xAI
- carry internal base-URL and key-policy routing metadata now so follow-up compatible-provider prefixes can extend the parser without changing its public contract
- lead the README Quick Start with one-string setup while retaining the explicit-client example

## Usage

Choose a provider and model in one string:

```rust
let ticket: Ticket = rstructor::client("openai/gpt-5.6-sol")?
    .materialize(text).await?;
```

Use a provider's default model by omitting `/model`:

```rust
let client = rstructor::client("anthropic")?;
```

Or select the first configured provider using deterministic environment precedence:

```rust
let client = rstructor::client_from_env()?;
```

Configuration code can parse without reading the environment:

```rust
let (provider, model) = rstructor::parse_client_spec("OpenAI/vendor/model")?;
assert_eq!(provider, rstructor::Provider::OpenAI);
assert_eq!(model, Some("vendor/model"));
```

## Behavior note

`AnyClient::from_env()` now follows the item 11 order when multiple keys are present: OpenAI, Anthropic, Gemini (`GEMINI_API_KEY` or `GOOGLE_API_KEY`), then xAI. This means Gemini wins over xAI when both are configured. Single-key behavior is unchanged, and `GOOGLE_API_KEY` is now accepted as a Gemini alias.

## Tests

- parser unit coverage for defaults, embedded slashes, aliases, case-insensitivity, unknown providers, and disabled-provider feature errors
- scoped env tests for every precedence step, both Gemini key names, no-key errors, and per-provider construction
- mocked OpenAI HTTP coverage proving `client("openai/vendor/some-model")` sends `"model": "vendor/some-model"`
- single-provider feature-matrix tests for OpenAI, Anthropic, Gemini, and Grok
- runnable rustdoc examples for all three top-level helpers

Validated locally with:

```text
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all-features --no-fail-fast
cargo build --all-features --examples
cargo build --no-default-features --features derive
```
