### PR TITLE
[codex] Refresh dependencies and provider models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,16 +71,16 @@
    - **Google (Gemini)**: `GET https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY` (API key as query parameter)
 2. **NEVER guess model identifiers** - Always get exact model names from API responses or official documentation
 3. **NEVER rely on web search results** - Web search often returns outdated, incorrect, or speculative information
-4. **ALWAYS use exact API identifiers** - Model identifiers must match exactly what the API expects (e.g., `gpt-5.6-sol`, `claude-sonnet-5`, `grok-4.5`, `gemini-3.5-flash`)
+4. **ALWAYS use exact API identifiers** - Model identifiers must match exactly what the API expects (e.g., `gpt-5.6-sol`, `claude-opus-5`, `grok-4.5`, `gemini-3.6-flash`)
 5. **If API key is not available**: Ask the user to provide the exact model identifiers from the API endpoint response, rather than guessing or using web search
 6. **NEVER use web search for model lists** - Web search results are often outdated, incorrect, or speculative. Always use official API endpoints or documentation
 7. **Verify versioning conventions** - Some providers use dated snapshots while newer Anthropic models use dateless pinned IDs; confirm the current provider convention rather than inferring one
 8. **Check for new major versions** - Don't assume only minor version updates; check for major version releases (e.g., Claude 5, GPT-5.6, Gemini 3.5)
 9. **Verify model name format** - Different providers may use different naming conventions:
    - OpenAI: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`
-   - Anthropic: `claude-sonnet-5` (dateless pinned ID for current generations)
+   - Anthropic: `claude-opus-5` (dateless pinned ID for current generations)
    - Grok: `grok-4.5`
-   - Gemini: `gemini-3.5-flash`, `gemini-3.1-pro-preview` (may include a preview suffix)
+   - Gemini: `gemini-3.6-flash`, `gemini-3.1-pro-preview` (may include a preview suffix)
 10. **Filter for chat completion models** - Only include models suitable for chat completions:
     - **OpenAI**: Filter for chat completion models (exclude `whisper-*`, `text-embedding-*`, `text-moderation-*`, etc.)
     - **Anthropic**: Filter for chat completion models (exclude specialized variants unless needed)
@@ -95,8 +95,8 @@
    - **Grok**: Check documentation at `https://docs.x.ai/developers/models` (API endpoint may not be publicly available)
 2. **Parse API response**: Extract model identifiers from the JSON response (field names vary by provider):
    - **OpenAI**: Extract `id` field (e.g., `"id": "gpt-5.6-sol"`)
-   - **Anthropic**: Extract `id` field (e.g., `"id": "claude-sonnet-5"`)
-   - **Gemini**: Extract `name` field and remove `models/` prefix (e.g., `"name": "models/gemini-3.5-flash"` → use `gemini-3.5-flash`)
+   - **Anthropic**: Extract `id` field (e.g., `"id": "claude-opus-5"`)
+   - **Gemini**: Extract `name` field and remove `models/` prefix (e.g., `"name": "models/gemini-3.6-flash"` → use `gemini-3.6-flash`)
    - **Grok**: Extract from documentation or ask user for exact identifiers
 3. **Filter appropriate models**: For chat completions, include main chat models and exclude specialized variants:
    - **OpenAI**: Filter for chat completion models (exclude `whisper-*`, `text-embedding-*`, `text-moderation-*`, etc.)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,31 +38,33 @@ categories = [
 ]
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.151"
 serde_path_to_error = { version = "0.1.20", optional = true }
-async-trait = "0.1.89"
-tokio = { version = "1.52.1", features = [
+async-trait = "0.1.91"
+tokio = { version = "1.53.1", features = [
   "rt",
   "macros",
   "rt-multi-thread",
   "io-std",
 ], optional = true }
-reqwest = { version = "0.13.3", features = [
+reqwest = { version = "0.13.4", features = [
   "json",
   "query",
   "default-tls",
 ], default-features = false, optional = true }
-thiserror = "2.0.18"
+thiserror = "2.0.19"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = [
   "env-filter",
 ], optional = true }
 tracing-futures = { version = "0.2.5", optional = true }
 rstructor_derive = { version = "0.4.0", path = "./rstructor_derive", optional = true }
-schemars = { version = "1.0", optional = true }
-base64 = { version = "0.22.1", optional = true }
-futures-util = { version = "0.3.31", default-features = false, optional = true }
+schemars = { version = "1.2.2", optional = true }
+base64 = { version = "0.23.0", default-features = false, features = [
+  "std",
+], optional = true }
+futures-util = { version = "0.3.33", default-features = false, optional = true }
 async-stream = { version = "0.3.6", optional = true }
 
 # Feature flags
@@ -213,18 +215,18 @@ required-features = ["derive", "openai"]
 [dev-dependencies]
 # Builds and exercises the typed HTTP-handler cookbook recipe in-process. The
 # public dependency closure is unchanged.
-axum = { version = "0.8", default-features = false, features = ["json"] }
+axum = { version = "0.8.9", default-features = false, features = ["json"] }
 # Used only by examples and tests (date/time fields, custom types); not part of
 # the public dependency closure.
-chrono = { version = "0.4.44", features = ["serde"] }
+chrono = { version = "0.4.45", features = ["serde"] }
 # Drives async tests/examples (e.g. for the `mock` feature, which does not itself
 # pull in tokio). Dev-only — excluded from the public dependency closure.
-tokio = { version = "1.52.1", features = ["rt", "macros", "rt-multi-thread"] }
+tokio = { version = "1.53.1", features = ["rt", "macros", "rt-multi-thread"] }
 # Local HTTP mock server for testing the real provider clients (request building,
 # response parsing, retry/re-ask loop) offline, with no API key. Dev-only.
-mockito = "1.7.0"
+mockito = "1.7.2"
 # `ServiceExt::oneshot` drives the axum cookbook router without opening a port.
-tower = { version = "0.5", features = ["util"] }
+tower = { version = "0.5.3", features = ["util"] }
 
 [workspace]
 members = ["rstructor_derive"]

--- a/README.md
+++ b/README.md
@@ -159,16 +159,16 @@ complete copy-paste recipes.
 use rstructor::{OpenAIClient, AnthropicClient, GrokClient, GeminiClient, LLMClient};
 
 // OpenAI (reads OPENAI_API_KEY)
-let client = OpenAIClient::from_env()?.model("gpt-5.6");
+let client = OpenAIClient::from_env()?.model("gpt-5.6-sol");
 
 // Anthropic (reads ANTHROPIC_API_KEY)
-let client = AnthropicClient::from_env()?.model("claude-sonnet-5");
+let client = AnthropicClient::from_env()?.model("claude-opus-5");
 
 // Grok/xAI (reads XAI_API_KEY)
 let client = GrokClient::from_env()?.model("grok-4.5");
 
 // Gemini (reads GEMINI_API_KEY)
-let client = GeminiClient::from_env()?.model("gemini-3.5-flash");
+let client = GeminiClient::from_env()?.model("gemini-3.6-flash");
 
 // Local Ollama (no API key)
 let client = OpenAIClient::ollama()?.model("llama3.3");
@@ -218,7 +218,7 @@ loop, without endpoint-specific schema-dialect rewriting.
 use rstructor::{AnyClient, Provider, LLMClient};
 
 // Parse a case-insensitive "provider/model" string.
-let client = rstructor::client("anthropic/claude-sonnet-5")?;
+let client = rstructor::client("anthropic/claude-opus-5")?;
 let movie: Movie = client.materialize("Describe Inception").await?;
 
 // Or auto-detect in deterministic environment-key order:
@@ -233,7 +233,7 @@ let movie: Movie = client.materialize("Describe Inception").await?;
 let client = AnyClient::from_env()?;
 
 // Or wrap a pre-configured client:
-let client: AnyClient = OpenAIClient::from_env()?.model("gpt-5.6").into();
+let client: AnyClient = OpenAIClient::from_env()?.model("gpt-5.6-sol").into();
 ```
 
 ## Validation
@@ -589,9 +589,10 @@ Configure reasoning depth for supported models:
 ```rust
 use rstructor::ThinkingLevel;
 
-// GPT-5.6, Claude 4.6 Sonnet, Gemini 3.1
+// GPT-5.6 and Gemini 3.6 use named effort levels; Claude 4.x uses
+// extended-thinking token budgets.
 let client = OpenAIClient::from_env()?
-    .model("gpt-5.6")
+    .model("gpt-5.6-sol")
     .thinking_level(ThinkingLevel::High);
 
 // Levels: Off, Minimal, Low, Medium, High

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -364,7 +364,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 Examples of valid values are `openai/gpt-5.6-sol`,
-`anthropic/claude-sonnet-5`, `ollama/llama3.3`, and
+`anthropic/claude-opus-5`, `ollama/llama3.3`, and
 `openrouter/moonshotai/kimi-k3`. Hosted routes read their provider-specific key;
 Ollama and LM Studio are keyless.
 

--- a/examples/anthropic_multimodal_example.rs
+++ b/examples/anthropic_multimodal_example.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image_bytes = reqwest::get(image_url).await?.bytes().await?;
     let media = MediaFile::from_bytes(&image_bytes, "image/png");
 
-    let client = AnthropicClient::from_env()?.model(AnthropicModel::ClaudeSonnet5);
+    let client = AnthropicClient::from_env()?.model(AnthropicModel::ClaudeOpus5);
 
     let analysis: ImageAnalysis = client
         .materialize_with_media("Describe this image and list dominant colors.", &[media])

--- a/examples/openai_multimodal_example.rs
+++ b/examples/openai_multimodal_example.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let media = MediaFile::from_bytes(&image_bytes, "image/png");
 
     let client = OpenAIClient::from_env()?
-        .model(OpenAIModel::Gpt56)
+        .model(OpenAIModel::Gpt56Sol)
         .temperature(0.0);
 
     let analysis: ImageAnalysis = client

--- a/rstructor_derive/Cargo.toml
+++ b/rstructor_derive/Cargo.toml
@@ -23,15 +23,15 @@ categories = [
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0.117", features = ["full"] }
-quote = "1.0.45"
-proc-macro2 = "1.0.106"
-serde_json = "1.0.149"
+syn = { version = "3.0.3", features = ["full"] }
+quote = "1.0.47"
+proc-macro2 = "1.0.107"
+serde_json = "1.0.151"
 
 [dev-dependencies]
 rstructor = { path = ".." }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-chrono = { version = "0.4.44", features = ["serde"] }
-uuid = { version = "1.23.1", features = ["serde"] }
-trybuild = "1"
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.151"
+chrono = { version = "0.4.45", features = ["serde"] }
+uuid = { version = "1.24.0", features = ["serde"] }
+trybuild = "1.0.118"

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -43,11 +43,13 @@ define_model_enum! {
     /// let model = AnthropicModel::from_string("claude-custom");
     /// ```
     pub enum AnthropicModel {
-        /// Claude Fable 5 (latest highest-capability generally available model)
-        ClaudeFable5 => "claude-fable-5",
+        /// Claude Opus 5 (latest recommended model for agentic coding and enterprise work)
+        ClaudeOpus5 => "claude-opus-5",
         /// Claude Sonnet 5 (latest balanced model)
         ClaudeSonnet5 => "claude-sonnet-5",
-        /// Claude Opus 4.8 (recommended for complex agentic and enterprise work)
+        /// Claude Fable 5 (highest-capability generally available model)
+        ClaudeFable5 => "claude-fable-5",
+        /// Claude Opus 4.8 (previous recommended model for complex work)
         ClaudeOpus48 => "claude-opus-4-8",
         /// Claude Opus 4.7 (previous most capable model)
         ClaudeOpus47 => "claude-opus-4-7",
@@ -127,7 +129,11 @@ struct CompletionRequest {
 fn effective_temperature(model: &str, configured: f32, thinking_enabled: bool) -> f32 {
     let requires_default_sampling = matches!(
         model,
-        "claude-fable-5" | "claude-sonnet-5" | "claude-opus-4-8" | "claude-opus-4-7"
+        "claude-opus-5"
+            | "claude-sonnet-5"
+            | "claude-fable-5"
+            | "claude-opus-4-8"
+            | "claude-opus-4-7"
     );
     if thinking_enabled || requires_default_sampling {
         1.0
@@ -202,7 +208,7 @@ impl AnthropicClient {
     /// # Ok(())
     /// # }
     /// ```
-    #[instrument(name = "anthropic_client_new", skip(api_key), fields(model = ?AnthropicModel::ClaudeSonnet5))]
+    #[instrument(name = "anthropic_client_new", skip(api_key), fields(model = ?AnthropicModel::ClaudeOpus5))]
     pub fn new(api_key: impl Into<String>) -> Result<Self> {
         let api_key = api_key.into();
         if api_key.is_empty() {
@@ -216,7 +222,7 @@ impl AnthropicClient {
 
         let config = AnthropicConfig {
             api_key,
-            model: AnthropicModel::ClaudeSonnet5, // Default to Claude Sonnet 5 (latest balanced model)
+            model: AnthropicModel::ClaudeOpus5, // Default to Claude Opus 5 (latest recommended model)
             temperature: 0.0,
             max_tokens: None,
             timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
@@ -247,7 +253,7 @@ impl AnthropicClient {
     /// # Ok(())
     /// # }
     /// ```
-    #[instrument(name = "anthropic_client_from_env", fields(model = ?AnthropicModel::ClaudeSonnet5))]
+    #[instrument(name = "anthropic_client_from_env", fields(model = ?AnthropicModel::ClaudeOpus5))]
     pub fn from_env() -> Result<Self> {
         let api_key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| {
             RStructorError::api_error("Anthropic", ApiErrorKind::AuthenticationFailed)
@@ -258,7 +264,7 @@ impl AnthropicClient {
 
         let config = AnthropicConfig {
             api_key,
-            model: AnthropicModel::ClaudeSonnet5, // Default to Claude Sonnet 5 (latest balanced model)
+            model: AnthropicModel::ClaudeOpus5, // Default to Claude Opus 5 (latest recommended model)
             temperature: 0.0,
             max_tokens: None,
             timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
@@ -1117,8 +1123,9 @@ mod tests {
     #[test]
     fn latest_models_use_default_sampling_temperature() {
         for model in [
-            "claude-fable-5",
+            "claude-opus-5",
             "claude-sonnet-5",
+            "claude-fable-5",
             "claude-opus-4-8",
             "claude-opus-4-7",
         ] {
@@ -1149,9 +1156,9 @@ mod tests {
     }
 
     #[test]
-    fn default_config_uses_latest_balanced_model() {
+    fn default_config_uses_latest_recommended_model() {
         let client = super::AnthropicClient::new("test-key").unwrap();
-        assert_eq!(client.config.model, super::AnthropicModel::ClaudeSonnet5);
+        assert_eq!(client.config.model, super::AnthropicModel::ClaudeOpus5);
     }
 
     #[test]

--- a/src/backend/any_client.rs
+++ b/src/backend/any_client.rs
@@ -169,7 +169,7 @@ fn provider_feature_disabled(provider: &str, feature: &str) -> RStructorError {
 /// # fn ex() -> Result<(), Box<dyn std::error::Error>> {
 /// use rstructor::{AnyClient, OpenAIClient, OpenAIModel};
 ///
-/// let configured = OpenAIClient::from_env()?.model(OpenAIModel::Gpt56);
+/// let configured = OpenAIClient::from_env()?.model(OpenAIModel::Gpt56Sol);
 /// let client: AnyClient = configured.into();
 /// # let _ = client;
 /// # Ok(())

--- a/src/backend/client.rs
+++ b/src/backend/client.rs
@@ -114,7 +114,7 @@ impl MediaFile {
 /// and raw text completions.
 ///
 /// The library includes implementations for popular LLM providers:
-/// - `OpenAIClient` for OpenAI's GPT models (gpt-3.5-turbo, gpt-4, etc.)
+/// - `OpenAIClient` for OpenAI's GPT models (GPT-5.6 and earlier families)
 /// - `AnthropicClient` for Anthropic's Claude models
 /// - `GrokClient` for xAI's Grok models
 /// - `GeminiClient` for Google's Gemini models
@@ -153,7 +153,7 @@ impl MediaFile {
 ///
 /// // Create a client
 /// let client = OpenAIClient::new("your-openai-api-key")?
-///     .model(OpenAIModel::Gpt56)
+///     .model(OpenAIModel::Gpt56Sol)
 ///     .temperature(0.0)
 ///     .timeout(Duration::from_secs(30));  // Optional: set 30 second timeout
 ///
@@ -186,7 +186,7 @@ impl MediaFile {
 ///
 /// // Create a client
 /// let client = AnthropicClient::new("your-anthropic-api-key")?
-///     .model(AnthropicModel::ClaudeSonnet5)
+///     .model(AnthropicModel::ClaudeOpus5)
 ///     .timeout(Duration::from_secs(30));  // Optional: set 30 second timeout
 ///
 /// // Materialize a structured response

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -43,8 +43,12 @@ define_model_enum! {
     /// let model = GeminiModel::from_string("gemini-custom");
     /// ```
     pub enum Model {
-        /// Gemini 3.5 Flash (latest Flash model, best price/performance, default)
+        /// Gemini 3.6 Flash (latest stable model balancing speed and intelligence)
+        Gemini36Flash => "gemini-3.6-flash",
+        /// Gemini 3.5 Flash (stable model for sustained frontier performance)
         Gemini35Flash => "gemini-3.5-flash",
+        /// Gemini 3.5 Flash-Lite (fastest, most cost-effective Gemini 3.5 model)
+        Gemini35FlashLite => "gemini-3.5-flash-lite",
         /// Gemini 3.1 Pro Preview (latest Pro model)
         Gemini31ProPreview => "gemini-3.1-pro-preview",
         /// Gemini 3.1 Pro Preview Custom Tools (agentic custom-tool variant)
@@ -265,7 +269,7 @@ impl GeminiClient {
     /// # Ok(())
     /// # }
     /// ```
-    #[instrument(name = "gemini_client_new", skip(api_key), fields(model = ?Model::Gemini35Flash))]
+    #[instrument(name = "gemini_client_new", skip(api_key), fields(model = ?Model::Gemini36Flash))]
     pub fn new(api_key: impl Into<String>) -> Result<Self> {
         let api_key = api_key.into();
         if api_key.is_empty() {
@@ -277,7 +281,7 @@ impl GeminiClient {
 
         let config = GeminiConfig {
             api_key,
-            model: Model::Gemini35Flash, // Default to Gemini 3.5 Flash (latest Flash, best price/performance)
+            model: Model::Gemini36Flash, // Default to Gemini 3.6 Flash (latest balanced stable model)
             temperature: 0.0,
             max_tokens: None,
             timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
@@ -314,7 +318,7 @@ impl GeminiClient {
     /// # Ok(())
     /// # }
     /// ```
-    #[instrument(name = "gemini_client_from_env", fields(model = ?Model::Gemini35Flash))]
+    #[instrument(name = "gemini_client_from_env", fields(model = ?Model::Gemini36Flash))]
     pub fn from_env() -> Result<Self> {
         let api_key = std::env::var("GEMINI_API_KEY")
             .or_else(|_| std::env::var("GOOGLE_API_KEY"))
@@ -322,7 +326,7 @@ impl GeminiClient {
 
         let config = GeminiConfig {
             api_key,
-            model: Model::Gemini35Flash, // Default to Gemini 3.5 Flash (latest Flash, best price/performance)
+            model: Model::Gemini36Flash, // Default to Gemini 3.6 Flash (latest balanced stable model)
             temperature: 0.0,
             max_tokens: None,
             timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
@@ -1230,7 +1234,7 @@ mod tests {
     #[test]
     fn default_config_uses_latest_stable_model() {
         let client = super::GeminiClient::new("test-key").unwrap();
-        assert_eq!(client.config.model, super::Model::Gemini35Flash);
+        assert_eq!(client.config.model, super::Model::Gemini36Flash);
     }
 
     #[test]

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -27,7 +27,7 @@ define_model_enum! {
     /// OpenAI models available for completion
     ///
     /// For the latest available models and their identifiers, check the
-    /// [OpenAI Models Documentation](https://platform.openai.com/docs/models).
+    /// [OpenAI Models Documentation](https://developers.openai.com/api/docs/models).
     ///
     /// # Using Custom Models
     ///
@@ -143,7 +143,7 @@ impl OpenAIClient {
     fn with_api_key(api_key: String) -> Self {
         let config = OpenAIConfig {
             api_key,
-            model: Model::Gpt56, // Default to GPT-5.6 (latest flagship alias)
+            model: Model::Gpt56Sol, // Default to GPT-5.6 Sol (latest recommended flagship)
             temperature: 0.0,
             max_tokens: None,
             timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
@@ -193,7 +193,7 @@ impl OpenAIClient {
     /// # Ok(())
     /// # }
     /// ```
-    #[instrument(name = "openai_client_new", skip(api_key), fields(model = ?Model::Gpt56))]
+    #[instrument(name = "openai_client_new", skip(api_key), fields(model = ?Model::Gpt56Sol))]
     pub fn new(api_key: impl Into<String>) -> Result<Self> {
         let api_key = api_key.into();
         if api_key.is_empty() {
@@ -224,7 +224,7 @@ impl OpenAIClient {
     /// # Ok(())
     /// # }
     /// ```
-    #[instrument(name = "openai_client_from_env", fields(model = ?Model::Gpt56))]
+    #[instrument(name = "openai_client_from_env", fields(model = ?Model::Gpt56Sol))]
     pub fn from_env() -> Result<Self> {
         let api_key = std::env::var("OPENAI_API_KEY")
             .map_err(|_| RStructorError::api_error("OpenAI", ApiErrorKind::AuthenticationFailed))?;
@@ -1147,7 +1147,7 @@ mod tests {
     #[test]
     fn default_config_uses_latest_model() {
         let client = OpenAIClient::new("test-key").unwrap();
-        assert_eq!(client.config.model, Model::Gpt56);
+        assert_eq!(client.config.model, Model::Gpt56Sol);
     }
 
     #[test]

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -1185,13 +1185,13 @@ fn extract_model_from_error(error_text: &str) -> Option<String> {
 fn suggest_model(error_text: &str) -> Option<String> {
     // Common model name patterns and their suggestions
     if error_text.contains("gpt") {
-        Some("gpt-5.6".to_string())
+        Some("gpt-5.6-sol".to_string())
     } else if error_text.contains("claude") || error_text.contains("sonnet") {
-        Some("claude-sonnet-5".to_string())
+        Some("claude-opus-5".to_string())
     } else if error_text.contains("grok") {
         Some("grok-4.5".to_string())
     } else if error_text.contains("gemini") {
-        Some("gemini-3.5-flash".to_string())
+        Some("gemini-3.6-flash".to_string())
     } else {
         None
     }
@@ -2974,7 +2974,7 @@ mod tests {
             ApiErrorKind::InvalidModel { model, suggestion } => {
                 assert_eq!(model, "override-model");
                 // "gpt" appears in the (lowercased) error text -> gpt suggestion.
-                assert_eq!(suggestion, Some("gpt-5.6".to_string()));
+                assert_eq!(suggestion, Some("gpt-5.6-sol".to_string()));
             }
             other => panic!("expected InvalidModel, got {:?}", other),
         }
@@ -2991,7 +2991,7 @@ mod tests {
         match kind {
             ApiErrorKind::InvalidModel { model, suggestion } => {
                 assert_eq!(model, "gemini-2.0-flash");
-                assert_eq!(suggestion, Some("gemini-3.5-flash".to_string()));
+                assert_eq!(suggestion, Some("gemini-3.6-flash".to_string()));
             }
             other => panic!("expected InvalidModel, got {:?}", other),
         }
@@ -3039,20 +3039,23 @@ mod tests {
     fn suggest_model_matches_provider_keywords() {
         assert_eq!(
             suggest_model("sonnet is down"),
-            Some("claude-sonnet-5".to_string())
+            Some("claude-opus-5".to_string())
         );
         assert_eq!(
             suggest_model("claude unavailable"),
-            Some("claude-sonnet-5".to_string())
+            Some("claude-opus-5".to_string())
         );
-        assert_eq!(suggest_model("gpt is gone"), Some("gpt-5.6".to_string()));
+        assert_eq!(
+            suggest_model("gpt is gone"),
+            Some("gpt-5.6-sol".to_string())
+        );
         assert_eq!(
             suggest_model("grok unavailable"),
             Some("grok-4.5".to_string())
         );
         assert_eq!(
             suggest_model("gemini missing"),
-            Some("gemini-3.5-flash".to_string())
+            Some("gemini-3.6-flash".to_string())
         );
         assert_eq!(suggest_model("totally unknown provider"), None);
     }

--- a/src/model/instructor.rs
+++ b/src/model/instructor.rs
@@ -88,7 +88,7 @@ use crate::schema::SchemaType;
 ///
 /// // Create a client
 /// let client = OpenAIClient::new("your-api-key")?
-///     .model(OpenAIModel::Gpt56);
+///     .model(OpenAIModel::Gpt56Sol);
 ///
 /// // Get structured data with automatic validation
 /// let product = client.materialize::<ProductInfo>("Describe a laptop").await?;

--- a/tests/anthropic_multimodal_tests.rs
+++ b/tests/anthropic_multimodal_tests.rs
@@ -34,7 +34,7 @@ mod anthropic_multimodal_tests {
         let media = download_media(RUST_LOGO_URL, RUST_LOGO_MIME).await;
         let client = AnthropicClient::from_env()
             .expect("ANTHROPIC_API_KEY must be set for this test")
-            .model(AnthropicModel::ClaudeSonnet5);
+            .model(AnthropicModel::ClaudeOpus5);
 
         let result: ImageSummary = client
             .materialize_with_media(
@@ -54,7 +54,7 @@ mod anthropic_multimodal_tests {
         let media = media_url(RUST_LOGO_URL, RUST_LOGO_MIME);
         let client = AnthropicClient::from_env()
             .expect("ANTHROPIC_API_KEY must be set for this test")
-            .model(AnthropicModel::ClaudeSonnet5);
+            .model(AnthropicModel::ClaudeOpus5);
 
         let result: ImageSummary = client
             .materialize_with_media(
@@ -75,7 +75,7 @@ mod anthropic_multimodal_tests {
         let lake_media = media_url(RUST_LOGO_URL, RUST_LOGO_MIME);
         let client = AnthropicClient::from_env()
             .expect("ANTHROPIC_API_KEY must be set for this test")
-            .model(AnthropicModel::ClaudeSonnet5);
+            .model(AnthropicModel::ClaudeOpus5);
 
         let result: MultiImageSummary = client
             .materialize_with_media(

--- a/tests/attempt_ledger_provider_tests.rs
+++ b/tests/attempt_ledger_provider_tests.rs
@@ -90,6 +90,41 @@ fn assert_semantic_retry_success(
 
 #[cfg(feature = "anthropic")]
 #[tokio::test]
+async fn anthropic_default_request_sends_the_recommended_model() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/messages")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "model": "claude-opus-5",
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "content": [{ "type": "text", "text": POSITION_JSON }],
+                "model": "claude-opus-5",
+                "usage": { "input_tokens": 70, "output_tokens": 14 },
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let position = rstructor::AnthropicClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .materialize::<Position>("reconcile the futures position")
+        .await
+        .unwrap();
+
+    assert_eq!(position.symbol, "ESU6");
+    assert_eq!(position.quantity, -240);
+    request.assert_async().await;
+}
+
+#[cfg(feature = "anthropic")]
+#[tokio::test]
 async fn anthropic_attempt_report_parses_usage() {
     let mut server = mockito::Server::new_async().await;
     let request = server
@@ -197,6 +232,48 @@ async fn anthropic_protocol_failure_keeps_reported_usage() {
         .unwrap_err();
 
     assert_usage_bearing_protocol_failure(failure, 52);
+    request.assert_async().await;
+}
+
+#[cfg(feature = "gemini")]
+#[tokio::test]
+async fn gemini_default_request_sends_the_latest_stable_model() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/models/gemini-3.6-flash:generateContent")
+        .match_query(mockito::Matcher::UrlEncoded(
+            "key".to_string(),
+            "test-key".to_string(),
+        ))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "candidates": [{
+                    "content": { "parts": [{ "text": POSITION_JSON }] },
+                    "finishReason": "STOP",
+                }],
+                "usageMetadata": {
+                    "promptTokenCount": 60,
+                    "candidatesTokenCount": 12,
+                },
+                "modelVersion": "gemini-3.6-flash",
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let position = rstructor::GeminiClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .materialize::<Position>("reconcile the futures position")
+        .await
+        .unwrap();
+
+    assert_eq!(position.symbol, "ESU6");
+    assert_eq!(position.quantity, -240);
     request.assert_async().await;
 }
 

--- a/tests/gemini_multimodal_tests.rs
+++ b/tests/gemini_multimodal_tests.rs
@@ -47,7 +47,7 @@ mod gemini_multimodal_tests {
 
         let client = GeminiClient::from_env()
             .expect("GEMINI_API_KEY must be set for this test")
-            .model(GeminiModel::Gemini31ProPreview)
+            .model(GeminiModel::Gemini36Flash)
             .temperature(0.0);
 
         let result: ImageDescription = client
@@ -71,7 +71,7 @@ mod gemini_multimodal_tests {
 
         let client = GeminiClient::from_env()
             .expect("GEMINI_API_KEY must be set for this test")
-            .model(GeminiModel::Gemini31ProPreview)
+            .model(GeminiModel::Gemini36Flash)
             .temperature(0.0);
 
         let result: ImageDescription = client
@@ -98,7 +98,7 @@ mod gemini_multimodal_tests {
 
         let client = GeminiClient::from_env()
             .expect("GEMINI_API_KEY must be set for this test")
-            .model(GeminiModel::Gemini31ProPreview)
+            .model(GeminiModel::Gemini36Flash)
             .temperature(0.0);
 
         let result: MultiImageSummary = client

--- a/tests/http_mock_tests.rs
+++ b/tests/http_mock_tests.rs
@@ -166,6 +166,36 @@ async fn materialize_parses_a_real_response() {
 }
 
 #[tokio::test]
+async fn default_client_sends_the_recommended_openai_model() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/chat/completions")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "model": "gpt-5.6-sol",
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(chat_completion(
+            r#"{"portfolio_id":"HF-ALPHA-001","positions":[{"symbol":"ESU6","quantity":-240}]}"#,
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let portfolio: Portfolio = OpenAIClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .materialize("Extract the reconciled futures position")
+        .await
+        .unwrap();
+
+    assert_eq!(portfolio.portfolio_id, "HF-ALPHA-001");
+    assert_eq!(portfolio.positions[0].symbol, "ESU6");
+    assert_eq!(portfolio.positions[0].quantity, -240);
+    request.assert_async().await;
+}
+
+#[tokio::test]
 async fn routed_client_sends_the_full_custom_model_string() {
     let _env = OpenAiEnvGuard::set_for_test();
     let mut server = mockito::Server::new_async().await;

--- a/tests/llm_integration_tests.rs
+++ b/tests/llm_integration_tests.rs
@@ -76,7 +76,7 @@ mod llm_integration_tests {
 
         let client = OpenAIClient::new(api_key)
             .expect("Failed to create OpenAI client")
-            .model(OpenAIModel::Gpt56)
+            .model(OpenAIModel::Gpt56Sol)
             .temperature(0.0);
 
         let prompt = "Provide information about the movie Inception";
@@ -104,7 +104,7 @@ mod llm_integration_tests {
 
         let client = AnthropicClient::new(api_key)
             .expect("Failed to create Anthropic client")
-            .model(AnthropicModel::ClaudeSonnet5);
+            .model(AnthropicModel::ClaudeOpus5);
 
         let prompt = "Provide information about the movie Inception";
         let movie_result = client.materialize::<Movie>(prompt).await;
@@ -155,7 +155,7 @@ mod llm_integration_tests {
         // Read from GEMINI_API_KEY env var
         let client = GeminiClient::from_env()
             .expect("GEMINI_API_KEY must be set for this test")
-            .model(GeminiModel::Gemini31ProPreview)
+            .model(GeminiModel::Gemini36Flash)
             .temperature(0.0);
 
         let prompt = "Provide information about the movie Inception";

--- a/tests/model_string_test.rs
+++ b/tests/model_string_test.rs
@@ -46,6 +46,9 @@ mod tests {
     #[test]
     fn test_anthropic_model_from_string() {
         // Test known model
+        let model = AnthropicModel::from_string("claude-opus-5");
+        assert_eq!(model, AnthropicModel::ClaudeOpus5);
+
         let model = AnthropicModel::from_string("claude-sonnet-5");
         assert_eq!(model, AnthropicModel::ClaudeSonnet5);
 
@@ -110,6 +113,12 @@ mod tests {
     #[test]
     fn test_gemini_model_from_string() {
         // Test known model
+        let model = GeminiModel::from_string("gemini-3.6-flash");
+        assert_eq!(model, GeminiModel::Gemini36Flash);
+
+        let model = GeminiModel::from_string("gemini-3.5-flash-lite");
+        assert_eq!(model, GeminiModel::Gemini35FlashLite);
+
         let model = GeminiModel::from_string("gemini-3.1-pro-preview");
         assert_eq!(model, GeminiModel::Gemini31ProPreview);
 

--- a/tests/openai_enum_anyof_test.rs
+++ b/tests/openai_enum_anyof_test.rs
@@ -65,7 +65,7 @@ mod openai_enum_anyof_tests {
 
         let client = OpenAIClient::new(api_key)
             .expect("Failed to create OpenAI client")
-            .model(OpenAIModel::Gpt56)
+            .model(OpenAIModel::Gpt56Sol)
             .temperature(0.0);
 
         let result = client

--- a/tests/openai_multimodal_tests.rs
+++ b/tests/openai_multimodal_tests.rs
@@ -34,7 +34,7 @@ mod openai_multimodal_tests {
         let media = download_media(RUST_LOGO_URL, RUST_LOGO_MIME).await;
         let client = OpenAIClient::from_env()
             .expect("OPENAI_API_KEY must be set for this test")
-            .model(OpenAIModel::Gpt56)
+            .model(OpenAIModel::Gpt56Sol)
             .temperature(0.0);
 
         let result: ImageSummary = client
@@ -55,7 +55,7 @@ mod openai_multimodal_tests {
         let media = media_url(RUST_LOGO_URL, RUST_LOGO_MIME);
         let client = OpenAIClient::from_env()
             .expect("OPENAI_API_KEY must be set for this test")
-            .model(OpenAIModel::Gpt56)
+            .model(OpenAIModel::Gpt56Sol)
             .temperature(0.0);
 
         let result: ImageSummary = client
@@ -77,7 +77,7 @@ mod openai_multimodal_tests {
         let lake_media = media_url(RUST_LOGO_URL, RUST_LOGO_MIME);
         let client = OpenAIClient::from_env()
             .expect("OPENAI_API_KEY must be set for this test")
-            .model(OpenAIModel::Gpt56)
+            .model(OpenAIModel::Gpt56Sol)
             .temperature(0.0);
 
         let result: MultiImageSummary = client

--- a/tests/provider_offline_tests.rs
+++ b/tests/provider_offline_tests.rs
@@ -228,8 +228,9 @@ fn openai_model_roundtrip_all_variants() {
 fn anthropic_model_roundtrip_all_variants() {
     use AnthropicModel::*;
     let table: &[(AnthropicModel, &str)] = &[
-        (ClaudeFable5, "claude-fable-5"),
+        (ClaudeOpus5, "claude-opus-5"),
         (ClaudeSonnet5, "claude-sonnet-5"),
+        (ClaudeFable5, "claude-fable-5"),
         (ClaudeOpus48, "claude-opus-4-8"),
         (ClaudeOpus47, "claude-opus-4-7"),
         (ClaudeSonnet46, "claude-sonnet-4-6"),
@@ -241,7 +242,7 @@ fn anthropic_model_roundtrip_all_variants() {
     ];
     assert_eq!(
         table.len(),
-        10,
+        11,
         "Anthropic variant table drifted from source"
     );
     for (variant, id) in table {
@@ -253,7 +254,9 @@ fn anthropic_model_roundtrip_all_variants() {
 fn gemini_model_roundtrip_all_variants() {
     use GeminiModel::*;
     let table: &[(GeminiModel, &str)] = &[
+        (Gemini36Flash, "gemini-3.6-flash"),
         (Gemini35Flash, "gemini-3.5-flash"),
+        (Gemini35FlashLite, "gemini-3.5-flash-lite"),
         (Gemini31ProPreview, "gemini-3.1-pro-preview"),
         (
             Gemini31ProPreviewCustomTools,
@@ -275,7 +278,7 @@ fn gemini_model_roundtrip_all_variants() {
         (GeminiFlashLatest, "gemini-flash-latest"),
         (GeminiFlashLiteLatest, "gemini-flash-lite-latest"),
     ];
-    assert_eq!(table.len(), 18, "Gemini variant table drifted from source");
+    assert_eq!(table.len(), 20, "Gemini variant table drifted from source");
     for (variant, id) in table {
         assert_model_roundtrip!(GeminiModel, variant.clone(), id);
     }


### PR DESCRIPTION
## Summary

This refresh closes two kinds of maintenance drift in one pass:

- updates every direct dependency in the root crate and `rstructor_derive` to the latest published compatible major/minor release
- reconciles all four provider model enums and defaults against official model-list APIs or official provider documentation

Historical model variants and request fixtures remain intact, and every provider still preserves unknown IDs through `Custom(String)`.

## Dependency refresh

Root crate:

- `serde` 1.0.228 -> 1.0.229
- `serde_json` 1.0.149 -> 1.0.151
- `async-trait` 0.1.89 -> 0.1.91
- `tokio` 1.52.1 -> 1.53.1
- `reqwest` 0.13.3 -> 0.13.4
- `thiserror` 2.0.18 -> 2.0.19
- `schemars` 1.0 -> 1.2.2
- `base64` 0.22.1 -> 0.23.0
- `futures-util` 0.3.31 -> 0.3.33
- `axum` 0.8 -> 0.8.9
- `chrono` 0.4.44 -> 0.4.45
- `mockito` 1.7.0 -> 1.7.2
- `tower` 0.5 -> 0.5.3

Derive crate:

- `syn` 2.0.117 -> 3.0.3
- `quote` 1.0.45 -> 1.0.47
- `proc-macro2` 1.0.106 -> 1.0.107
- `serde_json` 1.0.149 -> 1.0.151
- `serde` 1.0.228 -> 1.0.229
- `chrono` 0.4.44 -> 0.4.45
- `uuid` 1.23.1 -> 1.24.0
- `trybuild` 1 -> 1.0.118

`base64` now explicitly disables its new default SIMD feature and enables only `std`, preserving the crate's previous safe implementation posture. The `syn` 3 migration required no source changes after full derive and trybuild coverage.

Already-current dependencies were left unchanged: `serde_path_to_error`, `tracing`, `tracing-subscriber`, `tracing-futures`, and `async-stream`.

## Provider model refresh

- OpenAI: the default now uses the exact `gpt-5.6-sol` ID instead of the documented `gpt-5.6` rolling alias. `Gpt56` remains available and round-trippable for compatibility.
- Anthropic: adds `ClaudeOpus5` / `claude-opus-5` and changes the default from `ClaudeSonnet5` to Anthropic's recommended Opus 5 starting point.
- Gemini: adds `Gemini36Flash` / `gemini-3.6-flash` and `Gemini35FlashLite` / `gemini-3.5-flash-lite`; the default moves from Gemini 3.5 Flash to the latest stable Gemini 3.6 Flash.
- xAI: no enum change was needed. `Grok45` remains the recommended default, and every retained Grok chat ID was confirmed by the live model-list API.

Default behavior note: Anthropic's default moves from Sonnet 5 ($3/$15 per MTok input/output) to Opus 5 ($5/$25), trading roughly 67% higher token cost for the provider's current recommended complex-work model. Explicit `.model(...)` calls are unaffected.

Official sources:

- OpenAI: https://developers.openai.com/api/docs/models
- Anthropic: https://platform.claude.com/docs/en/about-claude/models/overview
- Gemini: https://ai.google.dev/gemini-api/docs/models
- xAI: https://docs.x.ai/developers/models

The OpenRouter, Groq, and Moonshot documentation links used by the compatible constructors were also rechecked and still resolve:

- https://openrouter.ai/docs/quickstart
- https://console.groq.com/docs/openai
- https://platform.kimi.ai/docs/api/overview

## Usage examples

The environment constructors now select the refreshed exact defaults:

```rust
let openai = rstructor::OpenAIClient::from_env()?;
// Sends model: "gpt-5.6-sol"

let anthropic = rstructor::AnthropicClient::from_env()?;
// Sends model: "claude-opus-5"

let gemini = rstructor::GeminiClient::from_env()?;
// Sends model: "gemini-3.6-flash"
```

The new variants can also be selected explicitly:

```rust
use rstructor::{AnthropicClient, AnthropicModel, GeminiClient, GeminiModel};

let opus = AnthropicClient::from_env()?.model(AnthropicModel::ClaudeOpus5);
let flash = GeminiClient::from_env()?.model(GeminiModel::Gemini36Flash);
let economical =
    GeminiClient::from_env()?.model(GeminiModel::Gemini35FlashLite);
```

## Test coverage

- exhaustive enum/string round trips, including every new variant and `Custom(String)`
- mocked HTTP assertions proving each refreshed default reaches the provider request
- realistic typed portfolio/position materialization fixtures in default request tests
- live materialization and multimodal calls against all four current provider defaults
- model-list API reconciliation for OpenAI, Anthropic, Gemini, and xAI

Validation completed locally:

```text
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --no-fail-fast
cargo test --all-features --no-fail-fast
```
