### PR TITLE
[codex] Add local model and aggregator endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,10 @@ required-features = ["mock"]
 name = "retry_attempt_ledger"
 required-features = ["openai"]
 
+[[example]]
+name = "ollama_local_example"
+required-features = ["openai"]
+
 [dev-dependencies]
 # Used only by examples and tests (date/time fields, custom types); not part of
 # the public dependency closure.

--- a/README.md
+++ b/README.md
@@ -132,11 +132,45 @@ let client = GrokClient::from_env()?.model("grok-4.5");
 // Gemini (reads GEMINI_API_KEY)
 let client = GeminiClient::from_env()?.model("gemini-3.5-flash");
 
-// Custom endpoint (local LLMs, proxies)
-let client = OpenAIClient::new("key")?
-    .base_url("http://localhost:1234/v1")
-    .model("llama-3.1-70b");
+// Local Ollama (no API key)
+let client = OpenAIClient::ollama()?.model("llama3.3");
 ```
+
+### Local models & aggregators
+
+Ollama and LM Studio use the OpenAI-compatible client without an API key or
+`Authorization` header:
+
+```rust
+use rstructor::{LLMClient, OpenAIClient};
+
+let local = rstructor::client("ollama/llama3.3")?;
+let movie: Movie = local.materialize("Describe Inception").await?;
+
+// The named constructor is equivalent and supports all normal builders.
+let local = OpenAIClient::lm_studio()?.model("your-loaded-model");
+```
+
+Hosted aggregators read their own keys instead of `OPENAI_API_KEY`. Model IDs
+may contain `/`; only the first slash separates the route prefix from the model:
+
+```rust
+use rstructor::LLMClient;
+
+// Reads OPENROUTER_API_KEY.
+let router = rstructor::client("openrouter/moonshotai/kimi-k3")?;
+let movie: Movie = router.materialize("Describe Inception").await?;
+
+// GROQ_API_KEY and MOONSHOT_API_KEY work the same way.
+let groq = rstructor::client("groq/openai/gpt-oss-120b")?;
+let moonshot = rstructor::client("moonshot/kimi-k3")?;
+```
+
+The named constructors are `OpenAIClient::ollama()`, `lm_studio()`,
+`openrouter()`, `groq()`, and `moonshot()`. They all require the `openai` Cargo
+feature. Strict `response_format` / JSON Schema support varies between compatible
+servers; rstructor keeps the same schema request and validation/re-ask retry
+loop, without endpoint-specific schema-dialect rewriting.
 
 ### Selecting a provider at runtime
 

--- a/examples/ollama_local_example.rs
+++ b/examples/ollama_local_example.rs
@@ -1,0 +1,47 @@
+//! Materialize a typed value with a local Ollama model.
+//!
+//! Pull a model, start Ollama, and opt in by setting `OLLAMA_MODEL`:
+//!
+//! ```text
+//! ollama pull llama3.3
+//! OLLAMA_MODEL=llama3.3 cargo run --example ollama_local_example --features openai
+//! ```
+//!
+//! The example exits successfully without making a request when `OLLAMA_MODEL`
+//! is unset, which keeps example validation safe on machines without Ollama.
+
+use rstructor::{Instructor, LLMClient, OpenAIClient};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, Instructor)]
+struct LocalSummary {
+    #[llm(description = "A concise summary of the input")]
+    summary: String,
+    #[llm(description = "The two most important topics in the input")]
+    topics: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> rstructor::Result<()> {
+    let model = match std::env::var("OLLAMA_MODEL") {
+        Ok(model) if !model.is_empty() => model,
+        _ => {
+            eprintln!(
+                "Skipping Ollama request. Set OLLAMA_MODEL to a pulled model, \
+                 for example: OLLAMA_MODEL=llama3.3"
+            );
+            return Ok(());
+        }
+    };
+
+    let client = OpenAIClient::ollama()?.model(model);
+    let result: LocalSummary = client
+        .materialize(
+            "Rust combines memory safety without garbage collection, zero-cost \
+             abstractions, and fearless concurrency.",
+        )
+        .await?;
+
+    println!("{result:#?}");
+    Ok(())
+}

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -4,6 +4,10 @@ use std::time::Duration;
 use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::backend::model_macro::define_model_enum;
+use crate::backend::routing::{
+    GROQ_BASE_URL, KeyPolicy, LM_STUDIO_BASE_URL, MOONSHOT_BASE_URL, OLLAMA_BASE_URL,
+    OPENROUTER_BASE_URL,
+};
 use crate::backend::{
     ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient, MaterializeAttemptError,
     MaterializeFailure, MaterializeInternalOutput, MaterializeReport, MaterializeResult, ModelInfo,
@@ -136,6 +140,44 @@ pub struct OpenAIClient {
 // OpenAI-compatible chat completion request/response types are in openai_compatible.rs.
 
 impl OpenAIClient {
+    fn with_api_key(api_key: String) -> Self {
+        let config = OpenAIConfig {
+            api_key,
+            model: Model::Gpt56, // Default to GPT-5.6 (latest flagship alias)
+            temperature: 0.0,
+            max_tokens: None,
+            timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
+            max_retries: Some(3),                   // Default: 3 retries with error feedback
+            base_url: None,                         // Default: use official OpenAI API
+            thinking_level: Some(ThinkingLevel::Medium), // GPT-5.6 defaults to medium reasoning
+        };
+
+        Self {
+            config,
+            client: build_http_client(DEFAULT_REQUEST_TIMEOUT),
+        }
+    }
+
+    fn api_key_from_env(provider: &'static str, variable: &'static str) -> Result<String> {
+        std::env::var(variable)
+            .ok()
+            .filter(|api_key| !api_key.is_empty())
+            .ok_or_else(|| RStructorError::api_error(provider, ApiErrorKind::AuthenticationFailed))
+    }
+
+    /// Create an OpenAI-compatible client with an endpoint-specific key policy.
+    pub(crate) fn openai_compatible(base_url: &'static str, key_policy: KeyPolicy) -> Result<Self> {
+        let api_key = match key_policy {
+            KeyPolicy::ProviderDefault => Self::api_key_from_env("OpenAI", "OPENAI_API_KEY")?,
+            KeyPolicy::Keyless => String::new(),
+            KeyPolicy::Environment { provider, variable } => {
+                Self::api_key_from_env(provider, variable)?
+            }
+        };
+
+        Ok(Self::with_api_key(api_key).base_url(base_url))
+    }
+
     /// Create a new OpenAI client with the provided API key.
     ///
     /// # Arguments
@@ -163,22 +205,8 @@ impl OpenAIClient {
         info!("Creating new OpenAI client");
         trace!("API key length: {}", api_key.len());
 
-        let config = OpenAIConfig {
-            api_key,
-            model: Model::Gpt56, // Default to GPT-5.6 (latest flagship alias)
-            temperature: 0.0,
-            max_tokens: None,
-            timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
-            max_retries: Some(3),                   // Default: 3 retries with error feedback
-            base_url: None,                         // Default: use official OpenAI API
-            thinking_level: Some(ThinkingLevel::Medium), // GPT-5.6 defaults to medium reasoning
-        };
-
         debug!("OpenAI client created with default configuration");
-        Ok(Self {
-            config,
-            client: build_http_client(DEFAULT_REQUEST_TIMEOUT),
-        })
+        Ok(Self::with_api_key(api_key))
     }
 
     /// Create a new OpenAI client by reading the API key from the `OPENAI_API_KEY` environment variable.
@@ -204,22 +232,123 @@ impl OpenAIClient {
         info!("Creating new OpenAI client from environment variable");
         trace!("API key length: {}", api_key.len());
 
-        let config = OpenAIConfig {
-            api_key,
-            model: Model::Gpt56, // Default to GPT-5.6 (latest flagship alias)
-            temperature: 0.0,
-            max_tokens: None,
-            timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
-            max_retries: Some(3),                   // Default: 3 retries with error feedback
-            base_url: None,                         // Default: use official OpenAI API
-            thinking_level: Some(ThinkingLevel::Medium), // GPT-5.6 defaults to medium reasoning
-        };
-
         debug!("OpenAI client created with default configuration");
-        Ok(Self {
-            config,
-            client: build_http_client(DEFAULT_REQUEST_TIMEOUT),
-        })
+        Ok(Self::with_api_key(api_key))
+    }
+
+    /// Connect to a local [Ollama](https://docs.ollama.com/api/openai-compatibility)
+    /// server at `http://localhost:11434/v1`.
+    ///
+    /// Local Ollama requests are keyless and send no `Authorization` header.
+    /// Select a pulled model with [`model`](Self::model).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rstructor::OpenAIClient;
+    ///
+    /// let client = OpenAIClient::ollama()?.model("llama3.3");
+    /// # let _ = client;
+    /// # Ok::<(), rstructor::RStructorError>(())
+    /// ```
+    pub fn ollama() -> Result<Self> {
+        Self::openai_compatible(OLLAMA_BASE_URL, KeyPolicy::Keyless)
+    }
+
+    /// Connect to a local [LM Studio](https://lmstudio.ai/docs/developer/openai-compat)
+    /// server at `http://localhost:1234/v1`.
+    ///
+    /// LM Studio does not require authentication by default, so this constructor
+    /// sends no `Authorization` header. Select a loaded model with
+    /// [`model`](Self::model).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rstructor::OpenAIClient;
+    ///
+    /// let client = OpenAIClient::lm_studio()?.model("your-loaded-model");
+    /// # let _ = client;
+    /// # Ok::<(), rstructor::RStructorError>(())
+    /// ```
+    pub fn lm_studio() -> Result<Self> {
+        Self::openai_compatible(LM_STUDIO_BASE_URL, KeyPolicy::Keyless)
+    }
+
+    /// Connect to [OpenRouter](https://openrouter.ai/docs/quickstart).
+    ///
+    /// Reads `OPENROUTER_API_KEY` and uses `https://openrouter.ai/api/v1`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use rstructor::OpenAIClient;
+    ///
+    /// # fn example() -> rstructor::Result<()> {
+    /// let client = OpenAIClient::openrouter()?.model("moonshotai/kimi-k3");
+    /// # let _ = client;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn openrouter() -> Result<Self> {
+        Self::openai_compatible(
+            OPENROUTER_BASE_URL,
+            KeyPolicy::Environment {
+                provider: "OpenRouter",
+                variable: "OPENROUTER_API_KEY",
+            },
+        )
+    }
+
+    /// Connect to [Groq](https://console.groq.com/docs/openai).
+    ///
+    /// Reads `GROQ_API_KEY` and uses `https://api.groq.com/openai/v1`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use rstructor::OpenAIClient;
+    ///
+    /// # fn example() -> rstructor::Result<()> {
+    /// let client = OpenAIClient::groq()?.model("openai/gpt-oss-120b");
+    /// # let _ = client;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn groq() -> Result<Self> {
+        Self::openai_compatible(
+            GROQ_BASE_URL,
+            KeyPolicy::Environment {
+                provider: "Groq",
+                variable: "GROQ_API_KEY",
+            },
+        )
+    }
+
+    /// Connect to the international
+    /// [Moonshot/Kimi API](https://platform.kimi.ai/docs/api/overview).
+    ///
+    /// Reads `MOONSHOT_API_KEY` and uses `https://api.moonshot.ai/v1`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use rstructor::OpenAIClient;
+    ///
+    /// # fn example() -> rstructor::Result<()> {
+    /// let client = OpenAIClient::moonshot()?.model("kimi-k3");
+    /// # let _ = client;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn moonshot() -> Result<Self> {
+        Self::openai_compatible(
+            MOONSHOT_BASE_URL,
+            KeyPolicy::Environment {
+                provider: "Moonshot",
+                variable: "MOONSHOT_API_KEY",
+            },
+        )
     }
 
     // Builder methods are generated by the macro below
@@ -382,10 +511,7 @@ impl OpenAIClient {
             .unwrap_or("https://api.openai.com/v1");
         let url = format!("{}/chat/completions", base_url);
         debug!(url = %url, "Sending request to OpenAI API");
-        let response = self
-            .client
-            .post(&url)
-            .header("Authorization", format!("Bearer {}", self.config.api_key))
+        let response = optional_bearer_auth(self.client.post(&url), &self.config.api_key)
             .header("Content-Type", "application/json")
             .json(&request)
             .send()
@@ -499,10 +625,7 @@ impl OpenAIClient {
             .unwrap_or("https://api.openai.com/v1");
         let url = format!("{}/chat/completions", base_url);
         debug!(url = %url, "Sending request to OpenAI API");
-        let response = self
-            .client
-            .post(&url)
-            .header("Authorization", format!("Bearer {}", self.config.api_key))
+        let response = optional_bearer_auth(self.client.post(&url), &self.config.api_key)
             .header("Content-Type", "application/json")
             .json(&request)
             .send()
@@ -612,9 +735,7 @@ impl OpenAIClient {
             .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
         async move {
             let url = format!("{}/chat/completions", base_url);
-            let resp = client
-                .post(&url)
-                .header("Authorization", format!("Bearer {api_key}"))
+            let resp = optional_bearer_auth(client.post(&url), &api_key)
                 .header("Content-Type", "application/json")
                 .json(&body)
                 .send()
@@ -953,10 +1074,7 @@ impl LLMClient for OpenAIClient {
 
         debug!(url = %url, "Fetching available models from OpenAI");
 
-        let response = self
-            .client
-            .get(&url)
-            .header("Authorization", format!("Bearer {}", self.config.api_key))
+        let response = optional_bearer_auth(self.client.get(&url), &self.config.api_key)
             .header("Content-Type", "application/json")
             .send()
             .await
@@ -1000,6 +1118,17 @@ impl LLMClient for OpenAIClient {
     }
 }
 
+fn optional_bearer_auth(
+    request: reqwest::RequestBuilder,
+    api_key: &str,
+) -> reqwest::RequestBuilder {
+    if api_key.is_empty() {
+        request
+    } else {
+        request.bearer_auth(api_key)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1023,6 +1152,20 @@ mod tests {
             .unwrap()
             .timeout(Duration::from_secs(10));
         assert_eq!(client.config.timeout, Some(Duration::from_secs(10)));
+    }
+
+    #[test]
+    fn local_constructors_are_keyless_and_use_official_base_urls() {
+        let ollama = OpenAIClient::ollama().unwrap();
+        assert_eq!(ollama.config.base_url.as_deref(), Some(OLLAMA_BASE_URL));
+        assert!(ollama.config.api_key.is_empty());
+
+        let lm_studio = OpenAIClient::lm_studio().unwrap();
+        assert_eq!(
+            lm_studio.config.base_url.as_deref(),
+            Some(LM_STUDIO_BASE_URL)
+        );
+        assert!(lm_studio.config.api_key.is_empty());
     }
 
     #[cfg(feature = "tools")]

--- a/src/backend/routing.rs
+++ b/src/backend/routing.rs
@@ -2,23 +2,32 @@
 
 use std::str::FromStr;
 
+#[cfg(feature = "openai")]
+use crate::backend::openai::OpenAIClient;
 use crate::backend::{AnyClient, LLMClient, Provider};
-use crate::error::Result;
+use crate::error::{RStructorError, Result};
+
+pub(crate) const OLLAMA_BASE_URL: &str = "http://localhost:11434/v1";
+pub(crate) const LM_STUDIO_BASE_URL: &str = "http://localhost:1234/v1";
+pub(crate) const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
+pub(crate) const GROQ_BASE_URL: &str = "https://api.groq.com/openai/v1";
+pub(crate) const MOONSHOT_BASE_URL: &str = "https://api.moonshot.ai/v1";
 
 /// How a routed provider obtains its API key.
-///
-/// Item 12 can add provider prefixes with optional or prefix-specific key
-/// policies without changing the public `provider/model` parser contract.
 #[derive(Debug, Clone, Copy)]
-enum KeyPolicy {
+pub(crate) enum KeyPolicy {
     ProviderDefault,
+    Keyless,
+    Environment {
+        provider: &'static str,
+        variable: &'static str,
+    },
 }
 
 /// Internal routing metadata kept separate from the public parser result.
 ///
-/// The `base_url` and `key_policy` fields are intentionally present before any
-/// compatible-provider prefixes use them. Adding `ollama/`, `openrouter/`, or
-/// similar routes can therefore remain a table/parser extension.
+/// Compatible-provider prefixes carry their endpoint and authentication policy
+/// here while preserving the public `(Provider, model)` parser contract.
 #[derive(Debug, Clone, Copy)]
 struct ClientRoute<'a> {
     provider: Provider,
@@ -33,12 +42,78 @@ fn parse_route(spec: &str) -> Result<ClientRoute<'_>> {
         None => (spec, None),
     };
 
-    Ok(ClientRoute {
-        provider: Provider::from_str(provider_name)?,
-        model,
-        base_url: None,
-        key_policy: KeyPolicy::ProviderDefault,
-    })
+    match provider_name.to_ascii_lowercase().as_str() {
+        "openai" | "anthropic" | "gemini" | "grok" | "xai" => Ok(ClientRoute {
+            provider: Provider::from_str(provider_name)?,
+            model,
+            base_url: None,
+            key_policy: KeyPolicy::ProviderDefault,
+        }),
+        "ollama" => {
+            openai_compatible_route(provider_name, model, OLLAMA_BASE_URL, KeyPolicy::Keyless)
+        }
+        "lm_studio" => {
+            openai_compatible_route(provider_name, model, LM_STUDIO_BASE_URL, KeyPolicy::Keyless)
+        }
+        "openrouter" => openai_compatible_route(
+            provider_name,
+            model,
+            OPENROUTER_BASE_URL,
+            KeyPolicy::Environment {
+                provider: "OpenRouter",
+                variable: "OPENROUTER_API_KEY",
+            },
+        ),
+        "groq" => openai_compatible_route(
+            provider_name,
+            model,
+            GROQ_BASE_URL,
+            KeyPolicy::Environment {
+                provider: "Groq",
+                variable: "GROQ_API_KEY",
+            },
+        ),
+        "moonshot" => openai_compatible_route(
+            provider_name,
+            model,
+            MOONSHOT_BASE_URL,
+            KeyPolicy::Environment {
+                provider: "Moonshot",
+                variable: "MOONSHOT_API_KEY",
+            },
+        ),
+        _ => Err(RStructorError::Unsupported(format!(
+            "unknown provider `{provider_name}`; valid providers: openai, anthropic, gemini, grok (alias: xai), ollama, lm_studio, openrouter, groq, moonshot"
+        ))),
+    }
+}
+
+fn openai_compatible_route<'a>(
+    provider_name: &str,
+    model: Option<&'a str>,
+    base_url: &'static str,
+    key_policy: KeyPolicy,
+) -> Result<ClientRoute<'a>> {
+    #[cfg(feature = "openai")]
+    {
+        let _ = provider_name;
+        Ok(ClientRoute {
+            provider: Provider::OpenAI,
+            model,
+            base_url: Some(base_url),
+            key_policy,
+        })
+    }
+    #[cfg(not(feature = "openai"))]
+    {
+        if let KeyPolicy::Environment { provider, variable } = key_policy {
+            let _ = (provider, variable);
+        }
+        let _ = (model, base_url);
+        Err(RStructorError::Unsupported(format!(
+            "provider `{provider_name}` is disabled; enable the `openai` Cargo feature"
+        )))
+    }
 }
 
 /// Parse a `provider/model` client specification without reading the environment.
@@ -47,8 +122,10 @@ fn parse_route(spec: &str) -> Result<ClientRoute<'_>> {
 /// characters remain part of the model identifier. Omitting the slash selects
 /// the provider's default model.
 ///
-/// Provider names are case-insensitive. Supported names are `openai`,
-/// `anthropic`, `gemini`, and `grok`; `xai` is an alias for `grok`.
+/// Provider names are case-insensitive. Native providers are `openai`,
+/// `anthropic`, `gemini`, and `grok` (`xai` is an alias for `grok`).
+/// OpenAI-compatible prefixes are `ollama`, `lm_studio`, `openrouter`, `groq`,
+/// and `moonshot`; these parse as [`Provider::OpenAI`].
 ///
 /// # Examples
 ///
@@ -61,6 +138,10 @@ fn parse_route(spec: &str) -> Result<ClientRoute<'_>> {
 ///
 /// let (_, default_model) = parse_client_spec("openai")?;
 /// assert_eq!(default_model, None);
+///
+/// let (provider, model) = parse_client_spec("openrouter/moonshotai/kimi-k3")?;
+/// assert_eq!(provider, Provider::OpenAI);
+/// assert_eq!(model, Some("moonshotai/kimi-k3"));
 /// # Ok::<(), rstructor::RStructorError>(())
 /// ```
 ///
@@ -75,9 +156,11 @@ pub fn parse_client_spec(spec: &str) -> Result<(Provider, Option<&str>)> {
 
 /// Build a client from a `provider/model` string.
 ///
-/// The provider's API key is read from its standard environment variable.
+/// Native and hosted providers read their API key from the provider-specific
+/// environment variable. Local `ollama` and `lm_studio` routes are keyless.
 /// Unknown model identifiers are preserved and sent as custom model strings.
-/// Leave off `/model` to use the provider's default model.
+/// Leave off `/model` to retain the OpenAI client's default model; compatible
+/// endpoints will normally need an explicit model string.
 ///
 /// # Examples
 ///
@@ -93,7 +176,11 @@ pub fn parse_client_spec(spec: &str) -> Result<(Provider, Option<&str>)> {
 /// # async fn example() -> rstructor::Result<()> {
 /// let client = rstructor::client("openai/gpt-5.6-sol")?;
 /// let ticket: Ticket = client.materialize("Customer cannot sign in").await?;
+///
+/// // Local endpoints need no API key:
+/// let local = rstructor::client("ollama/llama3.3")?;
 /// # let _ = ticket;
+/// # let _ = local;
 /// # Ok(())
 /// # }
 /// ```
@@ -101,11 +188,24 @@ pub fn parse_client_spec(spec: &str) -> Result<(Provider, Option<&str>)> {
 /// # Errors
 ///
 /// Returns an error when the specification is invalid, the provider feature is
-/// disabled, or the provider's API key environment variable is unavailable.
+/// disabled, or a required provider API key environment variable is unavailable.
 pub fn client(spec: &str) -> Result<AnyClient> {
     let route = parse_route(spec)?;
     let client = match route.key_policy {
         KeyPolicy::ProviderDefault => AnyClient::from_env_for(route.provider)?,
+        #[cfg(feature = "openai")]
+        key_policy @ (KeyPolicy::Keyless | KeyPolicy::Environment { .. }) => {
+            AnyClient::OpenAI(OpenAIClient::openai_compatible(
+                route
+                    .base_url
+                    .expect("OpenAI-compatible routes always define a base URL"),
+                key_policy,
+            )?)
+        }
+        #[cfg(not(feature = "openai"))]
+        KeyPolicy::Keyless | KeyPolicy::Environment { .. } => {
+            unreachable!("disabled OpenAI-compatible routes fail during parsing")
+        }
     };
 
     Ok(configure_client(client, route.model, route.base_url))
@@ -174,6 +274,8 @@ fn configure_client(client: AnyClient, model: Option<&str>, base_url: Option<&st
 #[cfg(test)]
 mod tests {
     use super::parse_client_spec;
+    #[cfg(feature = "openai")]
+    use super::{KeyPolicy, parse_route};
     #[cfg(any(
         feature = "openai",
         feature = "anthropic",
@@ -197,6 +299,76 @@ mod tests {
             parse_client_spec("openai/vendor/model/version").unwrap(),
             (Provider::OpenAI, Some("vendor/model/version"))
         );
+    }
+
+    #[cfg(feature = "openai")]
+    #[test]
+    fn parses_openai_compatible_prefixes_and_preserves_model_slashes() {
+        for (spec, expected_model) in [
+            ("ollama/llama3.3", "llama3.3"),
+            ("lm_studio/local-model", "local-model"),
+            ("openrouter/moonshotai/kimi-k3", "moonshotai/kimi-k3"),
+            ("groq/openai/gpt-oss-120b", "openai/gpt-oss-120b"),
+            ("moonshot/kimi-k3", "kimi-k3"),
+        ] {
+            assert_eq!(
+                parse_client_spec(spec).unwrap(),
+                (Provider::OpenAI, Some(expected_model)),
+                "{spec}"
+            );
+        }
+
+        assert_eq!(
+            parse_client_spec("OlLaMa").unwrap(),
+            (Provider::OpenAI, None)
+        );
+        assert_eq!(
+            parse_client_spec("LM_STUDIO/model").unwrap(),
+            (Provider::OpenAI, Some("model"))
+        );
+    }
+
+    #[cfg(feature = "openai")]
+    #[test]
+    fn compatible_routes_carry_base_url_and_key_policy_metadata() {
+        let cases = [
+            ("ollama/model", super::OLLAMA_BASE_URL, None),
+            ("lm_studio/model", super::LM_STUDIO_BASE_URL, None),
+            (
+                "openrouter/model",
+                super::OPENROUTER_BASE_URL,
+                Some(("OpenRouter", "OPENROUTER_API_KEY")),
+            ),
+            (
+                "groq/model",
+                super::GROQ_BASE_URL,
+                Some(("Groq", "GROQ_API_KEY")),
+            ),
+            (
+                "moonshot/model",
+                super::MOONSHOT_BASE_URL,
+                Some(("Moonshot", "MOONSHOT_API_KEY")),
+            ),
+        ];
+
+        for (spec, expected_base_url, expected_env) in cases {
+            let route = parse_route(spec).unwrap();
+            assert_eq!(route.provider, Provider::OpenAI, "{spec}");
+            assert_eq!(route.base_url, Some(expected_base_url), "{spec}");
+            match (route.key_policy, expected_env) {
+                (KeyPolicy::Keyless, None) => {}
+                (
+                    KeyPolicy::Environment { provider, variable },
+                    Some((expected_provider, expected_variable)),
+                ) => {
+                    assert_eq!(provider, expected_provider, "{spec}");
+                    assert_eq!(variable, expected_variable, "{spec}");
+                }
+                (actual, expected) => {
+                    panic!("unexpected key policy for {spec}: {actual:?}, expected {expected:?}")
+                }
+            }
+        }
     }
 
     #[cfg(feature = "grok")]
@@ -240,7 +412,18 @@ mod tests {
     fn unknown_provider_error_lists_every_valid_name() {
         let error = parse_client_spec("mystery/model").unwrap_err().to_string();
         assert!(error.contains("unknown provider `mystery`"));
-        for valid_name in ["openai", "anthropic", "gemini", "grok", "xai"] {
+        for valid_name in [
+            "openai",
+            "anthropic",
+            "gemini",
+            "grok",
+            "xai",
+            "ollama",
+            "lm_studio",
+            "openrouter",
+            "groq",
+            "moonshot",
+        ] {
             assert!(
                 error.contains(valid_name),
                 "error should list `{valid_name}`: {error}"
@@ -256,5 +439,20 @@ mod tests {
             .to_string();
         assert!(error.contains("provider `anthropic` is disabled"));
         assert!(error.contains("`anthropic` Cargo feature"));
+    }
+
+    #[cfg(not(feature = "openai"))]
+    #[test]
+    fn disabled_compatible_provider_error_names_the_openai_feature() {
+        for provider in ["ollama", "lm_studio", "openrouter", "groq", "moonshot"] {
+            let error = parse_client_spec(&format!("{provider}/model"))
+                .unwrap_err()
+                .to_string();
+            assert!(
+                error.contains(&format!("provider `{provider}` is disabled")),
+                "{error}"
+            );
+            assert!(error.contains("`openai` Cargo feature"), "{error}");
+        }
     }
 }

--- a/src/backend/tools.rs
+++ b/src/backend/tools.rs
@@ -330,9 +330,13 @@ pub(crate) async fn run_openai_compatible_tools(
             body["reasoning_effort"] = json!(effort);
         }
 
-        let response = client
-            .post(url)
-            .header("Authorization", format!("Bearer {api_key}"))
+        let request = client.post(url);
+        let request = if api_key.is_empty() {
+            request
+        } else {
+            request.bearer_auth(api_key)
+        };
+        let response = request
             .header("Content-Type", "application/json")
             .json(&body)
             .send()

--- a/tests/http_mock_tests.rs
+++ b/tests/http_mock_tests.rs
@@ -28,6 +28,36 @@ impl OpenAiEnvGuard {
     }
 }
 
+struct EnvVarGuard {
+    key: &'static str,
+    saved: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let saved = std::env::var_os(key);
+        // SAFETY: each compatible-provider key is mutated by only one test in
+        // this integration-test binary and restored by this guard.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, saved }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: restores the key after the only test in this binary that
+        // mutates it.
+        unsafe {
+            match self.saved.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
 impl Drop for OpenAiEnvGuard {
     fn drop(&mut self) {
         // SAFETY: restores the key after the only test in this binary that
@@ -165,6 +195,98 @@ async fn routed_client_sends_the_full_custom_model_string() {
         .unwrap();
 
     assert_eq!(movie.title, "Provider Routing");
+    request.assert_async().await;
+}
+
+#[tokio::test]
+async fn ollama_client_sends_to_the_compatible_path_without_authorization() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "model": "llama3.3",
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(chat_completion(
+            r#"{"title":"Local Inference","year":2026}"#,
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let movie: Movie = OpenAIClient::ollama()
+        .unwrap()
+        .base_url(server.url())
+        .model("llama3.3")
+        .no_retries()
+        .materialize("Describe local inference")
+        .await
+        .unwrap();
+
+    assert_eq!(movie.title, "Local Inference");
+    request.assert_async().await;
+}
+
+#[tokio::test]
+async fn lm_studio_client_sends_to_the_compatible_path_without_authorization() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "model": "lmstudio-community/local-model",
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(chat_completion(r#"{"title":"Local Studio","year":2026}"#))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let movie: Movie = OpenAIClient::lm_studio()
+        .unwrap()
+        .base_url(server.url())
+        .model("lmstudio-community/local-model")
+        .no_retries()
+        .materialize("Describe local inference")
+        .await
+        .unwrap();
+
+    assert_eq!(movie.title, "Local Studio");
+    request.assert_async().await;
+}
+
+#[tokio::test]
+async fn aggregator_client_sends_its_environment_key_as_bearer_auth() {
+    let _env = EnvVarGuard::set("OPENROUTER_API_KEY", "openrouter-test-key");
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", "Bearer openrouter-test-key")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "model": "moonshotai/kimi-k3",
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(chat_completion(
+            r#"{"title":"Aggregated Inference","year":2026}"#,
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let movie: Movie = OpenAIClient::openrouter()
+        .unwrap()
+        .base_url(server.url())
+        .model("moonshotai/kimi-k3")
+        .no_retries()
+        .materialize("Describe aggregated inference")
+        .await
+        .unwrap();
+
+    assert_eq!(movie.title, "Aggregated Inference");
     request.assert_async().await;
 }
 
@@ -1326,6 +1448,35 @@ async fn gpt56_tool_request_disables_reasoning() {
     let body = body.as_ref().expect("request body should be captured");
     assert_eq!(body["reasoning_effort"], json!("none"));
     assert_eq!(body["temperature"], json!(1.0));
+}
+
+#[cfg(feature = "tools")]
+#[tokio::test]
+async fn ollama_tool_request_sends_no_authorization_header() {
+    use rstructor::{RequestExt, Toolbox};
+
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/chat/completions")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(200)
+        .with_body(chat_completion("local tools are ready"))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let toolbox = Toolbox::new();
+    let answer = OpenAIClient::ollama()
+        .unwrap()
+        .base_url(server.url())
+        .model("llama3.3")
+        .with_tools(&toolbox)
+        .run("say hello")
+        .await
+        .unwrap();
+
+    assert_eq!(answer, "local tools are ready");
+    request.assert_async().await;
 }
 
 /// Full OpenAI tool round-trip: the first response asks for a tool call, the loop

--- a/tests/openai_compatible_env_tests.rs
+++ b/tests/openai_compatible_env_tests.rs
@@ -1,0 +1,114 @@
+#![cfg(feature = "openai")]
+//! Environment-variable contracts for named OpenAI-compatible constructors.
+//!
+//! Environment variables are process-global, so all mutations live in this one
+//! test and are restored on drop, including non-Unicode values.
+
+use rstructor::{AnyClient, ApiErrorKind, OpenAIClient};
+
+const ENV_KEYS: [&str; 3] = ["OPENROUTER_API_KEY", "GROQ_API_KEY", "MOONSHOT_API_KEY"];
+
+struct EnvGuard {
+    saved: Vec<(&'static str, Option<std::ffi::OsString>)>,
+}
+
+impl EnvGuard {
+    fn capture() -> Self {
+        Self {
+            saved: ENV_KEYS
+                .iter()
+                .map(|&key| (key, std::env::var_os(key)))
+                .collect(),
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in &self.saved {
+            // SAFETY: this is the only test in this binary and restores every
+            // environment variable it mutates.
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+}
+
+fn set_only(key: Option<&str>, value: &str) {
+    for env_key in ENV_KEYS {
+        // SAFETY: environment mutation is confined to the single test below.
+        unsafe {
+            if Some(env_key) == key {
+                std::env::set_var(env_key, value);
+            } else {
+                std::env::remove_var(env_key);
+            }
+        }
+    }
+}
+
+fn assert_authentication_failed(result: rstructor::Result<OpenAIClient>, context: &str) {
+    let error = match result {
+        Ok(_) => panic!("{context} should fail without its API key"),
+        Err(error) => error,
+    };
+    assert!(
+        matches!(
+            error.api_error_kind(),
+            Some(ApiErrorKind::AuthenticationFailed)
+        ),
+        "{context}: {error:?}"
+    );
+}
+
+#[test]
+fn compatible_constructor_environment_contracts() {
+    let _guard = EnvGuard::capture();
+
+    set_only(None, "");
+    OpenAIClient::ollama().expect("Ollama must not require an API key");
+    OpenAIClient::lm_studio().expect("LM Studio must not require an API key");
+    assert!(matches!(
+        rstructor::client("ollama/llama3.3").unwrap(),
+        AnyClient::OpenAI(_)
+    ));
+    assert!(matches!(
+        rstructor::client("lm_studio/local-model").unwrap(),
+        AnyClient::OpenAI(_)
+    ));
+    assert_authentication_failed(OpenAIClient::openrouter(), "OpenRouter");
+    assert_authentication_failed(OpenAIClient::groq(), "Groq");
+    assert_authentication_failed(OpenAIClient::moonshot(), "Moonshot");
+
+    for (variable, constructor) in [
+        (
+            "OPENROUTER_API_KEY",
+            OpenAIClient::openrouter as fn() -> rstructor::Result<OpenAIClient>,
+        ),
+        ("GROQ_API_KEY", OpenAIClient::groq),
+        ("MOONSHOT_API_KEY", OpenAIClient::moonshot),
+    ] {
+        set_only(Some(variable), &format!("{variable}-value"));
+        constructor().unwrap_or_else(|error| {
+            panic!("{variable} should construct its compatible client: {error}")
+        });
+
+        let route = match variable {
+            "OPENROUTER_API_KEY" => "openrouter/vendor/model",
+            "GROQ_API_KEY" => "groq/openai/gpt-oss-120b",
+            "MOONSHOT_API_KEY" => "moonshot/kimi-k3",
+            _ => unreachable!(),
+        };
+        assert!(
+            matches!(rstructor::client(route).unwrap(), AnyClient::OpenAI(_)),
+            "{route} should use {variable}"
+        );
+
+        set_only(Some(variable), "");
+        assert_authentication_failed(constructor(), variable);
+    }
+}


### PR DESCRIPTION
## Summary

This makes the existing OpenAI-compatible transport discoverable and safe for
local inference and hosted aggregators.

- adds `OpenAIClient::ollama()`, `lm_studio()`, `openrouter()`, `groq()`, and
  `moonshot()` through one internal `openai_compatible(base_url, key_policy)`
  constructor
- makes Ollama and LM Studio genuinely keyless by omitting the
  `Authorization` header across materialization, generation, streaming, model
  listing, and tool calls
- reads `OPENROUTER_API_KEY`, `GROQ_API_KEY`, and `MOONSHOT_API_KEY` for hosted
  compatible endpoints
- extends provider-string routing while preserving embedded slashes in model
  IDs
- adds an opt-in Ollama example and a README guide covering local and hosted
  compatible endpoints

## Why

`OpenAIClient::base_url()` could already target compatible servers, but callers
had to know each endpoint, invent API-key behavior, and manually configure the
client. That was especially awkward for local servers: `OpenAIClient::new`
rejects empty keys and every OpenAI request unconditionally sent a bearer
header.

The new constructors make endpoint and authentication policy one tested unit.
They are additive; existing OpenAI/provider defaults are unchanged.

## Usage

Local Ollama needs no key:

```rust
use rstructor::{LLMClient, OpenAIClient};

let client = OpenAIClient::ollama()?.model("llama3.3");
let movie: Movie = client.materialize("Describe Inception").await?;
```

The provider-string form configures the same endpoint:

```rust
let client = rstructor::client("ollama/llama3.3")?;
let movie: Movie = client.materialize("Describe Inception").await?;
```

Aggregator model slugs keep embedded `/` characters:

```rust
// Reads OPENROUTER_API_KEY.
let router = rstructor::client("openrouter/moonshotai/kimi-k3")?;

// Read GROQ_API_KEY and MOONSHOT_API_KEY, respectively.
let groq = rstructor::client("groq/openai/gpt-oss-120b")?;
let moonshot = rstructor::client("moonshot/kimi-k3")?;
```

LM Studio is also keyless:

```rust
let client = OpenAIClient::lm_studio()?.model("your-loaded-model");
```

Strict `response_format` / JSON Schema support still varies by compatible
server. This change deliberately keeps the existing schema request and
validation/re-ask retry behavior without adding endpoint-specific dialect
rewrites.

## Verified endpoints

The endpoint and auth policies were checked against official documentation:

- Ollama: `http://localhost:11434/v1`; local requests require no authentication
  - https://docs.ollama.com/api/openai-compatibility
  - https://docs.ollama.com/api/authentication
- LM Studio: `http://localhost:1234/v1`; authentication is disabled by default
  - https://lmstudio.ai/docs/developer/rest/quickstart
- OpenRouter: `https://openrouter.ai/api/v1`; bearer `OPENROUTER_API_KEY`
  - https://openrouter.ai/docs/quickstart
- Groq: `https://api.groq.com/openai/v1`; bearer `GROQ_API_KEY`
  - https://console.groq.com/docs/openai
- Moonshot/Kimi international: `https://api.moonshot.ai/v1`; bearer
  `MOONSHOT_API_KEY`
  - https://platform.kimi.ai/docs/api/overview

## Tests

New coverage includes:

- route parsing for all five prefixes, case insensitivity, feature gating, and
  embedded model-path slashes
- exact route base URL and key-policy metadata
- missing, empty, and present environment-key behavior for all hosted endpoints
- mocked Ollama and LM Studio requests proving no authorization header is sent
- a mocked OpenRouter request proving its environment key is sent as bearer auth
- a mocked Ollama tool request proving the tool loop remains keyless
- runnable rustdocs and an example that exits cleanly when `OLLAMA_MODEL` is not
  configured

Validation run:

```text
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all-features --no-fail-fast
cargo build --all-features --examples
cargo build --no-default-features --features derive
cargo build --no-default-features --features "derive,mock"
cargo test --no-default-features --features anthropic --lib routing::tests
git diff --check
```
