### PR TITLE
[codex] Add schemars schema bridge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ tracing-subscriber = { version = "0.3.23", features = [
 ], optional = true }
 tracing-futures = { version = "0.2.5", optional = true }
 rstructor_derive = { version = "0.4.0", path = "./rstructor_derive", optional = true }
+schemars = { version = "1.0", optional = true }
 base64 = { version = "0.22.1", optional = true }
 futures-util = { version = "0.3.31", default-features = false, optional = true }
 async-stream = { version = "0.3.6", optional = true }
@@ -73,6 +74,8 @@ anthropic = ["_client"]
 grok = ["_client"]
 gemini = ["_client"]
 derive = ["rstructor_derive"]
+# Opt-in adapter for types that already derive `schemars::JsonSchema`.
+schemars = ["dep:schemars"]
 logging = ["tracing-subscriber", "tracing-futures"]
 # Internal: the HTTP client + media stack shared by every networked provider.
 # Not meant to be enabled directly — enable a provider feature instead. Disabling

--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ let client = OpenAIClient::from_env()?.temperature(0.0);
 let ticket: Ticket = client.materialize(text).await?;
 ```
 
+### Already using schemars?
+
+Enable rstructor's `schemars` feature and wrap your existing
+`JsonSchema + Serialize + Deserialize` model; no `Instructor` derive is needed:
+
+```rust
+let ticket = client
+    .materialize::<rstructor::Schemars<Ticket>>(text)
+    .await?
+    .into_inner();
+```
+
+Nested schemas and doc-comment descriptions are inlined automatically.
+Recursive schemars models are rejected before a provider request because v1 of
+the bridge intentionally sends only reference-free schemas.
+
 ## Request Builder
 
 `materialize`, `generate`, and (with the `tools` feature) tool `run` are also

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -297,7 +297,7 @@ impl AnthropicClient {
         info!("Generating structured response with Anthropic (native structured outputs)");
 
         // Get the schema for type T
-        let schema = T::schema();
+        let schema = T::try_schema().map_err(MaterializeAttemptError::preflight)?;
         trace!("Retrieved JSON schema for type");
 
         // Reject dynamic maps before Anthropic's strict object transform can
@@ -942,8 +942,12 @@ impl LLMClient for AnthropicClient {
         T: Instructor + DeserializeOwned + Send + 'static,
         Self: Sync,
     {
+        let schema = match T::try_schema() {
+            Ok(schema) => schema,
+            Err(error) => return crate::backend::streaming::error_stream(error),
+        };
         let schema_json = match compile_strict_schema(
-            &T::schema(),
+            &schema,
             StrictSchemaProvider::Anthropic,
             "streamed structured output",
         ) {
@@ -971,8 +975,12 @@ impl LLMClient for AnthropicClient {
         T: Instructor + DeserializeOwned + Send + 'static,
         Self: Sync,
     {
+        let schema = match T::try_schema() {
+            Ok(schema) => schema,
+            Err(error) => return crate::backend::streaming::error_stream(error),
+        };
         let item_schema = match compile_strict_schema(
-            &T::schema(),
+            &schema,
             StrictSchemaProvider::Anthropic,
             "streamed item",
         ) {

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -363,7 +363,7 @@ impl GeminiClient {
     {
         info!("Generating structured response with Gemini");
 
-        let schema = T::schema();
+        let schema = T::try_schema().map_err(MaterializeAttemptError::preflight)?;
         let schema_name = T::schema_name().unwrap_or_else(|| "output".to_string());
         trace!(schema_name = schema_name, "Retrieved JSON schema for type");
 
@@ -996,7 +996,10 @@ impl LLMClient for GeminiClient {
         T: Instructor + DeserializeOwned + Send + 'static,
         Self: Sync,
     {
-        let schema = T::schema();
+        let schema = match T::try_schema() {
+            Ok(schema) => schema,
+            Err(error) => return crate::backend::streaming::error_stream(error),
+        };
         // Gemini may return internally-tagged enums; capture the mapping so the
         // final buffer can be transformed back before deserializing into `T`.
         let adjacently_tagged_info =
@@ -1036,7 +1039,10 @@ impl LLMClient for GeminiClient {
         T: Instructor + DeserializeOwned + Send + 'static,
         Self: Sync,
     {
-        let schema = T::schema();
+        let schema = match T::try_schema() {
+            Ok(schema) => schema,
+            Err(error) => return crate::backend::streaming::error_stream(error),
+        };
         let adjacently_tagged_info =
             crate::backend::utils::extract_adjacently_tagged_info(&schema.to_json());
         let item_schema =

--- a/src/backend/grok.rs
+++ b/src/backend/grok.rs
@@ -193,7 +193,7 @@ impl GrokClient {
         info!("Generating structured response with Grok (native structured outputs)");
 
         // Get the schema for type T
-        let schema = T::schema();
+        let schema = T::try_schema().map_err(MaterializeAttemptError::preflight)?;
         let schema_name = T::schema_name().unwrap_or_else(|| "output".to_string());
         trace!(schema_name = schema_name, "Retrieved JSON schema for type");
 
@@ -715,7 +715,10 @@ impl LLMClient for GrokClient {
         T: Instructor + DeserializeOwned + Send + 'static,
         Self: Sync,
     {
-        let schema = T::schema();
+        let schema = match T::try_schema() {
+            Ok(schema) => schema,
+            Err(error) => return crate::backend::streaming::error_stream(error),
+        };
         let schema_name = T::schema_name().unwrap_or_else(|| "output".to_string());
         let schema_json = match compile_strict_schema(
             &schema,
@@ -743,14 +746,15 @@ impl LLMClient for GrokClient {
         T: Instructor + DeserializeOwned + Send + 'static,
         Self: Sync,
     {
-        let item_schema = match compile_strict_schema(
-            &T::schema(),
-            StrictSchemaProvider::Grok,
-            "streamed item",
-        ) {
+        let schema = match T::try_schema() {
             Ok(schema) => schema,
             Err(error) => return crate::backend::streaming::error_stream(error),
         };
+        let item_schema =
+            match compile_strict_schema(&schema, StrictSchemaProvider::Grok, "streamed item") {
+                Ok(schema) => schema,
+                Err(error) => return crate::backend::streaming::error_stream(error),
+            };
         let wrapper = crate::backend::streaming::array_wrapper_schema(item_schema, true);
         let response_format = ResponseFormat::json_schema("items".to_string(), wrapper, None);
         let body = self.stream_body(prompt, Some(response_format));

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -734,7 +734,7 @@ impl LLMClient for MockClient {
     where
         T: Instructor + DeserializeOwned + Send + 'static,
     {
-        let schema = <T as SchemaType>::schema().to_json();
+        let schema = <T as SchemaType>::try_schema()?.to_json();
         let schema_name = <T as SchemaType>::schema_name();
         let mut view = MockRequestView::bare(RequestKind::Materialize, prompt);
         view.schema = Some(&schema);
@@ -747,7 +747,7 @@ impl LLMClient for MockClient {
     where
         T: Instructor + DeserializeOwned + Send + 'static,
     {
-        let schema = <T as SchemaType>::schema().to_json();
+        let schema = <T as SchemaType>::try_schema()?.to_json();
         let schema_name = <T as SchemaType>::schema_name();
         let mut view = MockRequestView::bare(RequestKind::MaterializeWithMedia, prompt);
         view.schema = Some(&schema);
@@ -761,7 +761,7 @@ impl LLMClient for MockClient {
     where
         T: Instructor + DeserializeOwned + Send + 'static,
     {
-        let schema = <T as SchemaType>::schema().to_json();
+        let schema = <T as SchemaType>::try_schema()?.to_json();
         let schema_name = <T as SchemaType>::schema_name();
         let mut view = MockRequestView::bare(RequestKind::MaterializeWithMetadata, prompt);
         view.schema = Some(&schema);
@@ -779,7 +779,9 @@ impl LLMClient for MockClient {
     where
         T: Instructor + DeserializeOwned + Send + 'static,
     {
-        let schema = <T as SchemaType>::schema().to_json();
+        let schema = <T as SchemaType>::try_schema()
+            .map_err(MaterializeFailure::from_error)?
+            .to_json();
         let schema_name = <T as SchemaType>::schema_name();
         let mut view = MockRequestView::bare(RequestKind::MaterializeWithAttempts, prompt);
         view.schema = Some(&schema);
@@ -796,7 +798,9 @@ impl LLMClient for MockClient {
     where
         T: Instructor + DeserializeOwned + Send + 'static,
     {
-        let schema = <T as SchemaType>::schema().to_json();
+        let schema = <T as SchemaType>::try_schema()
+            .map_err(MaterializeFailure::from_error)?
+            .to_json();
         let schema_name = <T as SchemaType>::schema_name();
         let mut view = MockRequestView::bare(RequestKind::MaterializeWithMediaAndAttempts, prompt);
         view.schema = Some(&schema);
@@ -863,7 +867,10 @@ impl LLMClient for MockClient {
         Self: Sync,
     {
         use crate::backend::streaming::StreamedObject;
-        let schema = <T as SchemaType>::schema().to_json();
+        let schema = match <T as SchemaType>::try_schema() {
+            Ok(schema) => schema.to_json(),
+            Err(error) => return crate::backend::streaming::error_stream(error),
+        };
         let schema_name = <T as SchemaType>::schema_name();
         let mut view = MockRequestView::bare(RequestKind::MaterializeStream, prompt);
         view.schema = Some(&schema);
@@ -892,7 +899,10 @@ impl LLMClient for MockClient {
         T: Instructor + DeserializeOwned + Send + 'static,
         Self: Sync,
     {
-        let schema = <T as SchemaType>::schema().to_json();
+        let schema = match <T as SchemaType>::try_schema() {
+            Ok(schema) => schema.to_json(),
+            Err(error) => return crate::backend::streaming::error_stream(error),
+        };
         let schema_name = <T as SchemaType>::schema_name();
         let mut view = MockRequestView::bare(RequestKind::MaterializeIter, prompt);
         view.schema = Some(&schema);

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -98,6 +98,8 @@ pub(crate) use openai_compatible::{
 };
 #[cfg(feature = "_client")]
 pub(crate) use schema_compatibility::{StrictSchemaProvider, compile_strict_schema};
+#[cfg(all(test, feature = "schemars"))]
+pub(crate) use utils::prepare_gemini_schema;
 #[cfg(feature = "_client")]
 pub use utils::{DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT};
 #[cfg(feature = "_client")]

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -450,7 +450,7 @@ impl OpenAIClient {
         info!("Generating structured response with OpenAI (native structured outputs)");
 
         // Get the schema for type T
-        let schema = T::schema();
+        let schema = T::try_schema().map_err(MaterializeAttemptError::preflight)?;
         let schema_name = T::schema_name().unwrap_or_else(|| "output".to_string());
         // Avoid calling to_string() in trace to prevent potential stack overflow with complex schemas
         trace!(schema_name = schema_name, "Retrieved JSON schema for type");
@@ -1005,7 +1005,10 @@ impl LLMClient for OpenAIClient {
         T: Instructor + DeserializeOwned + Send + 'static,
         Self: Sync,
     {
-        let schema = T::schema();
+        let schema = match T::try_schema() {
+            Ok(schema) => schema,
+            Err(error) => return crate::backend::streaming::error_stream(error),
+        };
         let schema_name = T::schema_name().unwrap_or_else(|| "output".to_string());
         let schema_json = match compile_strict_schema(
             &schema,
@@ -1037,14 +1040,15 @@ impl LLMClient for OpenAIClient {
         T: Instructor + DeserializeOwned + Send + 'static,
         Self: Sync,
     {
-        let item_schema = match compile_strict_schema(
-            &T::schema(),
-            StrictSchemaProvider::OpenAI,
-            "streamed item",
-        ) {
+        let schema = match T::try_schema() {
             Ok(schema) => schema,
             Err(error) => return crate::backend::streaming::error_stream(error),
         };
+        let item_schema =
+            match compile_strict_schema(&schema, StrictSchemaProvider::OpenAI, "streamed item") {
+                Ok(schema) => schema,
+                Err(error) => return crate::backend::streaming::error_stream(error),
+            };
         let wrapper = crate::backend::streaming::array_wrapper_schema(item_schema, true);
         let response_format = ResponseFormat::json_schema(
             "items".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,11 +53,15 @@ pub mod error;
 pub mod logging;
 pub mod model;
 pub mod schema;
+#[cfg(feature = "schemars")]
+mod schemars_bridge;
 
 // Re-exports for convenience
 pub use error::{ApiErrorKind, RStructorError, Result, StreamErrorKind};
 pub use model::Instructor;
 pub use schema::{CustomTypeSchema, Schema, SchemaBuilder, SchemaType};
+#[cfg(feature = "schemars")]
+pub use schemars_bridge::Schemars;
 
 #[cfg(feature = "openai")]
 pub use backend::openai::{Model as OpenAIModel, OpenAIClient};

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -205,6 +205,15 @@ pub trait SchemaType {
     /// Generate a JSON Schema representation of this type
     fn schema() -> Schema;
 
+    /// Generate a JSON Schema representation, returning generation failures.
+    ///
+    /// Existing implementations may rely on the default infallible behavior.
+    /// Adapters whose schema generators can reject a type override this method
+    /// so clients can report the failure before sending a provider request.
+    fn try_schema() -> Result<Schema> {
+        Ok(Self::schema())
+    }
+
     /// Build this type's schema inside an existing derived-schema graph.
     ///
     /// This hook lets derive-generated implementations share recursion state

--- a/src/schemars_bridge.rs
+++ b/src/schemars_bridge.rs
@@ -1,0 +1,346 @@
+//! Bridge for model types that already derive [`schemars::JsonSchema`].
+//!
+//! Wrap an existing Serde + schemars type in [`Schemars`] to use it with
+//! [`LLMClient::materialize`](crate::LLMClient::materialize) without deriving
+//! rstructor's `Instructor` macro:
+//!
+//! ```no_run
+//! use rstructor::{LLMClient, Schemars};
+//! use schemars::JsonSchema;
+//! use serde::{Deserialize, Serialize};
+//!
+//! /// A quote observed on a public exchange.
+//! #[derive(Debug, JsonSchema, Serialize, Deserialize)]
+//! struct Quote {
+//!     /// Exchange ticker symbol.
+//!     symbol: String,
+//!     /// Best bid price in USD.
+//!     bid: f64,
+//! }
+//!
+//! async fn extract_quote<C: LLMClient + Sync>(
+//!     client: &C,
+//! ) -> rstructor::Result<Quote> {
+//!     let quote = client
+//!         .materialize::<Schemars<Quote>>("AAPL bid 211.42")
+//!         .await?;
+//!     Ok(quote.into_inner())
+//! }
+//! ```
+//!
+//! Schemas use the JSON Schema draft-07 deserialization contract and inline
+//! every acyclic nested schema. Recursive types remain unsupported because
+//! strict provider schemas cannot accept the remaining references; attempts to
+//! materialize one return a clear [`RStructorError::SchemaError`](crate::RStructorError::SchemaError)
+//! before a provider request is sent.
+
+use schemars::JsonSchema;
+use schemars::generate::SchemaSettings;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{Instructor, RStructorError, Result, Schema, SchemaType};
+
+/// Transparent adapter from a schemars model to rstructor's [`Instructor`].
+///
+/// `Schemars<T>` serializes and deserializes exactly like `T`; the wrapper only
+/// supplies schema generation and rstructor's default no-op validation.
+///
+/// # Example
+///
+/// ```
+/// use rstructor::Schemars;
+///
+/// let wrapped = Schemars(String::from("AAPL"));
+/// assert_eq!(wrapped.into_inner(), "AAPL");
+/// ```
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Schemars<T>(pub T);
+
+impl<T> Schemars<T> {
+    /// Remove the adapter and return the wrapped model.
+    #[must_use]
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> SchemaType for Schemars<T>
+where
+    T: JsonSchema + Serialize + DeserializeOwned,
+{
+    fn schema() -> Schema {
+        Self::try_schema().unwrap_or_else(|error| {
+            panic!("failed to generate an rstructor schema from schemars: {error}")
+        })
+    }
+
+    fn try_schema() -> Result<Schema> {
+        generate_schema::<T>()
+    }
+
+    fn schema_name() -> Option<String> {
+        Some(T::schema_name().into_owned())
+    }
+}
+
+impl<T> Instructor for Schemars<T> where T: JsonSchema + Serialize + DeserializeOwned {}
+
+fn generate_schema<T: JsonSchema>() -> Result<Schema> {
+    let settings = SchemaSettings::draft07().with(|settings| {
+        settings.inline_subschemas = true;
+        // The dialect is fixed by `draft07`; the declaration itself is
+        // metadata that strict provider transports do not need.
+        settings.meta_schema = None;
+    });
+    let generated = settings.into_generator().into_root_schema_for::<T>();
+    let mut schema = generated.to_value();
+
+    if let Some((path, reference)) = find_reference(&schema, "$") {
+        return Err(RStructorError::SchemaError(format!(
+            "cannot generate a reference-free schemars schema for recursive type `{}`: \
+             found `{reference}` at {path}; recursive types are not supported by \
+             `Schemars<T>`",
+            std::any::type_name::<T>()
+        )));
+    }
+
+    // Inlining leaves no consumers for definition tables. Remove an empty or
+    // otherwise unused table so neither spelling can reach provider APIs.
+    if let Some(object) = schema.as_object_mut() {
+        object.remove("$defs");
+        object.remove("definitions");
+    }
+
+    Ok(Schema::new(schema))
+}
+
+fn find_reference<'a>(schema: &'a Value, path: &str) -> Option<(String, &'a str)> {
+    let mut pending = vec![(schema, path.to_string())];
+
+    while let Some((value, path)) = pending.pop() {
+        match value {
+            Value::Object(object) => {
+                if let Some(reference) = object.get("$ref").and_then(Value::as_str) {
+                    return Some((format!("{path}.$ref"), reference));
+                }
+
+                pending.extend(
+                    object
+                        .iter()
+                        .map(|(key, value)| (value, format!("{path}.{}", json_path_key(key)))),
+                );
+            }
+            Value::Array(values) => {
+                pending.extend(
+                    values
+                        .iter()
+                        .enumerate()
+                        .map(|(index, value)| (value, format!("{path}[{index}]"))),
+                );
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn json_path_key(key: &str) -> String {
+    let mut characters = key.chars();
+    if matches!(
+        characters.next(),
+        Some(first) if first == '_' || first.is_ascii_alphabetic()
+    ) && characters.all(|character| character == '_' || character.is_ascii_alphanumeric())
+    {
+        key.to_string()
+    } else {
+        serde_json::to_string(key).expect("serializing a string cannot fail")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "_client")]
+    use std::collections::BTreeSet;
+
+    use schemars::JsonSchema;
+    use serde::{Deserialize, Serialize};
+    use serde_json::{Value, json};
+
+    use super::*;
+
+    /// A security listed on a public exchange.
+    #[derive(JsonSchema, Serialize, Deserialize)]
+    struct Instrument {
+        /// Exchange ticker symbol.
+        symbol: String,
+        /// ISO 10383 market identifier code, when known.
+        venue: Option<String>,
+    }
+
+    /// A real-time top-of-book market quote.
+    #[derive(JsonSchema, Serialize, Deserialize)]
+    struct Quote {
+        /// Instrument whose order book was observed.
+        instrument: Instrument,
+        /// Best displayed bid in USD.
+        bid: f64,
+        /// Best displayed offer in USD.
+        ask: f64,
+    }
+
+    fn canonical_quote_schema() -> Schema {
+        Schemars::<Quote>::try_schema().expect("acyclic schemars model")
+    }
+
+    fn assert_no_keyword(schema: &Value, keyword: &str) {
+        match schema {
+            Value::Object(object) => {
+                assert!(
+                    !object.contains_key(keyword),
+                    "unexpected `{keyword}` in {schema}"
+                );
+                for value in object.values() {
+                    assert_no_keyword(value, keyword);
+                }
+            }
+            Value::Array(values) => {
+                for value in values {
+                    assert_no_keyword(value, keyword);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    #[cfg(feature = "_client")]
+    fn assert_strict_objects(schema: &Value, provider: StrictSchemaProvider) {
+        match schema {
+            Value::Object(object) => {
+                if let Some(properties) = object.get("properties").and_then(Value::as_object) {
+                    assert_eq!(
+                        object.get("additionalProperties"),
+                        Some(&Value::Bool(false)),
+                        "{provider} must close every object: {schema}"
+                    );
+
+                    let property_names = properties.keys().cloned().collect::<BTreeSet<_>>();
+                    let required_names = object
+                        .get("required")
+                        .and_then(Value::as_array)
+                        .expect("strict object must have required fields")
+                        .iter()
+                        .map(|name| {
+                            name.as_str()
+                                .expect("required field names must be strings")
+                                .to_string()
+                        })
+                        .collect::<BTreeSet<_>>();
+                    assert_eq!(
+                        required_names, property_names,
+                        "{provider} must require every object property"
+                    );
+                }
+
+                for value in object.values() {
+                    assert_strict_objects(value, provider);
+                }
+            }
+            Value::Array(values) => {
+                for value in values {
+                    assert_strict_objects(value, provider);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    #[cfg(feature = "_client")]
+    fn assert_strict_provider_schema(provider: StrictSchemaProvider) {
+        let compiled =
+            compile_strict_schema(&canonical_quote_schema(), provider, "schemars test output")
+                .expect("quote schema is compatible with strict providers");
+        assert_strict_objects(&compiled, provider);
+        assert_no_keyword(&compiled, "$ref");
+        assert_no_keyword(&compiled, "$defs");
+        assert_no_keyword(&compiled, "definitions");
+
+        assert_eq!(
+            compiled["properties"]["instrument"]["properties"]["symbol"]["description"],
+            "Exchange ticker symbol.",
+            "{provider} must preserve schemars field descriptions"
+        );
+        assert_eq!(
+            compiled["properties"]["instrument"]["properties"]["venue"]["type"],
+            json!(["string", "null"]),
+            "{provider} must retain schemars optional-field semantics"
+        );
+    }
+
+    #[test]
+    fn draft07_schema_is_inline_and_preserves_doc_comments() {
+        let schema = canonical_quote_schema().to_json();
+
+        assert_eq!(Schemars::<Quote>::schema_name().as_deref(), Some("Quote"));
+        assert_no_keyword(&schema, "$schema");
+        assert_no_keyword(&schema, "$ref");
+        assert_no_keyword(&schema, "$defs");
+        assert_no_keyword(&schema, "definitions");
+        assert_eq!(
+            schema["description"],
+            "A real-time top-of-book market quote."
+        );
+        assert_eq!(
+            schema["properties"]["instrument"]["description"],
+            "Instrument whose order book was observed."
+        );
+        assert_eq!(
+            schema["properties"]["instrument"]["properties"]["symbol"]["description"],
+            "Exchange ticker symbol."
+        );
+        assert_eq!(schema["required"], json!(["instrument", "bid", "ask"]));
+    }
+
+    #[cfg(feature = "_client")]
+    use crate::backend::{StrictSchemaProvider, compile_strict_schema};
+
+    #[cfg(feature = "_client")]
+    #[test]
+    fn openai_normalization_produces_a_strict_schema() {
+        assert_strict_provider_schema(StrictSchemaProvider::OpenAI);
+    }
+
+    #[cfg(feature = "_client")]
+    #[test]
+    fn anthropic_normalization_produces_a_strict_schema() {
+        assert_strict_provider_schema(StrictSchemaProvider::Anthropic);
+    }
+
+    #[cfg(feature = "_client")]
+    #[test]
+    fn grok_normalization_produces_a_strict_schema() {
+        assert_strict_provider_schema(StrictSchemaProvider::Grok);
+    }
+
+    #[cfg(feature = "_client")]
+    #[test]
+    fn gemini_normalization_preserves_the_supported_schema_shape() {
+        let compiled = crate::backend::prepare_gemini_schema(
+            &canonical_quote_schema(),
+            "schemars test output",
+        )
+        .expect("quote schema is compatible with Gemini");
+
+        for keyword in ["$schema", "$ref", "$defs", "definitions", "title"] {
+            assert_no_keyword(&compiled, keyword);
+        }
+        assert_eq!(compiled["required"], json!(["instrument", "bid", "ask"]));
+        assert_eq!(
+            compiled["properties"]["instrument"]["properties"]["symbol"]["description"],
+            "Exchange ticker symbol."
+        );
+    }
+}

--- a/tests/schemars_bridge_tests.rs
+++ b/tests/schemars_bridge_tests.rs
@@ -1,0 +1,165 @@
+#![cfg(all(feature = "schemars", feature = "mock"))]
+
+use rstructor::{LLMClient, MockClient, RStructorError, Schemars};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+/// A position held by an institutional portfolio.
+#[derive(Debug, PartialEq, JsonSchema, Serialize, Deserialize)]
+struct Position {
+    /// Exchange ticker symbol.
+    symbol: String,
+    /// Signed number of shares held.
+    quantity: i64,
+}
+
+/// A security listed on a public exchange.
+#[derive(Debug, PartialEq, JsonSchema, Serialize, Deserialize)]
+struct Instrument {
+    /// Exchange ticker symbol.
+    symbol: String,
+    /// ISO 10383 market identifier code.
+    venue: String,
+}
+
+/// A top-of-book quote for a listed instrument.
+#[derive(Debug, PartialEq, JsonSchema, Serialize, Deserialize)]
+struct Quote {
+    /// Instrument whose order book was observed.
+    instrument: Instrument,
+    /// Best displayed bid in USD.
+    bid: f64,
+    /// Best displayed offer in USD.
+    ask: f64,
+}
+
+/// Current exchange trading state.
+#[derive(Debug, PartialEq, JsonSchema, Serialize, Deserialize)]
+enum MarketState {
+    Open,
+    Halted,
+    Closed,
+}
+
+#[test]
+fn wrapper_serializes_transparently() {
+    let wrapped = Schemars(Position {
+        symbol: "AAPL".to_string(),
+        quantity: 125_000,
+    });
+
+    assert_eq!(
+        serde_json::to_value(&wrapped).expect("serialize transparent wrapper"),
+        json!({"symbol": "AAPL", "quantity": 125_000})
+    );
+}
+
+#[tokio::test]
+async fn materializes_a_schemars_only_struct() {
+    let client = MockClient::new().with_response(r#"{"symbol":"AAPL","quantity":125000}"#);
+
+    let position = client
+        .materialize::<Schemars<Position>>("AAPL: long 125,000 shares")
+        .await
+        .expect("valid position fixture")
+        .into_inner();
+
+    assert_eq!(
+        position,
+        Position {
+            symbol: "AAPL".to_string(),
+            quantity: 125_000,
+        }
+    );
+    let request = client.last_request().expect("recorded materialization");
+    assert_eq!(request.schema_name.as_deref(), Some("Position"));
+    assert_eq!(
+        request.schema.as_ref().unwrap()["properties"]["quantity"]["type"],
+        "integer"
+    );
+}
+
+#[tokio::test]
+async fn materializes_a_schemars_only_nested_struct() {
+    let client = MockClient::new().with_response(
+        r#"{"instrument":{"symbol":"MSFT","venue":"XNAS"},"bid":512.31,"ask":512.34}"#,
+    );
+
+    let quote = client
+        .materialize::<Schemars<Quote>>("Microsoft on Nasdaq is 512.31 bid and offered at 512.34")
+        .await
+        .expect("valid quote fixture")
+        .into_inner();
+
+    assert_eq!(
+        quote,
+        Quote {
+            instrument: Instrument {
+                symbol: "MSFT".to_string(),
+                venue: "XNAS".to_string(),
+            },
+            bid: 512.31,
+            ask: 512.34,
+        }
+    );
+
+    let schema = client
+        .last_request()
+        .and_then(|request| request.schema)
+        .expect("recorded nested schema");
+    assert_eq!(
+        schema["properties"]["instrument"]["properties"]["venue"]["description"],
+        "ISO 10383 market identifier code."
+    );
+    assert!(!schema.to_string().contains("\"$ref\""));
+    assert!(schema.get("definitions").is_none());
+}
+
+#[tokio::test]
+async fn materializes_a_schemars_only_enum() {
+    let client = MockClient::new().with_response(r#""Halted""#);
+
+    let state = client
+        .materialize::<Schemars<MarketState>>("The exchange paused trading after a limit move")
+        .await
+        .expect("valid market-state fixture")
+        .into_inner();
+
+    assert_eq!(state, MarketState::Halted);
+    let schema = client
+        .last_request()
+        .and_then(|request| request.schema)
+        .expect("recorded enum schema");
+    assert_eq!(schema["enum"], json!(["Open", "Halted", "Closed"]));
+}
+
+#[derive(Debug, JsonSchema, Serialize, Deserialize)]
+struct RecursiveNode {
+    name: String,
+    children: Vec<RecursiveNode>,
+}
+
+#[tokio::test]
+async fn recursive_schemars_type_returns_a_clear_preflight_error() {
+    let client = MockClient::new().with_response(r#"{"name":"root","children":[]}"#);
+
+    let error = client
+        .materialize::<Schemars<RecursiveNode>>("Build a recursive tree")
+        .await
+        .expect_err("recursive schemars models must be rejected");
+
+    assert!(matches!(
+        error,
+        RStructorError::SchemaError(message)
+            if message.contains("reference-free schemars schema")
+                && message.contains("RecursiveNode")
+                && message.contains("$ref")
+                && message.contains("recursive types are not supported")
+    ));
+    assert_eq!(
+        client.request_count(),
+        0,
+        "schema errors must occur before the mock records a provider request"
+    );
+}


### PR DESCRIPTION
## Why

Existing Rust model layers often already derive `schemars::JsonSchema` for API documentation or other structured-output libraries. rstructor previously required those types to also derive its `Instructor` macro, duplicating annotations and making adoption unnecessarily invasive.

The root cause was that `LLMClient::materialize` only accepted `Instructor` types and the schema interface had no fallible generation hook. Schemars can inline acyclic schemas, but intentionally retains `$ref` for recursive cycles; without a preflight error path, the bridge would either panic or risk sending unsupported references to provider strict modes.

## What changed

- Adds an off-by-default `schemars` Cargo feature backed by the optional schemars 1.x dependency.
- Adds the transparent `Schemars<T>` adapter for any `T: JsonSchema + Serialize + DeserializeOwned`.
- Generates against the draft-07 deserialization contract with `inline_subschemas = true`, removes unused definition tables, and preserves doc-comment descriptions.
- Detects any remaining `$ref` with an iterative scan and returns a clear `SchemaError` for recursive models before a provider request is sent.
- Adds `SchemaType::try_schema()` with an infallible default, then uses it across regular, metadata, attempt-ledger, media, mock, and streaming materialization paths.
- Sends bridge-generated schemas through the existing OpenAI, Anthropic, Grok, and Gemini compatibility transforms exactly like derive-generated schemas.
- Documents the adapter in rustdoc and the README's new **Already using schemars?** section.

The feature remains disabled by default. Existing `SchemaType` implementations and derive-generated schemas keep their current behavior through the default `try_schema()` implementation.

## Usage

Enable the adapter alongside schemars:

```toml
[dependencies]
rstructor = { version = "0.4", features = ["schemars"] }
schemars = "1"
serde = { version = "1", features = ["derive"] }
```

Existing models need only schemars and Serde derives:

```rust
use schemars::JsonSchema;
use serde::{Deserialize, Serialize};

/// A real-time top-of-book quote.
#[derive(Debug, JsonSchema, Serialize, Deserialize)]
struct Quote {
    /// Exchange ticker symbol.
    symbol: String,
    /// Best displayed bid in USD.
    bid: f64,
}
```

Wrap the target at the materialization boundary and unwrap the result:

```rust
use rstructor::{LLMClient, Schemars};

let quote = client
    .materialize::<Schemars<Quote>>("AAPL bid 211.42")
    .await?
    .into_inner();
```

Recursive models fail locally with a diagnostic that names the type and the remaining `$ref`; no provider or mock request is recorded.

## Tests and validation

The new tests use realistic listed-security, position, and top-of-book quote fixtures and cover:

- end-to-end `MockClient` materialization for a struct, nested struct, and enum deriving only `JsonSchema` and Serde;
- transparent serialization and `into_inner`;
- inlined nested schemas with doc-comment descriptions;
- OpenAI, Anthropic, and Grok strict-mode closure/required-field normalization;
- Gemini keyword normalization and description preservation;
- a recursive-type preflight error with zero requests sent.

Validated locally with:

```text
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo build --no-default-features --features schemars
cargo build --no-default-features --features "schemars,mock"
cargo test --all-features --no-fail-fast
cargo build --all-features --examples
```

The existing CI test job already runs `--all-features`, so the new feature and its tests are included in the normal full matrix without a workflow change.
