### PR TITLE
[codex] Add task-oriented cookbook and example gallery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,25 +96,124 @@ mock = ["dep:serde_path_to_error"]
 
 [[example]]
 name = "streaming_example"
-required-features = ["streaming"]
+required-features = ["derive", "openai", "streaming"]
 
 [[example]]
 name = "tool_calling_example"
-required-features = ["tools", "openai"]
+required-features = ["derive", "openai", "tools"]
 
 [[example]]
 name = "mock_testing_example"
-required-features = ["mock"]
+required-features = ["derive", "mock"]
 
 [[example]]
 name = "retry_attempt_ledger"
-required-features = ["openai"]
+required-features = ["derive", "openai"]
 
 [[example]]
 name = "ollama_local_example"
-required-features = ["openai"]
+required-features = ["derive", "openai"]
+
+[[example]]
+name = "structured_movie_info"
+required-features = ["derive", "openai"]
+
+[[example]]
+name = "news_article_categorizer"
+required-features = ["derive", "grok"]
+
+[[example]]
+name = "openai_multimodal_example"
+required-features = ["derive", "openai"]
+
+[[example]]
+name = "anthropic_multimodal_example"
+required-features = ["anthropic", "derive"]
+
+[[example]]
+name = "gemini_multimodal_example"
+required-features = ["derive", "gemini"]
+
+[[example]]
+name = "grok_multimodal_example"
+required-features = ["derive", "grok"]
+
+[[example]]
+name = "validation_example"
+required-features = ["derive"]
+
+[[example]]
+name = "nested_objects_example"
+required-features = ["derive", "gemini"]
+
+[[example]]
+name = "recursive_schema_graph"
+required-features = ["derive"]
+
+[[example]]
+name = "axum_handler_example"
+required-features = ["derive", "mock"]
+
+[[example]]
+name = "runtime_provider_example"
+required-features = ["derive", "openai"]
+
+[[example]]
+name = "schemars_bridge_example"
+required-features = ["mock", "schemars"]
+
+[[example]]
+name = "container_attributes_example"
+required-features = ["derive"]
+
+[[example]]
+name = "custom_type_example"
+required-features = ["derive"]
+
+[[example]]
+name = "enum_example"
+required-features = ["derive"]
+
+[[example]]
+name = "enum_with_data_example"
+required-features = ["derive"]
+
+[[example]]
+name = "event_planner"
+required-features = ["anthropic", "derive"]
+
+[[example]]
+name = "logging_example"
+required-features = ["anthropic", "derive", "logging"]
+
+[[example]]
+name = "medical_example"
+required-features = ["derive"]
+
+[[example]]
+name = "movie_example"
+required-features = ["derive"]
+
+[[example]]
+name = "nested_enum_example"
+required-features = ["derive"]
+
+[[example]]
+name = "serde_rename_example"
+required-features = ["derive"]
+
+[[example]]
+name = "token_usage_example"
+required-features = ["derive", "openai"]
+
+[[example]]
+name = "weather_example"
+required-features = ["derive", "openai"]
 
 [dev-dependencies]
+# Builds and exercises the typed HTTP-handler cookbook recipe in-process. The
+# public dependency closure is unchanged.
+axum = { version = "0.8", default-features = false, features = ["json"] }
 # Used only by examples and tests (date/time fields, custom types); not part of
 # the public dependency closure.
 chrono = { version = "0.4.44", features = ["serde"] }
@@ -124,6 +223,8 @@ tokio = { version = "1.52.1", features = ["rt", "macros", "rt-multi-thread"] }
 # Local HTTP mock server for testing the real provider clients (request building,
 # response parsing, retry/re-ask loop) offline, with no API key. Dev-only.
 mockito = "1.7.0"
+# `ServiceExt::oneshot` drives the axum cookbook router without opening a port.
+tower = { version = "0.5", features = ["util"] }
 
 [workspace]
 members = ["rstructor_derive"]

--- a/README.md
+++ b/README.md
@@ -131,6 +131,28 @@ The terminals are `materialize::<T>(prompt)` (structured), `generate(prompt)`
 attached tools in a loop). Builders compose: `with_system`, `with_media`, and
 `with_tools` can be chained in any order before the terminal.
 
+## Recipes
+
+Start with the task you need, then open the linked runnable example. The
+[task-oriented cookbook](docs/COOKBOOK.md) expands the core workflows into
+complete copy-paste recipes.
+
+| I want to… | Example | What it shows |
+|---|---|---|
+| Extract typed data from free text | [`structured_movie_info.rs`](examples/structured_movie_info.rs) | Turns one sentence into a validated Rust struct with field descriptions and business rules. |
+| Classify into an enum | [`news_article_categorizer.rs`](examples/news_article_categorizer.rs) | Selects a typed category while extracting sentiment, entities, and keywords. |
+| Extract from an image or PDF | [`openai_multimodal_example.rs`](examples/openai_multimodal_example.rs) ([Anthropic](examples/anthropic_multimodal_example.rs), [Gemini](examples/gemini_multimodal_example.rs), [Grok](examples/grok_multimodal_example.rs)) | Sends inline media with a prompt and materializes the answer into a struct. |
+| Put extraction behind an axum handler | [`axum_handler_example.rs`](examples/axum_handler_example.rs) | Injects any `LLMClient` into typed JSON request and response handling, tested in-process. |
+| Test without network | [`mock_testing_example.rs`](examples/mock_testing_example.rs) | Scripts realistic responses through the real deserialization, validation, and re-ask path. |
+| Use a local model with Ollama | [`ollama_local_example.rs`](examples/ollama_local_example.rs) | Connects to the keyless local endpoint through the same structured-output API. |
+| Choose a provider at runtime | [`runtime_provider_example.rs`](examples/runtime_provider_example.rs) | Parses `provider/model` into one `AnyClient`, including aggregator model IDs with slashes. |
+| Reuse an existing schemars model | [`schemars_bridge_example.rs`](examples/schemars_bridge_example.rs) | Materializes `JsonSchema + Serde` types through the transparent `Schemars<T>` adapter. |
+| Call tools in a loop | [`tool_calling_example.rs`](examples/tool_calling_example.rs) | Runs schema-validated tool calls until the model produces its final answer. |
+| Stream partial output | [`streaming_example.rs`](examples/streaming_example.rs) | Yields validated list items incrementally and explains completion integrity. |
+| Add custom validation and re-ask | [`validation_example.rs`](examples/validation_example.rs) | Rejects domain-invalid output with a custom validator that providers can retry. |
+| Inspect retries and token cost | [`retry_attempt_ledger.rs`](examples/retry_attempt_ledger.rs) | Reports every attempt, disposition, per-response usage, and cumulative known usage. |
+| Model nested or recursive schemas | [`nested_objects_example.rs`](examples/nested_objects_example.rs), [`recursive_schema_graph.rs`](examples/recursive_schema_graph.rs) | Builds deeply nested values and finite `$defs` graphs for recursive domain types. |
+
 ## Providers
 
 ```rust

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -1,0 +1,477 @@
+# rstructor cookbook
+
+These recipes start from a task instead of a provider. Every snippet is a
+complete binary, and every section links to a runnable example that CI builds
+and executes. Unless a section says otherwise, use the default rstructor
+features plus:
+
+```toml
+[dependencies]
+rstructor = "0.4"
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+Provider examples read the API-key environment variable named in the recipe.
+Offline examples use `MockClient` and never touch the network.
+
+## Extract typed data from an image or PDF
+
+The runnable
+[OpenAI multimodal example](../examples/openai_multimodal_example.rs) uses an
+image; equivalent examples cover
+[Anthropic](../examples/anthropic_multimodal_example.rs),
+[Gemini](../examples/gemini_multimodal_example.rs), and
+[Grok](../examples/grok_multimodal_example.rs). `MediaFile::from_bytes` also
+accepts PDF bytes for OpenAI, Anthropic, and Gemini. Grok rejects PDFs during
+preflight because its documented media path is image-only.
+
+```rust
+use std::{env, fs, path::Path};
+
+use rstructor::{Instructor, LLMClient, MediaFile};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Instructor, Serialize)]
+struct DocumentFacts {
+    title: String,
+    summary: String,
+    organizations: Vec<String>,
+    total_usd: Option<f64>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let path = env::args()
+        .nth(1)
+        .ok_or("pass an image or PDF path as the first argument")?;
+    let mime_type = match Path::new(&path)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("pdf") => "application/pdf",
+        Some("jpg" | "jpeg") => "image/jpeg",
+        Some("png") => "image/png",
+        _ => return Err("supported extensions are pdf, jpg, jpeg, and png".into()),
+    };
+
+    let media = MediaFile::from_bytes(fs::read(path)?, mime_type);
+    let client = rstructor::client("openai/gpt-5.6-sol")?;
+    let facts: DocumentFacts = client
+        .materialize_with_media(
+            "Extract the document title, a concise summary, named organizations, \
+             and the total USD amount when present.",
+            &[media],
+        )
+        .await?;
+
+    println!("{facts:#?}");
+    Ok(())
+}
+```
+
+Run it with `OPENAI_API_KEY` set and pass a local file path:
+
+```text
+cargo run -- invoice.pdf
+```
+
+## Classify text into an enum
+
+The full [news categorizer](../examples/news_article_categorizer.rs) combines
+classification with entity and sentiment extraction. An enum in the target
+type constrains the provider to the variants your application handles.
+
+```rust
+use rstructor::{Instructor, LLMClient};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Instructor, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum MarketEvent {
+    Earnings,
+    Macro,
+    Merger,
+    Regulatory,
+    Other,
+}
+
+#[derive(Debug, Deserialize, Instructor, Serialize)]
+struct Classification {
+    event: MarketEvent,
+    confidence: f64,
+    rationale: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = rstructor::client("grok/grok-4.5")?;
+    let result: Classification = client
+        .materialize(
+            "The FTC requested additional information about the proposed \
+             acquisition before the statutory waiting period expires.",
+        )
+        .await?;
+
+    println!("{result:#?}");
+    Ok(())
+}
+```
+
+This route reads `XAI_API_KEY`; change only the `provider/model` string to use a
+different enabled provider.
+
+## Put typed extraction behind an axum handler
+
+The runnable [axum handler example](../examples/axum_handler_example.rs) uses a
+real `Router` and a deterministic in-process request. Add the `mock` feature for
+the self-contained demo; production can pass an `AnyClient` to the same generic
+`app` function.
+
+```toml
+[dependencies]
+axum = { version = "0.8", features = ["json"] }
+rstructor = { version = "0.4", features = ["mock"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt"] }
+tower = { version = "0.5", features = ["util"] }
+```
+
+```rust
+use std::sync::Arc;
+
+use axum::{
+    body::{Body, to_bytes},
+    extract::State,
+    http::{Method, Request, StatusCode, header},
+    routing::post,
+    Json, Router,
+};
+use rstructor::{Instructor, LLMClient, MockClient};
+use serde::{Deserialize, Serialize};
+use tower::ServiceExt;
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ExtractRequest {
+    text: String,
+}
+
+#[derive(Debug, Deserialize, Instructor, PartialEq, Serialize)]
+struct PositionBreak {
+    portfolio_id: String,
+    symbol: String,
+    expected_quantity: i64,
+    actual_quantity: i64,
+    as_of: String,
+}
+
+struct AppState<C> {
+    client: C,
+}
+
+async fn extract<C>(
+    State(state): State<Arc<AppState<C>>>,
+    Json(request): Json<ExtractRequest>,
+) -> Result<Json<PositionBreak>, (StatusCode, String)>
+where
+    C: LLMClient + Send + Sync + 'static,
+{
+    state
+        .client
+        .materialize(&request.text)
+        .await
+        .map(Json)
+        .map_err(|error| (StatusCode::UNPROCESSABLE_ENTITY, error.to_string()))
+}
+
+fn app<C>(client: C) -> Router
+where
+    C: LLMClient + Send + Sync + 'static,
+{
+    Router::new()
+        .route("/position-breaks/extract", post(extract::<C>))
+        .with_state(Arc::new(AppState { client }))
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = MockClient::new().with_response(
+        r#"{
+            "portfolio_id": "HF-ALPHA-001",
+            "symbol": "ESU6",
+            "expected_quantity": -240,
+            "actual_quantity": -238,
+            "as_of": "2026-07-29T14:31:00Z"
+        }"#,
+    );
+    let payload = ExtractRequest {
+        text: "HF-ALPHA-001 expected short 240 ESU6; clearing shows short 238."
+            .to_string(),
+    };
+
+    let response = app(client)
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/position-breaks/extract")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(serde_json::to_vec(&payload)?))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), 1024 * 1024).await?;
+    let position_break: PositionBreak = serde_json::from_slice(&body)?;
+    println!("{position_break:#?}");
+    Ok(())
+}
+```
+
+`State` comes before `Json` because body-consuming extractors must be last. The
+one-shot request validates the whole HTTP boundary without opening a port.
+
+## Test extraction offline with `MockClient`
+
+The [offline testing example](../examples/mock_testing_example.rs) covers the
+success, validation failure, recorded-request, and re-ask paths. Enable the
+off-by-default `mock` feature:
+
+```toml
+rstructor = { version = "0.4", features = ["mock"] }
+```
+
+```rust
+use rstructor::{Instructor, LLMClient, MockClient, RStructorError};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Instructor, PartialEq, Serialize)]
+#[llm(validate = "validate_fill")]
+struct Fill {
+    symbol: String,
+    quantity: u64,
+    price: f64,
+}
+
+fn validate_fill(fill: &Fill) -> rstructor::Result<()> {
+    if fill.quantity == 0 || fill.price <= 0.0 {
+        return Err(RStructorError::ValidationError(
+            "quantity and price must be positive".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+async fn parse_fill<C: LLMClient + Sync>(
+    client: &C,
+    message: &str,
+) -> rstructor::Result<Fill> {
+    client.materialize(message).await
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = MockClient::new()
+        .with_response(r#"{"symbol":"AAPL","quantity":0,"price":238.0}"#)
+        .with_response(r#"{"symbol":"AAPL","quantity":5000,"price":238.0}"#)
+        .with_retries(1);
+
+    let fill = parse_fill(&client, "Bought 5,000 AAPL at 238").await?;
+    assert_eq!(fill.quantity, 5_000);
+    assert_eq!(client.request_count(), 2);
+    assert_eq!(
+        client.last_request().and_then(|request| request.schema_name),
+        Some("Fill".to_string())
+    );
+    Ok(())
+}
+```
+
+Scripted payloads still pass through the production Serde and `Instructor`
+validation path; only the provider transport is replaced.
+
+## Use a local model through Ollama
+
+The [Ollama example](../examples/ollama_local_example.rs) is safe to run in CI:
+it only connects when `OLLAMA_MODEL` is set. The route is keyless and therefore
+does not send an `Authorization` header.
+
+```rust
+use rstructor::{Instructor, LLMClient};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Instructor, Serialize)]
+struct Summary {
+    summary: String,
+    topics: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = rstructor::client("ollama/llama3.3")?;
+    let summary: Summary = client
+        .materialize(
+            "Rust combines memory safety, zero-cost abstractions, and fearless concurrency.",
+        )
+        .await?;
+
+    println!("{summary:#?}");
+    Ok(())
+}
+```
+
+Start Ollama and ensure the model is present before running:
+
+```text
+ollama pull llama3.3
+cargo run
+```
+
+LM Studio uses the same pattern with `lm_studio/your-loaded-model`.
+
+## Choose a provider at runtime
+
+The runnable
+[runtime provider example](../examples/runtime_provider_example.rs) accepts a
+CLI argument or `RSTRUCTOR_CLIENT`. `rstructor::client` parses the first path
+segment as the route and preserves the rest as the provider-native model ID.
+
+```rust
+use rstructor::{Instructor, LLMClient};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Instructor, Serialize)]
+struct Position {
+    symbol: String,
+    quantity: i64,
+    market_value_usd: f64,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let spec = std::env::var("RSTRUCTOR_CLIENT")
+        .unwrap_or_else(|_| "ollama/llama3.3".to_string());
+    let client = rstructor::client(&spec)?;
+    let position: Position = client
+        .materialize("AAPL: long 125,000 shares, market value $29,750,000")
+        .await?;
+
+    println!("{position:#?}");
+    Ok(())
+}
+```
+
+Examples of valid values are `openai/gpt-5.6-sol`,
+`anthropic/claude-sonnet-5`, `ollama/llama3.3`, and
+`openrouter/moonshotai/kimi-k3`. Hosted routes read their provider-specific key;
+Ollama and LM Studio are keyless.
+
+## Reuse a schemars model
+
+The runnable [schemars bridge example](../examples/schemars_bridge_example.rs)
+proves that no `Instructor` derive is needed. Enable both `schemars` and `mock`
+for this offline version:
+
+```toml
+rstructor = { version = "0.4", features = ["mock", "schemars"] }
+schemars = "1"
+```
+
+```rust
+use rstructor::{LLMClient, MockClient, Schemars};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// A position reported by a prime broker.
+#[derive(Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
+struct Position {
+    /// Fund or account identifier.
+    portfolio_id: String,
+    /// Exchange ticker or contract symbol.
+    symbol: String,
+    /// Signed quantity: positive is long and negative is short.
+    quantity: i64,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = MockClient::new().with_response(
+        r#"{
+            "portfolio_id": "HF-ALPHA-001",
+            "symbol": "ESU6",
+            "quantity": -240
+        }"#,
+    );
+    let position = client
+        .materialize::<Schemars<Position>>("HF-ALPHA-001 is short 240 ESU6")
+        .await?
+        .into_inner();
+
+    assert_eq!(position.quantity, -240);
+    Ok(())
+}
+```
+
+Doc comments become schema descriptions, and acyclic nested schemas are
+inlined. Recursive schemars types return a schema error before any provider
+request because strict provider schemas must be reference-free.
+
+## Inspect cumulative retry cost
+
+The [attempt-ledger example](../examples/retry_attempt_ledger.rs) shows both
+success and terminal-failure reporting. `materialize_with_attempts` preserves
+every provider attempt and sums all usage the provider reported.
+
+```rust
+use rstructor::{AttemptOutcome, Instructor, LLMClient};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Instructor, Serialize)]
+struct Portfolio {
+    portfolio_id: String,
+    positions: Vec<Position>,
+}
+
+#[derive(Debug, Deserialize, Instructor, Serialize)]
+struct Position {
+    symbol: String,
+    quantity: i64,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = rstructor::client("openai/gpt-5.6-sol")?;
+    match client
+        .materialize_with_attempts::<Portfolio>(
+            "HF-ALPHA-001: short 240 ESU6 and long 125,000 AAPL",
+        )
+        .await
+    {
+        Ok(report) => {
+            for attempt in &report.attempts {
+                println!(
+                    "attempt {}: {:?}, {:?}, usage={:?}",
+                    attempt.number, attempt.kind, attempt.outcome, attempt.usage
+                );
+                if let AttemptOutcome::Failed { message, .. } = &attempt.outcome {
+                    eprintln!("provider failure: {message}");
+                }
+            }
+            println!("known cumulative usage: {:?}", report.cumulative_usage);
+            println!("portfolio: {:#?}", report.data);
+        }
+        Err(failure) => {
+            eprintln!("final error: {}", failure.error());
+            eprintln!("attempts: {:#?}", failure.attempts);
+            eprintln!("known cumulative usage: {:?}", failure.cumulative_usage);
+        }
+    }
+    Ok(())
+}
+```
+
+Usage is deliberately conservative: if a provider omits usage for one response,
+the attempt remains in the ledger while cumulative totals include only reported
+tokens. Local preflight failures have an empty ledger.

--- a/examples/axum_handler_example.rs
+++ b/examples/axum_handler_example.rs
@@ -1,0 +1,133 @@
+//! Put typed LLM extraction behind an axum JSON handler.
+//!
+//! The router is generic over `LLMClient`, so production can inject an
+//! `AnyClient` while this runnable example uses `MockClient` and makes one
+//! deterministic in-process request:
+//!
+//! ```text
+//! cargo run --example axum_handler_example --features mock
+//! ```
+
+use std::sync::Arc;
+
+use axum::body::{Body, to_bytes};
+use axum::extract::State;
+use axum::http::{Method, Request, StatusCode, header};
+use axum::routing::post;
+use axum::{Json, Router};
+use rstructor::{Instructor, LLMClient, MockClient};
+use serde::{Deserialize, Serialize};
+use tower::ServiceExt;
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ExtractRequest {
+    text: String,
+}
+
+#[derive(Debug, Deserialize, Instructor, PartialEq, Serialize)]
+#[llm(description = "A reconciled discrepancy between expected and actual positions")]
+struct PositionBreak {
+    portfolio_id: String,
+    symbol: String,
+    expected_quantity: i64,
+    actual_quantity: i64,
+    as_of: String,
+}
+
+struct AppState<C> {
+    client: C,
+}
+
+async fn extract_position_break<C>(
+    State(state): State<Arc<AppState<C>>>,
+    Json(request): Json<ExtractRequest>,
+) -> Result<Json<PositionBreak>, (StatusCode, String)>
+where
+    C: LLMClient + Send + Sync + 'static,
+{
+    state
+        .client
+        .materialize(&request.text)
+        .await
+        .map(Json)
+        .map_err(|error| (StatusCode::UNPROCESSABLE_ENTITY, error.to_string()))
+}
+
+fn app<C>(client: C) -> Router
+where
+    C: LLMClient + Send + Sync + 'static,
+{
+    Router::new()
+        .route(
+            "/position-breaks/extract",
+            post(extract_position_break::<C>),
+        )
+        .with_state(Arc::new(AppState { client }))
+}
+
+async fn exercise_router() -> Result<PositionBreak, Box<dyn std::error::Error>> {
+    let client = MockClient::new().with_response(
+        r#"{
+            "portfolio_id": "HF-ALPHA-001",
+            "symbol": "ESU6",
+            "expected_quantity": -240,
+            "actual_quantity": -238,
+            "as_of": "2026-07-29T14:31:00Z"
+        }"#,
+    );
+
+    let request = ExtractRequest {
+        text: "At 14:31 UTC the HF-ALPHA-001 book expected short 240 ESU6, \
+               but the clearing file shows short 238."
+            .to_string(),
+    };
+    let response = app(client)
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/position-breaks/extract")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(serde_json::to_vec(&request)?))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), 1024 * 1024).await?;
+    Ok(serde_json::from_slice(&body)?)
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let position_break = exercise_router().await?;
+    assert_eq!(
+        position_break,
+        PositionBreak {
+            portfolio_id: "HF-ALPHA-001".to_string(),
+            symbol: "ESU6".to_string(),
+            expected_quantity: -240,
+            actual_quantity: -238,
+            as_of: "2026-07-29T14:31:00Z".to_string(),
+        }
+    );
+
+    println!("{}", serde_json::to_string_pretty(&position_break)?);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn handler_materializes_a_typed_response_in_process() {
+        let position_break = exercise_router()
+            .await
+            .expect("the in-process request should succeed");
+
+        assert_eq!(position_break.symbol, "ESU6");
+        assert_eq!(
+            position_break.actual_quantity - position_break.expected_quantity,
+            2
+        );
+    }
+}

--- a/examples/nested_objects_example.rs
+++ b/examples/nested_objects_example.rs
@@ -1,3 +1,5 @@
+//! Materialize and recursively validate a recipe made of nested structs and lists.
+
 use rstructor::{GeminiClient, Instructor, LLMClient, RStructorError};
 use serde::{Deserialize, Serialize};
 use std::env;

--- a/examples/news_article_categorizer.rs
+++ b/examples/news_article_categorizer.rs
@@ -1,3 +1,5 @@
+//! Classify an article into an enum while extracting sentiment, entities, and keywords.
+
 use rstructor::{GrokClient, Instructor, LLMClient};
 use serde::{Deserialize, Serialize};
 use std::env;

--- a/examples/retry_attempt_ledger.rs
+++ b/examples/retry_attempt_ledger.rs
@@ -1,3 +1,5 @@
+//! Inspect every retry plus cumulative known token usage for a materialization run.
+
 use rstructor::{AttemptOutcome, AttemptRecord, Instructor, LLMClient, OpenAIClient, RunUsage};
 use serde::{Deserialize, Serialize};
 

--- a/examples/runtime_provider_example.rs
+++ b/examples/runtime_provider_example.rs
@@ -1,0 +1,48 @@
+//! Choose a provider and model at runtime with `rstructor::client`.
+//!
+//! The first slash separates the route from the provider-native model ID, so
+//! model IDs may contain additional slashes:
+//!
+//! ```text
+//! RSTRUCTOR_CLIENT=openrouter/moonshotai/kimi-k3 \
+//!   cargo run --example runtime_provider_example
+//! ```
+//!
+//! The example exits without a request when neither a CLI spec nor
+//! `RSTRUCTOR_CLIENT` is supplied, keeping CI deterministic.
+
+use rstructor::{Instructor, LLMClient};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Instructor, Serialize)]
+struct Position {
+    symbol: String,
+    quantity: i64,
+    market_value_usd: f64,
+}
+
+fn client_spec() -> Option<String> {
+    std::env::args()
+        .nth(1)
+        .or_else(|| std::env::var("RSTRUCTOR_CLIENT").ok())
+        .filter(|spec| !spec.trim().is_empty())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let Some(spec) = client_spec() else {
+        eprintln!(
+            "Skipping provider request. Pass a provider/model argument or set \
+             RSTRUCTOR_CLIENT (for example, openai/gpt-5.6-sol)."
+        );
+        return Ok(());
+    };
+
+    let client = rstructor::client(&spec)?;
+    let position: Position = client
+        .materialize("AAPL: long 125,000 shares, market value $29,750,000")
+        .await?;
+
+    println!("{position:#?}");
+    Ok(())
+}

--- a/examples/schemars_bridge_example.rs
+++ b/examples/schemars_bridge_example.rs
@@ -1,0 +1,46 @@
+//! Reuse a Serde + schemars domain model without deriving `Instructor`.
+//!
+//! This runnable recipe uses `MockClient`, so it needs no API key or network:
+//!
+//! ```text
+//! cargo run --example schemars_bridge_example --features "mock,schemars"
+//! ```
+
+use rstructor::{LLMClient, MockClient, Schemars};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// A position reported by a prime broker.
+#[derive(Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
+struct Position {
+    /// Fund or separately managed account identifier.
+    portfolio_id: String,
+    /// Exchange ticker or contract symbol.
+    symbol: String,
+    /// Signed quantity: positive is long and negative is short.
+    quantity: i64,
+    /// Position market value in US dollars.
+    market_value_usd: f64,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = MockClient::new().with_response(
+        r#"{
+            "portfolio_id": "HF-ALPHA-001",
+            "symbol": "AAPL",
+            "quantity": 125000,
+            "market_value_usd": 29750000.0
+        }"#,
+    );
+
+    let position = client
+        .materialize::<Schemars<Position>>("HF-ALPHA-001 owns 125,000 AAPL worth $29.75 million.")
+        .await?
+        .into_inner();
+
+    assert_eq!(position.quantity, 125_000);
+    assert_eq!(client.request_count(), 1);
+    println!("{position:#?}");
+    Ok(())
+}

--- a/examples/structured_movie_info.rs
+++ b/examples/structured_movie_info.rs
@@ -1,8 +1,8 @@
+//! Extract a validated, typed movie record from one free-form sentence.
+
 use rstructor::{Instructor, LLMClient, OpenAIClient};
 use serde::{Deserialize, Serialize};
 use std::env;
-
-/// This example demonstrates extracting structured movie information.
 
 // Define our data model
 #[derive(Instructor, Serialize, Deserialize, Debug)]

--- a/examples/validation_example.rs
+++ b/examples/validation_example.rs
@@ -1,3 +1,5 @@
+//! Reject invalid structured output with a custom validator that can drive a re-ask.
+
 use rstructor::{Instructor, RStructorError, SchemaType};
 use serde::{Deserialize, Serialize};
 

--- a/tests/documentation_gallery_tests.rs
+++ b/tests/documentation_gallery_tests.rs
@@ -1,0 +1,180 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::{collections::BTreeSet, ffi::OsStr};
+
+const GALLERY_EXAMPLES: &[(&str, &[&str])] = &[
+    ("structured_movie_info", &["derive", "openai"]),
+    ("news_article_categorizer", &["derive", "grok"]),
+    ("openai_multimodal_example", &["derive", "openai"]),
+    ("anthropic_multimodal_example", &["anthropic", "derive"]),
+    ("gemini_multimodal_example", &["derive", "gemini"]),
+    ("grok_multimodal_example", &["derive", "grok"]),
+    ("axum_handler_example", &["derive", "mock"]),
+    ("mock_testing_example", &["derive", "mock"]),
+    ("ollama_local_example", &["derive", "openai"]),
+    ("runtime_provider_example", &["derive", "openai"]),
+    ("schemars_bridge_example", &["mock", "schemars"]),
+    ("tool_calling_example", &["derive", "openai", "tools"]),
+    ("streaming_example", &["derive", "openai", "streaming"]),
+    ("validation_example", &["derive"]),
+    ("retry_attempt_ledger", &["derive", "openai"]),
+    ("nested_objects_example", &["derive", "gemini"]),
+    ("recursive_schema_graph", &["derive"]),
+];
+
+const OTHER_FEATURE_GATED_EXAMPLES: &[(&str, &[&str])] = &[
+    ("container_attributes_example", &["derive"]),
+    ("custom_type_example", &["derive"]),
+    ("enum_example", &["derive"]),
+    ("enum_with_data_example", &["derive"]),
+    ("event_planner", &["anthropic", "derive"]),
+    ("logging_example", &["anthropic", "derive", "logging"]),
+    ("medical_example", &["derive"]),
+    ("movie_example", &["derive"]),
+    ("nested_enum_example", &["derive"]),
+    ("serde_rename_example", &["derive"]),
+    ("token_usage_example", &["derive", "openai"]),
+    ("weather_example", &["derive", "openai"]),
+];
+
+const COOKBOOK_RECIPES: &[(&str, &str)] = &[
+    (
+        "## Extract typed data from an image or PDF",
+        "openai_multimodal_example",
+    ),
+    ("## Classify text into an enum", "news_article_categorizer"),
+    (
+        "## Put typed extraction behind an axum handler",
+        "axum_handler_example",
+    ),
+    (
+        "## Test extraction offline with `MockClient`",
+        "mock_testing_example",
+    ),
+    (
+        "## Use a local model through Ollama",
+        "ollama_local_example",
+    ),
+    (
+        "## Choose a provider at runtime",
+        "runtime_provider_example",
+    ),
+    ("## Reuse a schemars model", "schemars_bridge_example"),
+    ("## Inspect cumulative retry cost", "retry_attempt_ledger"),
+];
+
+fn repo_path(path: impl AsRef<Path>) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
+}
+
+fn read(path: impl AsRef<Path>) -> String {
+    let path = repo_path(path);
+    fs::read_to_string(&path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+}
+
+fn example_manifest_block<'a>(manifest: &'a str, example: &str) -> &'a str {
+    manifest
+        .split("[[example]]")
+        .find(|block| block.contains(&format!("name = \"{example}\"")))
+        .unwrap_or_else(|| panic!("Cargo.toml must declare `{example}`"))
+}
+
+#[test]
+fn every_gallery_example_exists_and_is_linked() {
+    let readme = read("README.md");
+
+    for (example, _) in GALLERY_EXAMPLES {
+        let source = format!("examples/{example}.rs");
+        assert!(
+            repo_path(&source).is_file(),
+            "gallery target `{source}` must exist"
+        );
+        assert!(
+            readme.contains(&format!("]({source})")),
+            "README gallery must link `{source}`"
+        );
+    }
+}
+
+#[test]
+fn every_feature_dependent_example_declares_its_required_features() {
+    let manifest = read("Cargo.toml");
+
+    for (example, features) in GALLERY_EXAMPLES.iter().chain(OTHER_FEATURE_GATED_EXAMPLES) {
+        let block = example_manifest_block(&manifest, example);
+        for feature in *features {
+            assert!(
+                block.contains(&format!("\"{feature}\"")),
+                "`{example}` must require its `{feature}` feature: {block}"
+            );
+        }
+    }
+}
+
+#[test]
+fn feature_audit_covers_the_entire_examples_directory() {
+    let audited = GALLERY_EXAMPLES
+        .iter()
+        .chain(OTHER_FEATURE_GATED_EXAMPLES)
+        .map(|(example, _)| *example)
+        .chain(["manual_implementation"])
+        .collect::<BTreeSet<_>>();
+    let present = fs::read_dir(repo_path("examples"))
+        .expect("read examples directory")
+        .map(|entry| entry.expect("read example directory entry").path())
+        .filter(|path| path.extension() == Some(OsStr::new("rs")))
+        .map(|path| {
+            path.file_stem()
+                .and_then(OsStr::to_str)
+                .expect("example filename must be UTF-8")
+                .to_string()
+        })
+        .collect::<BTreeSet<_>>();
+    let audited = audited.into_iter().map(str::to_string).collect();
+
+    assert_eq!(
+        present, audited,
+        "every runnable example must be covered by the feature-gating audit"
+    );
+}
+
+#[test]
+fn recipes_gallery_precedes_providers_and_links_the_cookbook() {
+    let readme = read("README.md");
+    let gallery = readme.find("## Recipes").expect("README recipes gallery");
+    let providers = readme
+        .find("## Providers")
+        .expect("README providers section");
+
+    assert!(gallery < providers, "recipes must appear before providers");
+    assert!(
+        readme.contains("[task-oriented cookbook](docs/COOKBOOK.md)"),
+        "README must prominently link the cookbook"
+    );
+}
+
+#[test]
+fn cookbook_covers_every_requested_task_with_a_runnable_example() {
+    let cookbook = read("docs/COOKBOOK.md");
+
+    for (heading, example) in COOKBOOK_RECIPES {
+        assert!(cookbook.contains(heading), "missing recipe `{heading}`");
+
+        let link = format!("](../examples/{example}.rs)");
+        assert!(
+            cookbook.contains(&link),
+            "recipe `{heading}` must link runnable example `{example}`"
+        );
+        assert!(
+            repo_path(format!("examples/{example}.rs")).is_file(),
+            "cookbook target `{example}` must exist"
+        );
+    }
+
+    for line in cookbook.lines().filter(|line| line.starts_with("```")) {
+        assert!(
+            !line.contains("ignore"),
+            "cookbook doctests must never be ignored: {line}"
+        );
+    }
+}


### PR DESCRIPTION
## Why

rstructor had a large example directory but no task-oriented entry point, so a
user had to infer which example covered classification, media extraction,
offline testing, local models, runtime routing, schemars reuse, or retry-cost
inspection. The example manifest had also drifted: several examples could be
selected without every optional feature required by their imports.

## What changed

- add a README Recipes gallery above Providers, mapping common tasks to
  runnable examples with one-line descriptions
- add `docs/COOKBOOK.md` with complete copy-paste recipes for:
  - image and PDF extraction
  - enum classification
  - typed extraction behind an axum handler
  - offline `MockClient` testing
  - local Ollama models
  - runtime `provider/model` routing
  - the `Schemars<T>` bridge
  - cumulative retry and token-cost inspection
- add runnable, CI-safe examples for axum, runtime routing, and schemars
- add axum and tower as dev-only dependencies; downstream dependency behavior
  is unchanged
- audit every example and declare all required Cargo features, including fixing
  `streaming_example` to require both `streaming` and `openai`
- add regression tests for gallery placement, links, cookbook coverage, ignored
  doctests, full example-directory audit coverage, and feature declarations

## Usage examples

Choose a provider or OpenAI-compatible endpoint at runtime:

```rust
use rstructor::LLMClient;

let client = rstructor::client("openrouter/moonshotai/kimi-k3")?;
let position: Position = client
    .materialize("AAPL: long 125,000 shares, market value $29,750,000")
    .await?;
```

Reuse an existing schemars model without an `Instructor` derive:

```rust
let position = MockClient::new()
    .with_response(r#"{"symbol":"ESU6","quantity":-240}"#)
    .materialize::<rstructor::Schemars<Position>>(
        "The fund is short 240 ESU6",
    )
    .await?
    .into_inner();
```

Use the same API against a keyless local Ollama endpoint:

```rust
let client = rstructor::client("ollama/llama3.3")?;
let summary: Summary = client.materialize("Summarize this report").await?;
```

The axum recipe makes the router generic over `LLMClient`, allowing production
to inject `AnyClient` while the runnable test injects `MockClient` and exercises
the JSON request/response boundary in-process.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --no-fail-fast`
- `cargo test --all-features --no-fail-fast`
- `cargo test --all-features --example axum_handler_example`
- `cargo run --all-features --example axum_handler_example`
- `cargo run --all-features --example schemars_bridge_example`
- `cargo run --all-features --example runtime_provider_example`
- `cargo build --no-default-features --examples`
- `cargo build --no-default-features --features derive --examples`
- `cargo build --no-default-features --features "derive,mock" --examples`
- `cargo build --examples`
- `cargo build --all-features --examples`
