### PR TITLE
Fix native system prompts and expose cache usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ use rstructor::{Instructor, OpenAIClient, RequestExt};
 
 let client = OpenAIClient::from_env()?;
 
-// Add context that is prepended to the prompt, then materialize a struct.
+// Keep stable instructions separate from the dynamic user prompt.
 let movie: Movie = client
     .with_system("Assume USD; format dates as ISO-8601.")
     .materialize("Describe Inception")
@@ -130,6 +130,57 @@ The terminals are `materialize::<T>(prompt)` (structured), `generate(prompt)`
 (text), and — with the `tools` feature — `run(prompt)` (text, calling any
 attached tools in a loop). Builders compose: `with_system`, `with_media`, and
 `with_tools` can be chained in any order before the terminal.
+
+### System prompts and prompt caching
+
+Built-in clients send `with_system(...)` through each provider's native
+instruction channel for every request terminal:
+
+- OpenAI-compatible APIs and xAI receive an initial `system` message.
+- Anthropic receives the top-level `system` field.
+- Gemini receives `systemInstruction`.
+
+This preserves instruction semantics and keeps a stable prefix eligible for the
+provider's prompt cache instead of merging it into each changing user message.
+It applies to structured materialization, raw generation, streaming, media
+requests, retry ledgers, and `run` with or without tools.
+
+Put stable policy and examples in the system prompt, then keep request-specific
+data in the user prompt:
+
+```rust
+use rstructor::{LLMClient, OpenAIClient, RequestExt};
+
+const RISK_POLICY: &str =
+    "Use the fund's base currency. Report exposure as a multiple of NAV.";
+
+let client = OpenAIClient::from_env()?;
+let result = client
+    .with_system(RISK_POLICY)
+    .materialize_with_attempts::<Portfolio>(daily_positions)
+    .await?;
+
+if let Some(usage) = result.cumulative_usage {
+    println!(
+        "{} of {} input tokens came from cache",
+        usage.cached_input_tokens,
+        usage.input_tokens,
+    );
+}
+```
+
+OpenAI, Gemini, and xAI can apply implicit prefix caching when a request meets
+their model and token thresholds. Anthropic requires cache-control configuration
+to create a cache, which rstructor does not enable implicitly because it can
+change billing. Likewise, rstructor does not currently create Gemini explicit
+cache objects or set OpenAI cache-routing keys. Provider-reported cache reads and
+writes are exposed as `cached_input_tokens` and `cache_write_input_tokens`;
+both are subsets of `input_tokens` and are not added again by `total_tokens()`.
+See the official [OpenAI](https://developers.openai.com/api/docs/guides/prompt-caching),
+[Anthropic](https://platform.claude.com/docs/en/build-with-claude/prompt-caching),
+[Gemini](https://ai.google.dev/gemini-api/docs/caching), and
+[xAI](https://docs.x.ai/developers/advanced-api-usage/prompt-caching)
+prompt-caching guides for current eligibility and retention rules.
 
 ## Recipes
 
@@ -626,6 +677,11 @@ let result = client.materialize_with_metadata::<Movie>("...").await?;
 println!("Movie: {}", result.data.title);
 if let Some(usage) = result.usage {
     println!("Tokens: {} in, {} out", usage.input_tokens, usage.output_tokens);
+    println!(
+        "Prompt cache: {} read, {} written",
+        usage.cached_input_tokens,
+        usage.cache_write_input_tokens,
+    );
 }
 ```
 
@@ -658,6 +714,8 @@ match client.materialize_with_attempts::<Portfolio>("Reconcile the fund book").a
 Usage is conservative: attempts remain in the ledger when a provider omits
 token metadata, while cumulative totals include only responses with reported
 usage. Local schema/media preflight failures record zero provider attempts.
+Cache read and write counters are provider-reported subsets of input usage, so
+they provide cache observability without inflating `total_tokens()`.
 Built-in clients and `MockClient` set `attempts_complete` to `true`; the default
 implementation for custom clients sets it to `false` rather than inventing
 provider attempts it cannot observe.

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -492,3 +492,58 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 Usage is deliberately conservative: if a provider omits usage for one response,
 the attempt remains in the ledger while cumulative totals include only reported
 tokens. Local preflight failures have an empty ledger.
+
+## Reuse stable instructions with prompt caching
+
+The request builder keeps stable instructions in the provider's native system
+channel while the changing request stays in the user turn. This gives implicit
+prefix caches a reusable prefix and applies equally to `materialize`,
+`generate`, streaming, media, and `run`:
+
+```rust
+use rstructor::{Instructor, LLMClient, OpenAIClient, RequestExt};
+use serde::{Deserialize, Serialize};
+
+const RISK_POLICY: &str = "\
+Report gross exposure as a multiple of NAV.
+Use the portfolio's base currency.
+Return status as within_limits or breached.";
+
+#[derive(Debug, Deserialize, Instructor, Serialize)]
+struct RiskSummary {
+    status: String,
+    gross_exposure: f64,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = OpenAIClient::from_env()?;
+    let report = client
+        .with_system(RISK_POLICY)
+        .materialize_with_attempts::<RiskSummary>(
+            "NAV USD 100mm; long USD 92mm; short USD 50mm",
+        )
+        .await?;
+
+    if let Some(usage) = report.cumulative_usage {
+        println!(
+            "input={} cache_read={} cache_write={}",
+            usage.input_tokens,
+            usage.cached_input_tokens,
+            usage.cache_write_input_tokens,
+        );
+    }
+    println!("{:#?}", report.data);
+    Ok(())
+}
+```
+
+Cache counters are subsets of input tokens, not extra tokens. OpenAI, Gemini,
+and xAI can cache eligible exact prefixes implicitly. Anthropic requires
+cache-control configuration; rstructor does not enable paid cache writes by
+default. Current provider-specific thresholds and retention policies are in the
+official [OpenAI](https://developers.openai.com/api/docs/guides/prompt-caching),
+[Anthropic](https://platform.claude.com/docs/en/build-with-claude/prompt-caching),
+[Gemini](https://ai.google.dev/gemini-api/docs/caching), and
+[xAI](https://docs.x.ai/developers/advanced-api-usage/prompt-caching)
+documentation.

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -12,9 +12,10 @@ use crate::backend::{
     MaterializeResult, ModelInfo, StrictSchemaProvider, ThinkingLevel, TokenUsage,
     build_anthropic_message_content, build_http_client, check_response_status,
     compile_strict_schema, generate_with_retry_attempts_with_history,
-    generate_with_retry_with_history, handle_http_error, materialize_request_error,
+    generate_with_retry_attempts_with_initial_messages, generate_with_retry_with_history,
+    generate_with_retry_with_initial_messages, handle_http_error, materialize_request_error,
     materialize_with_media_and_attempts_with_retry, materialize_with_media_with_retry,
-    parse_validate_and_create_output,
+    parse_validate_and_create_output, request_messages,
 };
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
@@ -114,6 +115,8 @@ struct OutputFormat {
 #[derive(Debug, Serialize)]
 struct CompletionRequest {
     model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system: Option<String>,
     messages: Vec<AnthropicMessage>,
     temperature: f32,
     max_tokens: u32,
@@ -121,6 +124,32 @@ struct CompletionRequest {
     thinking: Option<ClaudeThinkingConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     output_format: Option<OutputFormat>,
+}
+
+fn anthropic_request_parts(
+    messages: &[ChatMessage],
+) -> Result<(Option<String>, Vec<AnthropicMessage>)> {
+    let (system, conversation) = match messages.split_first() {
+        Some((message, rest)) if message.role == crate::backend::ChatRole::System => {
+            if !message.media.is_empty() {
+                return Err(RStructorError::Unsupported(
+                    "Anthropic system instructions cannot contain media".to_string(),
+                ));
+            }
+            (Some(message.content.clone()), rest)
+        }
+        _ => (None, messages),
+    };
+    let messages = conversation
+        .iter()
+        .map(|message| {
+            Ok(AnthropicMessage {
+                role: message.role.as_str().to_string(),
+                content: build_anthropic_message_content(message)?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok((system, messages))
 }
 
 /// Claude 5 and recent Opus models reject non-default sampling parameters.
@@ -181,8 +210,30 @@ struct ContentBlock {
 
 #[derive(Debug, Deserialize)]
 struct UsageInfo {
+    #[serde(default)]
     input_tokens: u64,
+    #[serde(default)]
     output_tokens: u64,
+    #[serde(default)]
+    cache_creation_input_tokens: u64,
+    #[serde(default)]
+    cache_read_input_tokens: u64,
+}
+
+impl UsageInfo {
+    fn token_usage(&self, model: impl Into<String>) -> TokenUsage {
+        TokenUsage::new(
+            model,
+            self.input_tokens
+                .saturating_add(self.cache_creation_input_tokens)
+                .saturating_add(self.cache_read_input_tokens),
+            self.output_tokens,
+        )
+        .with_cache_tokens(
+            self.cache_read_input_tokens,
+            self.cache_creation_input_tokens,
+        )
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -317,16 +368,8 @@ impl AnthropicClient {
 
         // Build API messages from conversation history
         // With native structured outputs, we don't need to include schema instructions in the prompt
-        let api_messages: Vec<AnthropicMessage> = messages
-            .iter()
-            .map(|msg| {
-                Ok(AnthropicMessage {
-                    role: msg.role.as_str().to_string(),
-                    content: build_anthropic_message_content(msg)?,
-                })
-            })
-            .collect::<Result<Vec<_>>>()
-            .map_err(MaterializeAttemptError::preflight)?;
+        let (system, api_messages) =
+            anthropic_request_parts(messages).map_err(MaterializeAttemptError::preflight)?;
 
         // Build thinking config for Claude 4.x models
         let is_thinking_model = self.config.model.as_str().contains("sonnet-4")
@@ -361,6 +404,7 @@ impl AnthropicClient {
         );
         let request = CompletionRequest {
             model: self.config.model.as_str().to_string(),
+            system,
             messages: api_messages,
             temperature: effective_temp,
             max_tokens: effective_max_tokens(self.config.max_tokens, thinking_config.as_ref()),
@@ -412,7 +456,7 @@ impl AnthropicClient {
         let usage = completion
             .usage
             .as_ref()
-            .map(|u| TokenUsage::new(model_name.clone(), u.input_tokens, u.output_tokens));
+            .map(|u| u.token_usage(model_name.clone()));
 
         // Extract the content, assuming the first block is text containing JSON
         let raw_response = match completion
@@ -477,20 +521,13 @@ impl AnthropicClient {
         );
 
         // Build API messages, including any attached media blocks
-        let api_messages: Vec<AnthropicMessage> = messages
-            .iter()
-            .map(|msg| {
-                Ok(AnthropicMessage {
-                    role: msg.role.as_str().to_string(),
-                    content: build_anthropic_message_content(msg)?,
-                })
-            })
-            .collect::<Result<Vec<_>>>()?;
+        let (system, api_messages) = anthropic_request_parts(messages)?;
 
         // Build the request (no output_format for raw text generation)
         debug!("Building Anthropic API request for text generation");
         let request = CompletionRequest {
             model: self.config.model.as_str().to_string(),
+            system,
             messages: api_messages,
             temperature: effective_temp,
             max_tokens: effective_max_tokens(self.config.max_tokens, thinking_config.as_ref()),
@@ -536,10 +573,7 @@ impl AnthropicClient {
             .model
             .clone()
             .unwrap_or_else(|| self.config.model.as_str().to_string());
-        let usage = completion
-            .usage
-            .as_ref()
-            .map(|u| TokenUsage::new(model_name, u.input_tokens, u.output_tokens));
+        let usage = completion.usage.as_ref().map(|u| u.token_usage(model_name));
 
         // Extract the content
         debug!("Extracting text content from response blocks");
@@ -639,6 +673,7 @@ impl AnthropicClient {
     /// optionally with a structured-output `output_format`.
     fn stream_body(
         &self,
+        system: Option<&str>,
         prompt: &str,
         output_format: Option<serde_json::Value>,
     ) -> serde_json::Value {
@@ -671,6 +706,9 @@ impl AnthropicClient {
         if let Some(tc) = thinking_config {
             body["thinking"] =
                 serde_json::json!({ "type": tc.thinking_type, "budget_tokens": tc.budget_tokens });
+        }
+        if let Some(system) = system {
+            body["system"] = serde_json::json!(system);
         }
         if let Some(of) = output_format {
             body["output_format"] = of;
@@ -881,6 +919,47 @@ impl LLMClient for AnthropicClient {
         .await
     }
 
+    async fn materialize_request<T>(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        media: &[super::MediaFile],
+    ) -> Result<T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        let output = generate_with_retry_with_initial_messages(
+            |messages: Vec<ChatMessage>| {
+                let this = self;
+                async move { this.materialize_internal::<T>(&messages).await }
+            },
+            request_messages(system, prompt, media),
+            self.config.max_retries,
+        )
+        .await?;
+        Ok(output.data)
+    }
+
+    async fn materialize_request_with_attempts<T>(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        media: &[super::MediaFile],
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        generate_with_retry_attempts_with_initial_messages(
+            |messages: Vec<ChatMessage>| {
+                let this = self;
+                async move { this.materialize_internal::<T>(&messages).await }
+            },
+            request_messages(system, prompt, media),
+            self.config.max_retries,
+        )
+        .await
+    }
+
     #[instrument(
         name = "anthropic_generate",
         skip(self, prompt),
@@ -926,12 +1005,36 @@ impl LLMClient for AnthropicClient {
         self.generate_internal(&[ChatMessage::user(prompt)]).await
     }
 
+    async fn generate_request(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        media: &[super::MediaFile],
+    ) -> Result<String> {
+        let result = self
+            .generate_internal(&request_messages(system, prompt, media))
+            .await?;
+        Ok(result.text)
+    }
+
     #[cfg(feature = "streaming")]
     fn generate_stream<'a>(&'a self, prompt: &'a str) -> crate::backend::streaming::TextStream<'a>
     where
         Self: Sync,
     {
-        let body = self.stream_body(prompt, None);
+        self.generate_stream_request(None, prompt.to_string())
+    }
+
+    #[cfg(feature = "streaming")]
+    fn generate_stream_request<'a>(
+        &'a self,
+        system: Option<String>,
+        prompt: String,
+    ) -> crate::backend::streaming::TextStream<'a>
+    where
+        Self: Sync,
+    {
+        let body = self.stream_body(system.as_deref(), &prompt, None);
         crate::backend::streaming::sse_text_stream(
             self.send_stream(body),
             crate::backend::streaming::anthropic_stream_event,
@@ -943,6 +1046,19 @@ impl LLMClient for AnthropicClient {
     fn materialize_stream<'a, T>(
         &'a self,
         prompt: &'a str,
+    ) -> crate::backend::streaming::ObjectStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        self.materialize_stream_request(None, prompt.to_string())
+    }
+
+    #[cfg(feature = "streaming")]
+    fn materialize_stream_request<'a, T>(
+        &'a self,
+        system: Option<String>,
+        prompt: String,
     ) -> crate::backend::streaming::ObjectStream<'a, T>
     where
         T: Instructor + DeserializeOwned + Send + 'static,
@@ -964,7 +1080,7 @@ impl LLMClient for AnthropicClient {
             "type": "json_schema",
             "schema": schema_json,
         });
-        let body = self.stream_body(prompt, Some(output_format));
+        let body = self.stream_body(system.as_deref(), &prompt, Some(output_format));
         crate::backend::streaming::object_stream(
             self.send_stream(body),
             crate::backend::streaming::anthropic_stream_event,
@@ -976,6 +1092,19 @@ impl LLMClient for AnthropicClient {
     fn materialize_iter<'a, T>(
         &'a self,
         prompt: &'a str,
+    ) -> crate::backend::streaming::ItemStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        self.materialize_iter_request(None, prompt.to_string())
+    }
+
+    #[cfg(feature = "streaming")]
+    fn materialize_iter_request<'a, T>(
+        &'a self,
+        system: Option<String>,
+        prompt: String,
     ) -> crate::backend::streaming::ItemStream<'a, T>
     where
         T: Instructor + DeserializeOwned + Send + 'static,
@@ -995,7 +1124,7 @@ impl LLMClient for AnthropicClient {
         };
         let wrapper = crate::backend::streaming::array_wrapper_schema(item_schema, true);
         let output_format = serde_json::json!({ "type": "json_schema", "schema": wrapper });
-        let body = self.stream_body(prompt, Some(output_format));
+        let body = self.stream_body(system.as_deref(), &prompt, Some(output_format));
         crate::backend::streaming::iter_stream(
             self.send_stream(body),
             crate::backend::streaming::anthropic_stream_event,

--- a/src/backend/any_client.rs
+++ b/src/backend/any_client.rs
@@ -314,6 +314,30 @@ impl LLMClient for AnyClient {
         dispatch!(self, c => c.materialize_with_media_and_attempts(prompt, media).await)
     }
 
+    async fn materialize_request<T>(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        media: &[MediaFile],
+    ) -> Result<T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        dispatch!(self, c => c.materialize_request(system, prompt, media).await)
+    }
+
+    async fn materialize_request_with_attempts<T>(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        media: &[MediaFile],
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        dispatch!(self, c => c.materialize_request_with_attempts(system, prompt, media).await)
+    }
+
     async fn generate(&self, prompt: &str) -> Result<String> {
         dispatch!(self, c => c.generate(prompt).await)
     }
@@ -324,6 +348,53 @@ impl LLMClient for AnyClient {
 
     async fn generate_with_metadata(&self, prompt: &str) -> Result<GenerateResult> {
         dispatch!(self, c => c.generate_with_metadata(prompt).await)
+    }
+
+    async fn generate_request(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        media: &[MediaFile],
+    ) -> Result<String> {
+        dispatch!(self, c => c.generate_request(system, prompt, media).await)
+    }
+
+    #[cfg(feature = "streaming")]
+    fn generate_stream_request<'a>(
+        &'a self,
+        system: Option<String>,
+        prompt: String,
+    ) -> crate::backend::streaming::TextStream<'a>
+    where
+        Self: Sync,
+    {
+        dispatch!(self, c => c.generate_stream_request(system, prompt))
+    }
+
+    #[cfg(feature = "streaming")]
+    fn materialize_stream_request<'a, T>(
+        &'a self,
+        system: Option<String>,
+        prompt: String,
+    ) -> crate::backend::streaming::ObjectStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        dispatch!(self, c => c.materialize_stream_request::<T>(system, prompt))
+    }
+
+    #[cfg(feature = "streaming")]
+    fn materialize_iter_request<'a, T>(
+        &'a self,
+        system: Option<String>,
+        prompt: String,
+    ) -> crate::backend::streaming::ItemStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        dispatch!(self, c => c.materialize_iter_request::<T>(system, prompt))
     }
 
     /// Auto-detect a provider from the environment.

--- a/src/backend/client.rs
+++ b/src/backend/client.rs
@@ -513,6 +513,134 @@ pub trait LLMClient {
         }))
     }
 
+    /// Internal request-builder hook that preserves system instructions for
+    /// clients with first-class message support.
+    ///
+    /// Custom clients inherit the legacy concatenation fallback. Built-in
+    /// clients override this hook and send `system` through the provider's
+    /// native system-instruction field or message role.
+    #[doc(hidden)]
+    async fn materialize_request<T>(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        media: &[MediaFile],
+    ) -> Result<T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        let prompt = combine_system_prompt(system, prompt);
+        if media.is_empty() {
+            self.materialize(&prompt).await
+        } else {
+            self.materialize_with_media(&prompt, media).await
+        }
+    }
+
+    /// Internal attempt-ledger request-builder hook.
+    #[doc(hidden)]
+    async fn materialize_request_with_attempts<T>(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        media: &[MediaFile],
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        let prompt = combine_system_prompt(system, prompt);
+        if media.is_empty() {
+            self.materialize_with_attempts(&prompt).await
+        } else {
+            self.materialize_with_media_and_attempts(&prompt, media)
+                .await
+        }
+    }
+
+    /// Internal text-generation request-builder hook.
+    #[doc(hidden)]
+    async fn generate_request(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        media: &[MediaFile],
+    ) -> Result<String> {
+        let prompt = combine_system_prompt(system, prompt);
+        if media.is_empty() {
+            self.generate(&prompt).await
+        } else {
+            self.generate_with_media(&prompt, media).await
+        }
+    }
+
+    /// Internal streaming request-builder hook for raw text.
+    #[cfg(feature = "streaming")]
+    #[doc(hidden)]
+    fn generate_stream_request<'a>(
+        &'a self,
+        system: Option<String>,
+        prompt: String,
+    ) -> crate::backend::streaming::TextStream<'a>
+    where
+        Self: Sync,
+    {
+        use futures_util::StreamExt;
+
+        Box::pin(async_stream::try_stream! {
+            let combined = combine_system_prompt(system.as_deref(), &prompt);
+            let mut inner = self.generate_stream(&combined);
+            while let Some(chunk) = inner.next().await {
+                yield chunk?;
+            }
+        })
+    }
+
+    /// Internal streaming request-builder hook for one structured object.
+    #[cfg(feature = "streaming")]
+    #[doc(hidden)]
+    fn materialize_stream_request<'a, T>(
+        &'a self,
+        system: Option<String>,
+        prompt: String,
+    ) -> crate::backend::streaming::ObjectStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        use futures_util::StreamExt;
+
+        Box::pin(async_stream::try_stream! {
+            let combined = combine_system_prompt(system.as_deref(), &prompt);
+            let mut inner = self.materialize_stream::<T>(&combined);
+            while let Some(value) = inner.next().await {
+                yield value?;
+            }
+        })
+    }
+
+    /// Internal streaming request-builder hook for structured list items.
+    #[cfg(feature = "streaming")]
+    #[doc(hidden)]
+    fn materialize_iter_request<'a, T>(
+        &'a self,
+        system: Option<String>,
+        prompt: String,
+    ) -> crate::backend::streaming::ItemStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        use futures_util::StreamExt;
+
+        Box::pin(async_stream::try_stream! {
+            let combined = combine_system_prompt(system.as_deref(), &prompt);
+            let mut inner = self.materialize_iter::<T>(&combined);
+            while let Some(item) = inner.next().await {
+                yield item?;
+            }
+        })
+    }
+
     /// Create a new client by reading the API key from an environment variable.
     ///
     /// This is a required associated function that all `LLMClient` implementations must provide.
@@ -551,4 +679,11 @@ pub trait LLMClient {
     /// # }
     /// ```
     async fn list_models(&self) -> Result<Vec<ModelInfo>>;
+}
+
+fn combine_system_prompt(system: Option<&str>, prompt: &str) -> String {
+    match system {
+        Some(system) => format!("{system}\n\n{prompt}"),
+        None => prompt.to_string(),
+    }
 }

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -10,9 +10,10 @@ use crate::backend::{
     ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient, MaterializeAttemptError,
     MaterializeFailure, MaterializeInternalOutput, MaterializeReport, MaterializeResult, ModelInfo,
     ThinkingLevel, TokenUsage, build_http_client, check_response_status,
-    generate_with_retry_attempts_with_history, generate_with_retry_with_history, handle_http_error,
+    generate_with_retry_attempts_with_history, generate_with_retry_attempts_with_initial_messages,
+    generate_with_retry_with_history, generate_with_retry_with_initial_messages, handle_http_error,
     materialize_request_error, materialize_with_media_and_attempts_with_retry,
-    materialize_with_media_with_retry, parse_validate_and_create_output,
+    materialize_with_media_with_retry, parse_validate_and_create_output, request_messages,
 };
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
@@ -152,6 +153,8 @@ struct InlineData {
 
 #[derive(Debug, Serialize)]
 struct GenerateContentRequest {
+    #[serde(skip_serializing_if = "Option::is_none", rename = "systemInstruction")]
+    system_instruction: Option<Content>,
     contents: Vec<Content>,
     generation_config: GenerationConfig,
 }
@@ -181,6 +184,15 @@ struct UsageMetadata {
     prompt_token_count: u64,
     #[serde(rename = "candidatesTokenCount", default)]
     candidates_token_count: u64,
+    #[serde(rename = "cachedContentTokenCount", default)]
+    cached_content_token_count: u64,
+}
+
+impl UsageMetadata {
+    fn token_usage(&self, model: impl Into<String>) -> TokenUsage {
+        TokenUsage::new(model, self.prompt_token_count, self.candidates_token_count)
+            .with_cache_tokens(self.cached_content_token_count, 0)
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -212,8 +224,20 @@ struct CandidatePart {
 /// Convert provider-agnostic chat messages into Gemini `contents`, including any
 /// attached media as `inlineData` (base64) or `fileData` (URI) parts. Gemini
 /// passes the MIME type through, so images and PDFs share the same encoding.
-fn chat_messages_to_contents(messages: &[ChatMessage]) -> Vec<Content> {
-    messages
+fn gemini_request_parts(messages: &[ChatMessage]) -> (Option<Content>, Vec<Content>) {
+    let (system_instruction, conversation) = match messages.split_first() {
+        Some((message, rest)) if message.role == crate::backend::ChatRole::System => (
+            Some(Content {
+                role: None,
+                parts: vec![Part::Text {
+                    text: message.content.clone(),
+                }],
+            }),
+            rest,
+        ),
+        _ => (None, messages),
+    };
+    let contents = conversation
         .iter()
         .map(|msg| {
             // Gemini uses "user" and "model" (not "assistant")
@@ -250,7 +274,8 @@ fn chat_messages_to_contents(messages: &[ChatMessage]) -> Vec<Content> {
                 parts,
             }
         })
-        .collect()
+        .collect();
+    (system_instruction, contents)
 }
 
 impl GeminiClient {
@@ -373,7 +398,7 @@ impl GeminiClient {
 
         // Build API contents from conversation history
         // With native responseJsonSchema, we don't need to include schema instructions in the prompt
-        let contents = chat_messages_to_contents(messages);
+        let (system_instruction, contents) = gemini_request_parts(messages);
 
         // Build thinking config only for Gemini 3.x models
         let is_gemini3 = self.config.model.as_str().starts_with("gemini-3");
@@ -405,6 +430,7 @@ impl GeminiClient {
         };
 
         let request = GenerateContentRequest {
+            system_instruction,
             contents,
             generation_config,
         };
@@ -451,13 +477,10 @@ impl GeminiClient {
             .model_version
             .clone()
             .unwrap_or_else(|| self.config.model.as_str().to_string());
-        let usage = completion.usage_metadata.as_ref().map(|u| {
-            TokenUsage::new(
-                model_name.clone(),
-                u.prompt_token_count,
-                u.candidates_token_count,
-            )
-        });
+        let usage = completion
+            .usage_metadata
+            .as_ref()
+            .map(|u| u.token_usage(model_name.clone()));
 
         if completion.candidates.is_empty() {
             error!("Gemini API returned empty candidates array");
@@ -535,8 +558,10 @@ impl GeminiClient {
 
         // Build the request, including any attached media parts
         debug!("Building Gemini API request");
+        let (system_instruction, contents) = gemini_request_parts(messages);
         let request = GenerateContentRequest {
-            contents: chat_messages_to_contents(messages),
+            system_instruction,
+            contents,
             generation_config: GenerationConfig {
                 temperature: self.config.temperature,
                 max_output_tokens: self.config.max_tokens,
@@ -599,7 +624,7 @@ impl GeminiClient {
         let usage = completion
             .usage_metadata
             .as_ref()
-            .map(|u| TokenUsage::new(model_name, u.prompt_token_count, u.candidates_token_count));
+            .map(|u| u.token_usage(model_name));
 
         let candidate = &completion.candidates[0];
         trace!(finish_reason = %candidate.finish_reason, "Completion finish reason");
@@ -702,7 +727,12 @@ impl GeminiClient {
     /// Build the JSON request body for a streaming call, optionally with a
     /// structured-output `responseJsonSchema`. (Gemini streams via the
     /// `:streamGenerateContent?alt=sse` endpoint; the body itself is unchanged.)
-    fn stream_body(&self, prompt: &str, response_json_schema: Option<Value>) -> Value {
+    fn stream_body(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        response_json_schema: Option<Value>,
+    ) -> Value {
         let is_gemini3 = self.config.model.as_str().starts_with("gemini-3");
         let thinking_config = if is_gemini3 {
             self.config.thinking_level.and_then(|level| {
@@ -714,6 +744,12 @@ impl GeminiClient {
             None
         };
         let request = GenerateContentRequest {
+            system_instruction: system.map(|system| Content {
+                role: None,
+                parts: vec![Part::Text {
+                    text: system.to_string(),
+                }],
+            }),
             contents: vec![Content {
                 role: Some("user".to_string()),
                 parts: vec![Part::Text {
@@ -933,6 +969,47 @@ impl LLMClient for GeminiClient {
         .await
     }
 
+    async fn materialize_request<T>(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        media: &[super::MediaFile],
+    ) -> Result<T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        let output = generate_with_retry_with_initial_messages(
+            |messages: Vec<ChatMessage>| {
+                let this = self;
+                async move { this.materialize_internal::<T>(&messages).await }
+            },
+            request_messages(system, prompt, media),
+            self.config.max_retries,
+        )
+        .await?;
+        Ok(output.data)
+    }
+
+    async fn materialize_request_with_attempts<T>(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        media: &[super::MediaFile],
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        generate_with_retry_attempts_with_initial_messages(
+            |messages: Vec<ChatMessage>| {
+                let this = self;
+                async move { this.materialize_internal::<T>(&messages).await }
+            },
+            request_messages(system, prompt, media),
+            self.config.max_retries,
+        )
+        .await
+    }
+
     #[instrument(
         name = "gemini_generate",
         skip(self, prompt),
@@ -978,12 +1055,36 @@ impl LLMClient for GeminiClient {
         self.generate_internal(&[ChatMessage::user(prompt)]).await
     }
 
+    async fn generate_request(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        media: &[super::MediaFile],
+    ) -> Result<String> {
+        let result = self
+            .generate_internal(&request_messages(system, prompt, media))
+            .await?;
+        Ok(result.text)
+    }
+
     #[cfg(feature = "streaming")]
     fn generate_stream<'a>(&'a self, prompt: &'a str) -> crate::backend::streaming::TextStream<'a>
     where
         Self: Sync,
     {
-        let body = self.stream_body(prompt, None);
+        self.generate_stream_request(None, prompt.to_string())
+    }
+
+    #[cfg(feature = "streaming")]
+    fn generate_stream_request<'a>(
+        &'a self,
+        system: Option<String>,
+        prompt: String,
+    ) -> crate::backend::streaming::TextStream<'a>
+    where
+        Self: Sync,
+    {
+        let body = self.stream_body(system.as_deref(), &prompt, None);
         crate::backend::streaming::sse_text_stream(
             self.send_stream(body),
             crate::backend::streaming::gemini_stream_event,
@@ -995,6 +1096,19 @@ impl LLMClient for GeminiClient {
     fn materialize_stream<'a, T>(
         &'a self,
         prompt: &'a str,
+    ) -> crate::backend::streaming::ObjectStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        self.materialize_stream_request(None, prompt.to_string())
+    }
+
+    #[cfg(feature = "streaming")]
+    fn materialize_stream_request<'a, T>(
+        &'a self,
+        system: Option<String>,
+        prompt: String,
     ) -> crate::backend::streaming::ObjectStream<'a, T>
     where
         T: Instructor + DeserializeOwned + Send + 'static,
@@ -1013,7 +1127,7 @@ impl LLMClient for GeminiClient {
                 Ok(schema) => schema,
                 Err(error) => return crate::backend::streaming::error_stream(error),
             };
-        let body = self.stream_body(prompt, Some(gemini_schema));
+        let body = self.stream_body(system.as_deref(), &prompt, Some(gemini_schema));
 
         let finalize = move |raw: &str| -> Result<T> {
             let mut json = raw.to_string();
@@ -1043,6 +1157,19 @@ impl LLMClient for GeminiClient {
         T: Instructor + DeserializeOwned + Send + 'static,
         Self: Sync,
     {
+        self.materialize_iter_request(None, prompt.to_string())
+    }
+
+    #[cfg(feature = "streaming")]
+    fn materialize_iter_request<'a, T>(
+        &'a self,
+        system: Option<String>,
+        prompt: String,
+    ) -> crate::backend::streaming::ItemStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
         let schema = match T::try_schema() {
             Ok(schema) => schema,
             Err(error) => return crate::backend::streaming::error_stream(error),
@@ -1055,7 +1182,7 @@ impl LLMClient for GeminiClient {
                 Err(error) => return crate::backend::streaming::error_stream(error),
             };
         let wrapper = crate::backend::streaming::array_wrapper_schema(item_schema, false);
-        let body = self.stream_body(prompt, Some(wrapper));
+        let body = self.stream_body(system.as_deref(), &prompt, Some(wrapper));
 
         // Each streamed array element is a `T`; transform internally-tagged enums
         // back before deserializing.

--- a/src/backend/grok.rs
+++ b/src/backend/grok.rs
@@ -8,11 +8,12 @@ use crate::backend::{
     ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient, MaterializeAttemptError,
     MaterializeFailure, MaterializeInternalOutput, MaterializeReport, MaterializeResult, ModelInfo,
     OpenAICompatibleChatCompletionRequest, OpenAICompatibleChatCompletionResponse, ResponseFormat,
-    StrictSchemaProvider, TokenUsage, build_http_client, check_response_status,
-    compile_strict_schema, convert_openai_compatible_chat_messages,
-    generate_with_retry_attempts_with_history, generate_with_retry_with_history, handle_http_error,
-    materialize_request_error, materialize_with_media_and_attempts_with_retry,
-    materialize_with_media_with_retry, parse_validate_and_create_output,
+    StrictSchemaProvider, build_http_client, check_response_status, compile_strict_schema,
+    convert_openai_compatible_chat_messages, generate_with_retry_attempts_with_history,
+    generate_with_retry_attempts_with_initial_messages, generate_with_retry_with_history,
+    generate_with_retry_with_initial_messages, handle_http_error, materialize_request_error,
+    materialize_with_media_and_attempts_with_retry, materialize_with_media_with_retry,
+    parse_validate_and_create_output, request_messages,
 };
 #[cfg(feature = "streaming")]
 use crate::backend::{OpenAICompatibleChatMessage, OpenAICompatibleMessageContent};
@@ -261,7 +262,7 @@ impl GrokClient {
         let usage = completion
             .usage
             .as_ref()
-            .map(|u| TokenUsage::new(model_name.clone(), u.prompt_tokens, u.completion_tokens));
+            .map(|u| u.token_usage(model_name.clone()));
 
         if completion.choices.is_empty() {
             error!("Grok API returned empty choices array");
@@ -367,10 +368,7 @@ impl GrokClient {
             .model
             .clone()
             .unwrap_or_else(|| self.config.model.as_str().to_string());
-        let usage = completion
-            .usage
-            .as_ref()
-            .map(|u| TokenUsage::new(model_name, u.prompt_tokens, u.completion_tokens));
+        let usage = completion.usage.as_ref().map(|u| u.token_usage(model_name));
 
         let message = &completion.choices[0].message;
         trace!(finish_reason = %completion.choices[0].finish_reason, "Completion finish reason");
@@ -426,15 +424,24 @@ impl GrokClient {
     /// optionally with a structured-output `response_format`.
     fn stream_body(
         &self,
+        system: Option<&str>,
         prompt: &str,
         response_format: Option<ResponseFormat>,
     ) -> serde_json::Value {
+        let mut messages = Vec::with_capacity(usize::from(system.is_some()) + 1);
+        if let Some(system) = system {
+            messages.push(OpenAICompatibleChatMessage {
+                role: "system".to_string(),
+                content: OpenAICompatibleMessageContent::Text(system.to_string()),
+            });
+        }
+        messages.push(OpenAICompatibleChatMessage {
+            role: "user".to_string(),
+            content: OpenAICompatibleMessageContent::Text(prompt.to_string()),
+        });
         let request = OpenAICompatibleChatCompletionRequest {
             model: self.config.model.as_str().to_string(),
-            messages: vec![OpenAICompatibleChatMessage {
-                role: "user".to_string(),
-                content: OpenAICompatibleMessageContent::Text(prompt.to_string()),
-            }],
+            messages,
             response_format,
             temperature: self.config.temperature,
             max_tokens: self.config.max_tokens,
@@ -648,6 +655,47 @@ impl LLMClient for GrokClient {
         .await
     }
 
+    async fn materialize_request<T>(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        media: &[super::MediaFile],
+    ) -> Result<T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        let output = generate_with_retry_with_initial_messages(
+            |messages: Vec<ChatMessage>| {
+                let this = self;
+                async move { this.materialize_internal::<T>(&messages).await }
+            },
+            request_messages(system, prompt, media),
+            self.config.max_retries,
+        )
+        .await?;
+        Ok(output.data)
+    }
+
+    async fn materialize_request_with_attempts<T>(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        media: &[super::MediaFile],
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        generate_with_retry_attempts_with_initial_messages(
+            |messages: Vec<ChatMessage>| {
+                let this = self;
+                async move { this.materialize_internal::<T>(&messages).await }
+            },
+            request_messages(system, prompt, media),
+            self.config.max_retries,
+        )
+        .await
+    }
+
     #[instrument(
         name = "grok_generate",
         skip(self, prompt),
@@ -693,12 +741,36 @@ impl LLMClient for GrokClient {
         self.generate_internal(&[ChatMessage::user(prompt)]).await
     }
 
+    async fn generate_request(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        media: &[super::MediaFile],
+    ) -> Result<String> {
+        let result = self
+            .generate_internal(&request_messages(system, prompt, media))
+            .await?;
+        Ok(result.text)
+    }
+
     #[cfg(feature = "streaming")]
     fn generate_stream<'a>(&'a self, prompt: &'a str) -> crate::backend::streaming::TextStream<'a>
     where
         Self: Sync,
     {
-        let body = self.stream_body(prompt, None);
+        self.generate_stream_request(None, prompt.to_string())
+    }
+
+    #[cfg(feature = "streaming")]
+    fn generate_stream_request<'a>(
+        &'a self,
+        system: Option<String>,
+        prompt: String,
+    ) -> crate::backend::streaming::TextStream<'a>
+    where
+        Self: Sync,
+    {
+        let body = self.stream_body(system.as_deref(), &prompt, None);
         crate::backend::streaming::sse_text_stream(
             self.send_stream(body),
             crate::backend::streaming::openai_stream_event,
@@ -710,6 +782,19 @@ impl LLMClient for GrokClient {
     fn materialize_stream<'a, T>(
         &'a self,
         prompt: &'a str,
+    ) -> crate::backend::streaming::ObjectStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        self.materialize_stream_request(None, prompt.to_string())
+    }
+
+    #[cfg(feature = "streaming")]
+    fn materialize_stream_request<'a, T>(
+        &'a self,
+        system: Option<String>,
+        prompt: String,
     ) -> crate::backend::streaming::ObjectStream<'a, T>
     where
         T: Instructor + DeserializeOwned + Send + 'static,
@@ -729,7 +814,7 @@ impl LLMClient for GrokClient {
             Err(error) => return crate::backend::streaming::error_stream(error),
         };
         let response_format = ResponseFormat::json_schema(schema_name, schema_json, None);
-        let body = self.stream_body(prompt, Some(response_format));
+        let body = self.stream_body(system.as_deref(), &prompt, Some(response_format));
         crate::backend::streaming::object_stream(
             self.send_stream(body),
             crate::backend::streaming::openai_stream_event,
@@ -746,6 +831,19 @@ impl LLMClient for GrokClient {
         T: Instructor + DeserializeOwned + Send + 'static,
         Self: Sync,
     {
+        self.materialize_iter_request(None, prompt.to_string())
+    }
+
+    #[cfg(feature = "streaming")]
+    fn materialize_iter_request<'a, T>(
+        &'a self,
+        system: Option<String>,
+        prompt: String,
+    ) -> crate::backend::streaming::ItemStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
         let schema = match T::try_schema() {
             Ok(schema) => schema,
             Err(error) => return crate::backend::streaming::error_stream(error),
@@ -757,7 +855,7 @@ impl LLMClient for GrokClient {
             };
         let wrapper = crate::backend::streaming::array_wrapper_schema(item_schema, true);
         let response_format = ResponseFormat::json_schema("items".to_string(), wrapper, None);
-        let body = self.stream_body(prompt, Some(response_format));
+        let body = self.stream_body(system.as_deref(), &prompt, Some(response_format));
         crate::backend::streaming::iter_stream(
             self.send_stream(body),
             crate::backend::streaming::openai_stream_event,

--- a/src/backend/messages.rs
+++ b/src/backend/messages.rs
@@ -101,6 +101,20 @@ impl ChatMessage {
     }
 }
 
+#[cfg(feature = "_client")]
+pub(crate) fn request_messages(
+    system: Option<&str>,
+    prompt: &str,
+    media: &[MediaFile],
+) -> Vec<ChatMessage> {
+    let mut messages = Vec::with_capacity(usize::from(system.is_some()) + 1);
+    if let Some(system) = system {
+        messages.push(ChatMessage::system(system));
+    }
+    messages.push(ChatMessage::user_with_media(prompt, media.to_vec()));
+    messages
+}
+
 /// Result from a materialize internal call, including the raw response for retry handling.
 ///
 /// This struct captures both the successfully parsed data and the raw response string,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -36,9 +36,9 @@ pub mod openai;
 #[cfg(feature = "_client")]
 pub use any_client::{AnyClient, Provider};
 pub use client::{LLMClient, MediaFile};
-#[cfg(feature = "_client")]
-pub(crate) use messages::MaterializeAttemptError;
 pub use messages::{ChatMessage, ChatRole};
+#[cfg(feature = "_client")]
+pub(crate) use messages::{MaterializeAttemptError, request_messages};
 #[cfg(feature = "_client")]
 pub use messages::{MaterializeInternalOutput, ValidationFailureContext};
 #[cfg(feature = "mock")]
@@ -105,7 +105,8 @@ pub use utils::{DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT};
 #[cfg(feature = "_client")]
 pub(crate) use utils::{
     ResponseFormat, build_http_client, check_response_status,
-    generate_with_retry_attempts_with_history, generate_with_retry_with_history, handle_http_error,
+    generate_with_retry_attempts_with_history, generate_with_retry_attempts_with_initial_messages,
+    generate_with_retry_with_history, generate_with_retry_with_initial_messages, handle_http_error,
     materialize_request_error, materialize_with_media_and_attempts_with_retry,
     materialize_with_media_with_retry, parse_validate_and_create_output,
 };

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -12,11 +12,12 @@ use crate::backend::{
     ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient, MaterializeAttemptError,
     MaterializeFailure, MaterializeInternalOutput, MaterializeReport, MaterializeResult, ModelInfo,
     OpenAICompatibleChatCompletionRequest, OpenAICompatibleChatCompletionResponse, ResponseFormat,
-    StrictSchemaProvider, ThinkingLevel, TokenUsage, build_http_client, check_response_status,
+    StrictSchemaProvider, ThinkingLevel, build_http_client, check_response_status,
     compile_strict_schema, convert_openai_compatible_chat_messages,
-    generate_with_retry_attempts_with_history, generate_with_retry_with_history, handle_http_error,
+    generate_with_retry_attempts_with_history, generate_with_retry_attempts_with_initial_messages,
+    generate_with_retry_with_history, generate_with_retry_with_initial_messages, handle_http_error,
     materialize_request_error, materialize_with_media_and_attempts_with_retry,
-    materialize_with_media_with_retry, parse_validate_and_create_output,
+    materialize_with_media_with_retry, parse_validate_and_create_output, request_messages,
 };
 #[cfg(feature = "streaming")]
 use crate::backend::{OpenAICompatibleChatMessage, OpenAICompatibleMessageContent};
@@ -539,7 +540,7 @@ impl OpenAIClient {
         let usage = completion
             .usage
             .as_ref()
-            .map(|u| TokenUsage::new(model_name.clone(), u.prompt_tokens, u.completion_tokens));
+            .map(|u| u.token_usage(model_name.clone()));
 
         if completion.choices.is_empty() {
             error!("OpenAI returned empty choices array");
@@ -657,10 +658,7 @@ impl OpenAIClient {
             .model
             .clone()
             .unwrap_or_else(|| self.config.model.as_str().to_string());
-        let usage = completion
-            .usage
-            .as_ref()
-            .map(|u| TokenUsage::new(model_name, u.prompt_tokens, u.completion_tokens));
+        let usage = completion.usage.as_ref().map(|u| u.token_usage(model_name));
 
         let message = &completion.choices[0].message;
         trace!(finish_reason = %completion.choices[0].finish_reason, "Completion finish reason");
@@ -689,6 +687,7 @@ impl OpenAIClient {
     /// optionally with a structured-output `response_format`.
     fn stream_body(
         &self,
+        system: Option<&str>,
         prompt: &str,
         response_format: Option<ResponseFormat>,
     ) -> serde_json::Value {
@@ -705,12 +704,20 @@ impl OpenAIClient {
         } else {
             self.config.temperature
         };
+        let mut messages = Vec::with_capacity(usize::from(system.is_some()) + 1);
+        if let Some(system) = system {
+            messages.push(OpenAICompatibleChatMessage {
+                role: "system".to_string(),
+                content: OpenAICompatibleMessageContent::Text(system.to_string()),
+            });
+        }
+        messages.push(OpenAICompatibleChatMessage {
+            role: "user".to_string(),
+            content: OpenAICompatibleMessageContent::Text(prompt.to_string()),
+        });
         let request = OpenAICompatibleChatCompletionRequest {
             model: self.config.model.as_str().to_string(),
-            messages: vec![OpenAICompatibleChatMessage {
-                role: "user".to_string(),
-                content: OpenAICompatibleMessageContent::Text(prompt.to_string()),
-            }],
+            messages,
             response_format,
             temperature: effective_temp,
             max_tokens: self.config.max_tokens,
@@ -938,6 +945,47 @@ impl LLMClient for OpenAIClient {
         .await
     }
 
+    async fn materialize_request<T>(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        media: &[super::MediaFile],
+    ) -> Result<T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        let output = generate_with_retry_with_initial_messages(
+            |messages: Vec<ChatMessage>| {
+                let this = self;
+                async move { this.materialize_internal::<T>(&messages).await }
+            },
+            request_messages(system, prompt, media),
+            self.config.max_retries,
+        )
+        .await?;
+        Ok(output.data)
+    }
+
+    async fn materialize_request_with_attempts<T>(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        media: &[super::MediaFile],
+    ) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        generate_with_retry_attempts_with_initial_messages(
+            |messages: Vec<ChatMessage>| {
+                let this = self;
+                async move { this.materialize_internal::<T>(&messages).await }
+            },
+            request_messages(system, prompt, media),
+            self.config.max_retries,
+        )
+        .await
+    }
+
     #[instrument(
         name = "openai_generate",
         skip(self, prompt),
@@ -983,12 +1031,36 @@ impl LLMClient for OpenAIClient {
         self.generate_internal(&[ChatMessage::user(prompt)]).await
     }
 
+    async fn generate_request(
+        &self,
+        system: Option<&str>,
+        prompt: &str,
+        media: &[super::MediaFile],
+    ) -> Result<String> {
+        let result = self
+            .generate_internal(&request_messages(system, prompt, media))
+            .await?;
+        Ok(result.text)
+    }
+
     #[cfg(feature = "streaming")]
     fn generate_stream<'a>(&'a self, prompt: &'a str) -> crate::backend::streaming::TextStream<'a>
     where
         Self: Sync,
     {
-        let body = self.stream_body(prompt, None);
+        self.generate_stream_request(None, prompt.to_string())
+    }
+
+    #[cfg(feature = "streaming")]
+    fn generate_stream_request<'a>(
+        &'a self,
+        system: Option<String>,
+        prompt: String,
+    ) -> crate::backend::streaming::TextStream<'a>
+    where
+        Self: Sync,
+    {
+        let body = self.stream_body(system.as_deref(), &prompt, None);
         crate::backend::streaming::sse_text_stream(
             self.send_stream(body),
             crate::backend::streaming::openai_stream_event,
@@ -1000,6 +1072,19 @@ impl LLMClient for OpenAIClient {
     fn materialize_stream<'a, T>(
         &'a self,
         prompt: &'a str,
+    ) -> crate::backend::streaming::ObjectStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        self.materialize_stream_request(None, prompt.to_string())
+    }
+
+    #[cfg(feature = "streaming")]
+    fn materialize_stream_request<'a, T>(
+        &'a self,
+        system: Option<String>,
+        prompt: String,
     ) -> crate::backend::streaming::ObjectStream<'a, T>
     where
         T: Instructor + DeserializeOwned + Send + 'static,
@@ -1023,7 +1108,7 @@ impl LLMClient for OpenAIClient {
             schema_json,
             Some("Output in the specified format. Include ALL required fields and follow the schema exactly.".to_string()),
         );
-        let body = self.stream_body(prompt, Some(response_format));
+        let body = self.stream_body(system.as_deref(), &prompt, Some(response_format));
         crate::backend::streaming::object_stream(
             self.send_stream(body),
             crate::backend::streaming::openai_stream_event,
@@ -1035,6 +1120,19 @@ impl LLMClient for OpenAIClient {
     fn materialize_iter<'a, T>(
         &'a self,
         prompt: &'a str,
+    ) -> crate::backend::streaming::ItemStream<'a, T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+        Self: Sync,
+    {
+        self.materialize_iter_request(None, prompt.to_string())
+    }
+
+    #[cfg(feature = "streaming")]
+    fn materialize_iter_request<'a, T>(
+        &'a self,
+        system: Option<String>,
+        prompt: String,
     ) -> crate::backend::streaming::ItemStream<'a, T>
     where
         T: Instructor + DeserializeOwned + Send + 'static,
@@ -1055,7 +1153,7 @@ impl LLMClient for OpenAIClient {
             wrapper,
             Some("Return a JSON object with an `items` array; each element must follow the item schema exactly.".to_string()),
         );
-        let body = self.stream_body(prompt, Some(response_format));
+        let body = self.stream_body(system.as_deref(), &prompt, Some(response_format));
         crate::backend::streaming::iter_stream(
             self.send_stream(body),
             crate::backend::streaming::openai_stream_event,

--- a/src/backend/openai_compatible.rs
+++ b/src/backend/openai_compatible.rs
@@ -63,6 +63,25 @@ pub(crate) struct OpenAICompatibleUsageInfo {
     pub completion_tokens: u64,
     #[serde(default)]
     pub total_tokens: u64,
+    #[serde(default)]
+    pub prompt_tokens_details: OpenAICompatiblePromptTokensDetails,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct OpenAICompatiblePromptTokensDetails {
+    #[serde(default)]
+    pub cached_tokens: u64,
+    #[serde(default)]
+    pub cache_write_tokens: u64,
+}
+
+impl OpenAICompatibleUsageInfo {
+    pub(crate) fn token_usage(&self, model: impl Into<String>) -> crate::TokenUsage {
+        crate::TokenUsage::new(model, self.prompt_tokens, self.completion_tokens).with_cache_tokens(
+            self.prompt_tokens_details.cached_tokens,
+            self.prompt_tokens_details.cache_write_tokens,
+        )
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -231,6 +250,8 @@ mod tests {
         assert_eq!(usage.prompt_tokens, 3);
         assert_eq!(usage.completion_tokens, 5);
         assert_eq!(usage.total_tokens, 0);
+        assert_eq!(usage.prompt_tokens_details.cached_tokens, 0);
+        assert_eq!(usage.prompt_tokens_details.cache_write_tokens, 0);
     }
 
     /// When `total_tokens` is present in the response body it must be preserved
@@ -246,5 +267,25 @@ mod tests {
             serde_json::from_value(json).expect("deserialization should succeed");
 
         assert_eq!(usage.total_tokens, 8);
+    }
+
+    #[test]
+    fn test_usage_info_preserves_prompt_cache_details() {
+        let json = serde_json::json!({
+            "prompt_tokens": 2048,
+            "completion_tokens": 125,
+            "total_tokens": 2173,
+            "prompt_tokens_details": {
+                "cached_tokens": 1024,
+                "cache_write_tokens": 768,
+            },
+        });
+        let usage: OpenAICompatibleUsageInfo =
+            serde_json::from_value(json).expect("deserialization should succeed");
+
+        assert_eq!(
+            usage.token_usage("gpt-5.6"),
+            crate::TokenUsage::new("gpt-5.6", 2048, 125).with_cache_tokens(1024, 768)
+        );
     }
 }

--- a/src/backend/request.rs
+++ b/src/backend/request.rs
@@ -57,9 +57,14 @@ impl<'a, C: ?Sized> Request<'a, C> {
         }
     }
 
-    /// Attach system/context instructions, prepended to the prompt (for
-    /// `materialize`/`generate`) or sent as the provider's system prompt (for
-    /// tool `run`).
+    /// Attach system/context instructions.
+    ///
+    /// Built-in provider clients send this through the provider's first-class
+    /// system field or message role for every terminal. This keeps the static
+    /// instruction prefix separate from the dynamic user prompt, which also
+    /// improves provider prompt-cache reuse. Custom [`LLMClient`]
+    /// implementations inherit a backwards-compatible concatenation fallback
+    /// unless they override the request hooks on that trait.
     #[must_use]
     pub fn system(mut self, system: impl Into<String>) -> Self {
         self.system = Some(system.into());
@@ -91,14 +96,6 @@ impl<'a, C: ?Sized> Request<'a, C> {
         self.max_iterations = max_iterations;
         self
     }
-
-    /// Prompt with the system context prepended, if any.
-    fn combined(&self, prompt: &str) -> String {
-        match &self.system {
-            Some(system) => format!("{system}\n\n{prompt}"),
-            None => prompt.to_string(),
-        }
-    }
 }
 
 impl<C: LLMClient + Sync + ?Sized> Request<'_, C> {
@@ -107,14 +104,9 @@ impl<C: LLMClient + Sync + ?Sized> Request<'_, C> {
     where
         T: Instructor + DeserializeOwned + Send + 'static,
     {
-        let prompt = self.combined(prompt);
-        if self.media.is_empty() {
-            self.client.materialize(&prompt).await
-        } else {
-            self.client
-                .materialize_with_media(&prompt, &self.media)
-                .await
-        }
+        self.client
+            .materialize_request(self.system.as_deref(), prompt, &self.media)
+            .await
     }
 
     /// Materialize a structured `T` with cumulative usage and every provider attempt.
@@ -125,31 +117,23 @@ impl<C: LLMClient + Sync + ?Sized> Request<'_, C> {
     where
         T: Instructor + DeserializeOwned + Send + 'static,
     {
-        let prompt = self.combined(prompt);
-        if self.media.is_empty() {
-            self.client.materialize_with_attempts(&prompt).await
-        } else {
-            self.client
-                .materialize_with_media_and_attempts(&prompt, &self.media)
-                .await
-        }
+        self.client
+            .materialize_request_with_attempts(self.system.as_deref(), prompt, &self.media)
+            .await
     }
 
     /// Generate raw text, applying any attached system context and media.
     pub async fn generate(self, prompt: &str) -> Result<String> {
-        let prompt = self.combined(prompt);
-        if self.media.is_empty() {
-            self.client.generate(&prompt).await
-        } else {
-            self.client.generate_with_media(&prompt, &self.media).await
-        }
+        self.client
+            .generate_request(self.system.as_deref(), prompt, &self.media)
+            .await
     }
 }
 
 #[cfg(feature = "streaming")]
 impl<'a, C: LLMClient + Sync + ?Sized> Request<'a, C> {
     /// Stream a **list** of structured `T`, yielding each item as soon as it is
-    /// fully generated and validated, with any attached system context prepended.
+    /// fully generated and validated, with any attached system context applied.
     ///
     /// If media is attached, the stream yields one
     /// [`RStructorError::Unsupported`](crate::RStructorError::Unsupported) and
@@ -163,18 +147,11 @@ impl<'a, C: LLMClient + Sync + ?Sized> Request<'a, C> {
                 STREAMING_MEDIA_UNSUPPORTED.to_string(),
             ));
         }
-        use futures_util::StreamExt;
-        let combined = self.combined(prompt);
-        let client = self.client;
-        Box::pin(async_stream::try_stream! {
-            let mut inner = client.materialize_iter::<T>(&combined);
-            while let Some(item) = inner.next().await {
-                yield item?;
-            }
-        })
+        self.client
+            .materialize_iter_request::<T>(self.system, prompt.to_string())
     }
 
-    /// Stream raw text deltas, with any attached system context prepended.
+    /// Stream raw text deltas, with any attached system context applied.
     ///
     /// If media is attached, the stream yields one
     /// [`RStructorError::Unsupported`](crate::RStructorError::Unsupported) and
@@ -185,19 +162,12 @@ impl<'a, C: LLMClient + Sync + ?Sized> Request<'a, C> {
                 STREAMING_MEDIA_UNSUPPORTED.to_string(),
             ));
         }
-        use futures_util::StreamExt;
-        let combined = self.combined(prompt);
-        let client = self.client;
-        Box::pin(async_stream::try_stream! {
-            let mut inner = client.generate_stream(&combined);
-            while let Some(chunk) = inner.next().await {
-                yield chunk?;
-            }
-        })
+        self.client
+            .generate_stream_request(self.system, prompt.to_string())
     }
 
     /// Stream a single structured object as its JSON fills in, with any attached
-    /// system context prepended.
+    /// system context applied.
     ///
     /// If media is attached, the stream yields one
     /// [`RStructorError::Unsupported`](crate::RStructorError::Unsupported) and
@@ -214,15 +184,8 @@ impl<'a, C: LLMClient + Sync + ?Sized> Request<'a, C> {
                 STREAMING_MEDIA_UNSUPPORTED.to_string(),
             ));
         }
-        use futures_util::StreamExt;
-        let combined = self.combined(prompt);
-        let client = self.client;
-        Box::pin(async_stream::try_stream! {
-            let mut inner = client.materialize_stream::<T>(&combined);
-            while let Some(obj) = inner.next().await {
-                yield obj?;
-            }
-        })
+        self.client
+            .materialize_stream_request::<T>(self.system, prompt.to_string())
     }
 }
 
@@ -246,12 +209,9 @@ impl<C: crate::backend::tools::ToolRunner + LLMClient + Sync + ?Sized> Request<'
                     .await
             }
             None => {
-                let prompt = self.combined(prompt);
-                if self.media.is_empty() {
-                    self.client.generate(&prompt).await
-                } else {
-                    self.client.generate_with_media(&prompt, &self.media).await
-                }
+                self.client
+                    .generate_request(self.system.as_deref(), prompt, &self.media)
+                    .await
             }
         }
     }

--- a/src/backend/usage.rs
+++ b/src/backend/usage.rs
@@ -20,6 +20,7 @@ use crate::error::RStructorError;
 /// if let Some(usage) = &result.usage {
 ///     println!("Model: {}", usage.model);
 ///     println!("Input tokens: {}", usage.input_tokens);
+///     println!("Cached input tokens: {}", usage.cached_input_tokens);
 ///     println!("Output tokens: {}", usage.output_tokens);
 /// }
 /// # Ok(())
@@ -31,6 +32,15 @@ pub struct TokenUsage {
     pub model: String,
     /// Number of tokens in the input/prompt
     pub input_tokens: u64,
+    /// Input tokens served from a provider prompt cache.
+    ///
+    /// This is a subset of `input_tokens`, not an additional token count.
+    pub cached_input_tokens: u64,
+    /// Input tokens written to a provider prompt cache.
+    ///
+    /// This is a subset of `input_tokens`, not an additional token count.
+    /// Providers that perform implicit cache writes may not report this value.
+    pub cache_write_input_tokens: u64,
     /// Number of tokens in the output/completion
     pub output_tokens: u64,
 }
@@ -41,8 +51,22 @@ impl TokenUsage {
         Self {
             model: model.into(),
             input_tokens,
+            cached_input_tokens: 0,
+            cache_write_input_tokens: 0,
             output_tokens,
         }
+    }
+
+    /// Attach provider-reported prompt-cache token counts.
+    #[must_use]
+    pub fn with_cache_tokens(
+        mut self,
+        cached_input_tokens: u64,
+        cache_write_input_tokens: u64,
+    ) -> Self {
+        self.cached_input_tokens = cached_input_tokens;
+        self.cache_write_input_tokens = cache_write_input_tokens;
+        self
     }
 
     /// Total tokens used (input + output)
@@ -67,6 +91,14 @@ pub struct RunUsage {
     pub reported_attempts: usize,
     /// Cumulative input tokens across all reported responses.
     pub input_tokens: u64,
+    /// Cumulative input tokens served from provider prompt caches.
+    ///
+    /// This is a subset of `input_tokens`.
+    pub cached_input_tokens: u64,
+    /// Cumulative input tokens written to provider prompt caches.
+    ///
+    /// This is a subset of `input_tokens`.
+    pub cache_write_input_tokens: u64,
     /// Cumulative output tokens across all reported responses.
     pub output_tokens: u64,
     /// Cumulative usage grouped by reported model, or configured-model fallback.
@@ -104,6 +136,16 @@ impl RunUsage {
         };
         self.input_tokens =
             saturating_add(&mut self.overflowed, self.input_tokens, usage.input_tokens);
+        self.cached_input_tokens = saturating_add(
+            &mut self.overflowed,
+            self.cached_input_tokens,
+            usage.cached_input_tokens,
+        );
+        self.cache_write_input_tokens = saturating_add(
+            &mut self.overflowed,
+            self.cache_write_input_tokens,
+            usage.cache_write_input_tokens,
+        );
         self.output_tokens = saturating_add(
             &mut self.overflowed,
             self.output_tokens,
@@ -118,6 +160,16 @@ impl RunUsage {
             &mut self.overflowed,
             model_usage.input_tokens,
             usage.input_tokens,
+        );
+        model_usage.cached_input_tokens = saturating_add(
+            &mut self.overflowed,
+            model_usage.cached_input_tokens,
+            usage.cached_input_tokens,
+        );
+        model_usage.cache_write_input_tokens = saturating_add(
+            &mut self.overflowed,
+            model_usage.cache_write_input_tokens,
+            usage.cache_write_input_tokens,
         );
         model_usage.output_tokens = saturating_add(
             &mut self.overflowed,
@@ -450,34 +502,43 @@ mod tests {
     #[test]
     fn run_usage_groups_exact_provider_model_versions() {
         let mut usage = RunUsage::new();
-        usage.record(TokenUsage::new("gpt-5.6-2026-07-01", 120, 30));
-        usage.record(TokenUsage::new("gpt-5.6-2026-07-01", 180, 45));
-        usage.record(TokenUsage::new("gpt-5.6-2026-07-15", 200, 50));
+        usage.record(TokenUsage::new("gpt-5.6-2026-07-01", 120, 30).with_cache_tokens(80, 0));
+        usage.record(TokenUsage::new("gpt-5.6-2026-07-01", 180, 45).with_cache_tokens(100, 20));
+        usage.record(TokenUsage::new("gpt-5.6-2026-07-15", 200, 50).with_cache_tokens(0, 150));
 
         assert_eq!(usage.reported_attempts, 3);
         assert_eq!(usage.input_tokens, 500);
+        assert_eq!(usage.cached_input_tokens, 180);
+        assert_eq!(usage.cache_write_input_tokens, 170);
         assert_eq!(usage.output_tokens, 125);
         assert_eq!(usage.total_tokens(), 625);
         assert!(!usage.overflowed);
         assert_eq!(
             usage.by_model["gpt-5.6-2026-07-01"],
-            TokenUsage::new("gpt-5.6-2026-07-01", 300, 75)
+            TokenUsage::new("gpt-5.6-2026-07-01", 300, 75).with_cache_tokens(180, 20)
         );
         assert_eq!(
             usage.by_model["gpt-5.6-2026-07-15"],
-            TokenUsage::new("gpt-5.6-2026-07-15", 200, 50)
+            TokenUsage::new("gpt-5.6-2026-07-15", 200, 50).with_cache_tokens(0, 150)
         );
     }
 
     #[test]
     fn run_usage_saturates_and_flags_untrusted_counter_overflow() {
         let mut usage = RunUsage::new();
-        usage.record(TokenUsage::new("hostile-compatible-endpoint", u64::MAX, 1));
-        usage.record(TokenUsage::new("hostile-compatible-endpoint", 1, u64::MAX));
+        usage.record(
+            TokenUsage::new("hostile-compatible-endpoint", u64::MAX, 1)
+                .with_cache_tokens(u64::MAX, u64::MAX),
+        );
+        usage.record(
+            TokenUsage::new("hostile-compatible-endpoint", 1, u64::MAX).with_cache_tokens(1, 1),
+        );
 
         assert!(usage.overflowed);
         assert_eq!(usage.reported_attempts, 2);
         assert_eq!(usage.input_tokens, u64::MAX);
+        assert_eq!(usage.cached_input_tokens, u64::MAX);
+        assert_eq!(usage.cache_write_input_tokens, u64::MAX);
         assert_eq!(usage.output_tokens, u64::MAX);
         assert_eq!(usage.total_tokens(), u64::MAX);
         assert_eq!(
@@ -486,6 +547,14 @@ mod tests {
         );
         assert_eq!(
             usage.by_model["hostile-compatible-endpoint"].output_tokens,
+            u64::MAX
+        );
+        assert_eq!(
+            usage.by_model["hostile-compatible-endpoint"].cached_input_tokens,
+            u64::MAX
+        );
+        assert_eq!(
+            usage.by_model["hostile-compatible-endpoint"].cache_write_input_tokens,
             u64::MAX
         );
     }

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -1344,6 +1344,24 @@ where
         .map(|success| success.report)
 }
 
+/// Execute structured generation from a caller-supplied initial conversation
+/// and retain the complete retry ledger.
+pub async fn generate_with_retry_attempts_with_initial_messages<F, Fut, T>(
+    generate_fn: F,
+    initial_messages: Vec<ChatMessage>,
+    max_retries: Option<usize>,
+) -> std::result::Result<MaterializeReport<T>, MaterializeFailure>
+where
+    F: FnMut(Vec<ChatMessage>) -> Fut,
+    Fut: std::future::Future<
+            Output = std::result::Result<MaterializeInternalOutput<T>, MaterializeAttemptError>,
+        >,
+{
+    run_materialize_attempts(generate_fn, initial_messages, max_retries)
+        .await
+        .map(|success| success.report)
+}
+
 /// Execute structured generation with media and retain the complete retry ledger.
 pub async fn materialize_with_media_and_attempts_with_retry<F, Fut, T>(
     generate_fn: F,
@@ -2751,6 +2769,58 @@ mod tests {
 
         assert_eq!(attempts, 2);
         assert_eq!(output.data, "ok");
+    }
+
+    #[tokio::test]
+    async fn retry_history_preserves_the_system_and_user_prefix_exactly() {
+        let initial = vec![
+            ChatMessage::system("Use the fund's reporting policy."),
+            ChatMessage::user("Summarize today's risk."),
+        ];
+        let mut attempts = 0usize;
+
+        let output = generate_with_retry_with_initial_messages(
+            |messages: Vec<ChatMessage>| {
+                attempts += 1;
+                async move {
+                    assert_eq!(
+                        messages[0].role,
+                        crate::backend::ChatRole::System,
+                        "the stable system prefix must remain first"
+                    );
+                    assert_eq!(messages[0].content, "Use the fund's reporting policy.");
+                    assert_eq!(messages[1].role, crate::backend::ChatRole::User);
+                    assert_eq!(messages[1].content, "Summarize today's risk.");
+
+                    if attempts == 1 {
+                        Err(MaterializeAttemptError::semantic(
+                            RStructorError::ValidationError("invalid risk status".to_string()),
+                            ValidationFailureContext::new(
+                                "status must be snake_case",
+                                r#"{"status":"Within Limits"}"#,
+                            ),
+                            None,
+                        ))
+                    } else {
+                        assert_eq!(messages.len(), 4);
+                        assert_eq!(messages[2].role, crate::backend::ChatRole::Assistant);
+                        assert_eq!(messages[3].role, crate::backend::ChatRole::User);
+                        Ok(MaterializeInternalOutput::new(
+                            "within_limits".to_string(),
+                            r#"{"status":"within_limits"}"#.to_string(),
+                            None,
+                        ))
+                    }
+                }
+            },
+            initial,
+            Some(1),
+        )
+        .await
+        .expect("generation should succeed after one correction");
+
+        assert_eq!(attempts, 2);
+        assert_eq!(output.data, "within_limits");
     }
 
     #[tokio::test]

--- a/tests/fixtures/prompt_caching/anthropic_cache_hit.json
+++ b/tests/fixtures/prompt_caching/anthropic_cache_hit.json
@@ -1,0 +1,20 @@
+{
+  "id": "msg_cache_hit",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-opus-5-20260701",
+  "content": [
+    {
+      "type": "text",
+      "text": "Risk is within limits."
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 32,
+    "cache_creation_input_tokens": 2048,
+    "cache_read_input_tokens": 1024,
+    "output_tokens": 125
+  }
+}

--- a/tests/fixtures/prompt_caching/gemini_cache_hit.json
+++ b/tests/fixtures/prompt_caching/gemini_cache_hit.json
@@ -1,0 +1,23 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "Risk is within limits."
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 3072,
+    "cachedContentTokenCount": 2048,
+    "candidatesTokenCount": 125,
+    "totalTokenCount": 3197
+  },
+  "modelVersion": "gemini-3.1-pro-preview"
+}

--- a/tests/fixtures/prompt_caching/grok_cache_hit.json
+++ b/tests/fixtures/prompt_caching/grok_cache_hit.json
@@ -1,0 +1,24 @@
+{
+  "id": "chatcmpl-cache-hit",
+  "object": "chat.completion",
+  "created": 1785326400,
+  "model": "grok-4.1-fast",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Risk is within limits."
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 3072,
+    "completion_tokens": 125,
+    "total_tokens": 3197,
+    "prompt_tokens_details": {
+      "cached_tokens": 2048
+    }
+  }
+}

--- a/tests/fixtures/prompt_caching/openai_cache_hit.json
+++ b/tests/fixtures/prompt_caching/openai_cache_hit.json
@@ -1,0 +1,25 @@
+{
+  "id": "chatcmpl-cache-hit",
+  "object": "chat.completion",
+  "created": 1785326400,
+  "model": "gpt-5.6",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Risk is within limits."
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 2048,
+    "completion_tokens": 125,
+    "total_tokens": 2173,
+    "prompt_tokens_details": {
+      "cached_tokens": 1024,
+      "cache_write_tokens": 768
+    }
+  }
+}

--- a/tests/prompt_cache_usage_tests.rs
+++ b/tests/prompt_cache_usage_tests.rs
@@ -1,0 +1,143 @@
+//! Provider response regressions for prompt-cache usage accounting.
+//!
+//! Fixtures mirror the usage fields documented by each provider. Cache reads
+//! and writes remain subsets of total input usage, allowing callers to inspect
+//! cache effectiveness without double-counting billed tokens.
+
+#![cfg(feature = "_client")]
+
+use rstructor::LLMClient;
+
+#[cfg(feature = "openai")]
+#[tokio::test]
+async fn openai_reports_cache_reads_and_writes() {
+    let mut server = mockito::Server::new_async().await;
+    let response = server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(include_str!(
+            "fixtures/prompt_caching/openai_cache_hit.json"
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let result = rstructor::OpenAIClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("gpt-5.6")
+        .generate_with_metadata("Summarize today's risk.")
+        .await
+        .unwrap();
+
+    let usage = result.usage.unwrap();
+    assert_eq!(usage.model, "gpt-5.6");
+    assert_eq!(usage.input_tokens, 2048);
+    assert_eq!(usage.cached_input_tokens, 1024);
+    assert_eq!(usage.cache_write_input_tokens, 768);
+    assert_eq!(usage.output_tokens, 125);
+    assert_eq!(usage.total_tokens(), 2173);
+    response.assert_async().await;
+}
+
+#[cfg(feature = "grok")]
+#[tokio::test]
+async fn grok_reports_automatic_cache_hits() {
+    let mut server = mockito::Server::new_async().await;
+    let response = server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(include_str!("fixtures/prompt_caching/grok_cache_hit.json"))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let result = rstructor::GrokClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("grok-4.1-fast")
+        .generate_with_metadata("Summarize today's risk.")
+        .await
+        .unwrap();
+
+    let usage = result.usage.unwrap();
+    assert_eq!(usage.model, "grok-4.1-fast");
+    assert_eq!(usage.input_tokens, 3072);
+    assert_eq!(usage.cached_input_tokens, 2048);
+    assert_eq!(usage.cache_write_input_tokens, 0);
+    assert_eq!(usage.output_tokens, 125);
+    assert_eq!(usage.total_tokens(), 3197);
+    response.assert_async().await;
+}
+
+#[cfg(feature = "anthropic")]
+#[tokio::test]
+async fn anthropic_includes_cache_reads_and_writes_in_total_input() {
+    let mut server = mockito::Server::new_async().await;
+    let response = server
+        .mock("POST", "/messages")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(include_str!(
+            "fixtures/prompt_caching/anthropic_cache_hit.json"
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let result = rstructor::AnthropicClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("claude-opus-5-20260701")
+        .generate_with_metadata("Summarize today's risk.")
+        .await
+        .unwrap();
+
+    let usage = result.usage.unwrap();
+    assert_eq!(usage.model, "claude-opus-5-20260701");
+    assert_eq!(usage.input_tokens, 3104);
+    assert_eq!(usage.cached_input_tokens, 1024);
+    assert_eq!(usage.cache_write_input_tokens, 2048);
+    assert_eq!(usage.output_tokens, 125);
+    assert_eq!(usage.total_tokens(), 3229);
+    response.assert_async().await;
+}
+
+#[cfg(feature = "gemini")]
+#[tokio::test]
+async fn gemini_reports_implicit_cache_hits() {
+    let mut server = mockito::Server::new_async().await;
+    let response = server
+        .mock("POST", "/models/gemini-3.1-pro-preview:generateContent")
+        .match_query(mockito::Matcher::UrlEncoded(
+            "key".to_string(),
+            "test-key".to_string(),
+        ))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(include_str!(
+            "fixtures/prompt_caching/gemini_cache_hit.json"
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let result = rstructor::GeminiClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("gemini-3.1-pro-preview")
+        .generate_with_metadata("Summarize today's risk.")
+        .await
+        .unwrap();
+
+    let usage = result.usage.unwrap();
+    assert_eq!(usage.model, "gemini-3.1-pro-preview");
+    assert_eq!(usage.input_tokens, 3072);
+    assert_eq!(usage.cached_input_tokens, 2048);
+    assert_eq!(usage.cache_write_input_tokens, 0);
+    assert_eq!(usage.output_tokens, 125);
+    assert_eq!(usage.total_tokens(), 3197);
+    response.assert_async().await;
+}

--- a/tests/system_prompt_request_tests.rs
+++ b/tests/system_prompt_request_tests.rs
@@ -1,0 +1,661 @@
+//! Regression coverage for first-class system prompt request shapes.
+//!
+//! These tests drive each real provider client over a local HTTP server. The
+//! stable system instructions must remain separate from the dynamic user turn
+//! so providers can apply the correct instruction semantics and reuse a common
+//! prompt-cache prefix across requests.
+
+#![cfg(feature = "_client")]
+
+#[cfg(feature = "derive")]
+use rstructor::Instructor;
+use rstructor::RequestExt;
+#[cfg(all(feature = "derive", feature = "openai"))]
+use rstructor::{AnyClient, MediaFile};
+#[cfg(feature = "derive")]
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[cfg(feature = "streaming")]
+use futures_util::StreamExt;
+
+#[cfg(feature = "derive")]
+#[derive(Debug, Deserialize, Instructor, PartialEq, Serialize)]
+struct RiskSummary {
+    status: String,
+    gross_exposure: f64,
+}
+
+fn openai_compatible_completion(text: &str) -> String {
+    json!({
+        "choices": [{
+            "message": { "role": "assistant", "content": text },
+            "finish_reason": "stop",
+        }]
+    })
+    .to_string()
+}
+
+#[cfg(feature = "streaming")]
+const OPENAI_COMPATIBLE_TEXT_STREAM: &str = concat!(
+    "data: {\"id\":\"chatcmpl-risk\",\"object\":\"chat.completion.chunk\",",
+    "\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",",
+    "\"content\":\"Risk is within limits.\"},\"finish_reason\":\"stop\"}]}\n\n",
+    "data: [DONE]\n\n",
+);
+
+#[cfg(feature = "openai")]
+#[tokio::test]
+async fn openai_generate_sends_a_system_message_before_the_user_message() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/chat/completions")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "messages": [
+                { "role": "system", "content": "Use the fund's reporting policy." },
+                { "role": "user", "content": "Summarize today's risk." },
+            ],
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(openai_compatible_completion("Risk is within limits."))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let response = rstructor::OpenAIClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("gpt-4.1-mini")
+        .with_system("Use the fund's reporting policy.")
+        .generate("Summarize today's risk.")
+        .await
+        .unwrap();
+
+    assert_eq!(response, "Risk is within limits.");
+    request.assert_async().await;
+}
+
+#[cfg(all(feature = "derive", feature = "openai"))]
+#[tokio::test]
+async fn openai_materialize_keeps_system_separate_from_a_media_user_turn() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/chat/completions")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "messages": [
+                { "role": "system", "content": "Use the fund's reporting policy." },
+                {
+                    "role": "user",
+                    "content": [
+                        { "type": "text", "text": "Read the exposure chart." },
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "data:image/png;base64,iVBORw0KGgo=",
+                                "detail": "auto",
+                            },
+                        },
+                    ],
+                },
+            ],
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(openai_compatible_completion(
+            r#"{"status":"within_limits","gross_exposure":1.42}"#,
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let media = [MediaFile::from_bytes(b"\x89PNG\r\n\x1a\n", "image/png")];
+    let summary: RiskSummary = rstructor::OpenAIClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("gpt-4.1-mini")
+        .no_retries()
+        .with_system("Use the fund's reporting policy.")
+        .media(media.to_vec())
+        .materialize("Read the exposure chart.")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        summary,
+        RiskSummary {
+            status: "within_limits".to_string(),
+            gross_exposure: 1.42,
+        }
+    );
+    request.assert_async().await;
+}
+
+#[cfg(all(feature = "derive", feature = "openai"))]
+#[tokio::test]
+async fn openai_attempt_ledger_terminal_keeps_the_system_message_separate() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/chat/completions")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "messages": [
+                { "role": "system", "content": "Use the fund's reporting policy." },
+                { "role": "user", "content": "Summarize today's risk." },
+            ],
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(openai_compatible_completion(
+            r#"{"status":"within_limits","gross_exposure":1.42}"#,
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let report = rstructor::OpenAIClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("gpt-4.1-mini")
+        .no_retries()
+        .with_system("Use the fund's reporting policy.")
+        .materialize_with_attempts::<RiskSummary>("Summarize today's risk.")
+        .await
+        .unwrap();
+
+    assert_eq!(report.data.gross_exposure, 1.42);
+    assert_eq!(report.attempts.len(), 1);
+    request.assert_async().await;
+}
+
+#[cfg(all(feature = "derive", feature = "openai"))]
+#[tokio::test]
+async fn any_client_dispatch_preserves_the_system_message() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/chat/completions")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "messages": [
+                { "role": "system", "content": "Use the fund's reporting policy." },
+                { "role": "user", "content": "Summarize today's risk." },
+            ],
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(openai_compatible_completion(
+            r#"{"status":"within_limits","gross_exposure":1.42}"#,
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let client: AnyClient = rstructor::OpenAIClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("gpt-4.1-mini")
+        .no_retries()
+        .into();
+    let summary: RiskSummary = client
+        .with_system("Use the fund's reporting policy.")
+        .materialize("Summarize today's risk.")
+        .await
+        .unwrap();
+
+    assert_eq!(summary.status, "within_limits");
+    request.assert_async().await;
+}
+
+#[cfg(all(feature = "openai", feature = "tools"))]
+#[tokio::test]
+async fn run_without_tools_still_sends_a_first_class_system_message() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/chat/completions")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "messages": [
+                { "role": "system", "content": "Use the fund's reporting policy." },
+                { "role": "user", "content": "Summarize today's risk." },
+            ],
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(openai_compatible_completion("Risk is within limits."))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let response = rstructor::OpenAIClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("gpt-4.1-mini")
+        .with_system("Use the fund's reporting policy.")
+        .run("Summarize today's risk.")
+        .await
+        .unwrap();
+
+    assert_eq!(response, "Risk is within limits.");
+    request.assert_async().await;
+}
+
+#[cfg(feature = "anthropic")]
+#[tokio::test]
+async fn anthropic_generate_uses_the_top_level_system_field() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/messages")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "system": "Use the fund's reporting policy.",
+            "messages": [
+                { "role": "user", "content": "Summarize today's risk." },
+            ],
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "content": [{ "type": "text", "text": "Risk is within limits." }],
+                "usage": { "input_tokens": 12, "output_tokens": 5 },
+                "model": "claude-sonnet-4-5-20250929",
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let response = rstructor::AnthropicClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("claude-sonnet-4-5-20250929")
+        .with_system("Use the fund's reporting policy.")
+        .generate("Summarize today's risk.")
+        .await
+        .unwrap();
+
+    assert_eq!(response, "Risk is within limits.");
+    request.assert_async().await;
+}
+
+#[cfg(all(feature = "anthropic", feature = "derive"))]
+#[tokio::test]
+async fn anthropic_materialize_uses_the_top_level_system_field() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/messages")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "system": "Use the fund's reporting policy.",
+            "messages": [
+                { "role": "user", "content": "Summarize today's risk." },
+            ],
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "content": [{
+                    "type": "text",
+                    "text": r#"{"status":"within_limits","gross_exposure":1.42}"#,
+                }],
+                "usage": { "input_tokens": 12, "output_tokens": 5 },
+                "model": "claude-sonnet-4-5-20250929",
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let summary = rstructor::AnthropicClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("claude-sonnet-4-5-20250929")
+        .no_retries()
+        .with_system("Use the fund's reporting policy.")
+        .materialize::<RiskSummary>("Summarize today's risk.")
+        .await
+        .unwrap();
+
+    assert_eq!(summary.gross_exposure, 1.42);
+    request.assert_async().await;
+}
+
+#[cfg(feature = "gemini")]
+#[tokio::test]
+async fn gemini_generate_uses_system_instruction() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/models/test-model:generateContent")
+        .match_query(mockito::Matcher::UrlEncoded(
+            "key".to_string(),
+            "test-key".to_string(),
+        ))
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "systemInstruction": {
+                "parts": [{ "text": "Use the fund's reporting policy." }],
+            },
+            "contents": [{
+                "role": "user",
+                "parts": [{ "text": "Summarize today's risk." }],
+            }],
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{ "text": "Risk is within limits." }],
+                    },
+                    "finishReason": "STOP",
+                }],
+                "usageMetadata": {
+                    "promptTokenCount": 12,
+                    "candidatesTokenCount": 5,
+                },
+                "modelVersion": "test-model",
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let response = rstructor::GeminiClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("test-model")
+        .with_system("Use the fund's reporting policy.")
+        .generate("Summarize today's risk.")
+        .await
+        .unwrap();
+
+    assert_eq!(response, "Risk is within limits.");
+    request.assert_async().await;
+}
+
+#[cfg(all(feature = "gemini", feature = "derive"))]
+#[tokio::test]
+async fn gemini_materialize_uses_system_instruction() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/models/test-model:generateContent")
+        .match_query(mockito::Matcher::UrlEncoded(
+            "key".to_string(),
+            "test-key".to_string(),
+        ))
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "systemInstruction": {
+                "parts": [{ "text": "Use the fund's reporting policy." }],
+            },
+            "contents": [{
+                "role": "user",
+                "parts": [{ "text": "Summarize today's risk." }],
+            }],
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{
+                            "text": r#"{"status":"within_limits","gross_exposure":1.42}"#,
+                        }],
+                    },
+                    "finishReason": "STOP",
+                }],
+                "usageMetadata": {
+                    "promptTokenCount": 12,
+                    "candidatesTokenCount": 5,
+                },
+                "modelVersion": "test-model",
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let summary = rstructor::GeminiClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("test-model")
+        .no_retries()
+        .with_system("Use the fund's reporting policy.")
+        .materialize::<RiskSummary>("Summarize today's risk.")
+        .await
+        .unwrap();
+
+    assert_eq!(summary.gross_exposure, 1.42);
+    request.assert_async().await;
+}
+
+#[cfg(feature = "grok")]
+#[tokio::test]
+async fn grok_generate_sends_a_system_message_before_the_user_message() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/chat/completions")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "messages": [
+                { "role": "system", "content": "Use the fund's reporting policy." },
+                { "role": "user", "content": "Summarize today's risk." },
+            ],
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(openai_compatible_completion("Risk is within limits."))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let response = rstructor::GrokClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("grok-4.1-fast")
+        .with_system("Use the fund's reporting policy.")
+        .generate("Summarize today's risk.")
+        .await
+        .unwrap();
+
+    assert_eq!(response, "Risk is within limits.");
+    request.assert_async().await;
+}
+
+#[cfg(all(feature = "grok", feature = "derive"))]
+#[tokio::test]
+async fn grok_materialize_sends_a_system_message_before_the_user_message() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/chat/completions")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "messages": [
+                { "role": "system", "content": "Use the fund's reporting policy." },
+                { "role": "user", "content": "Summarize today's risk." },
+            ],
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(openai_compatible_completion(
+            r#"{"status":"within_limits","gross_exposure":1.42}"#,
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let summary = rstructor::GrokClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("grok-4.1-fast")
+        .no_retries()
+        .with_system("Use the fund's reporting policy.")
+        .materialize::<RiskSummary>("Summarize today's risk.")
+        .await
+        .unwrap();
+
+    assert_eq!(summary.gross_exposure, 1.42);
+    request.assert_async().await;
+}
+
+#[cfg(all(feature = "openai", feature = "streaming"))]
+#[tokio::test]
+async fn openai_stream_keeps_the_system_message_separate() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/chat/completions")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "stream": true,
+            "messages": [
+                { "role": "system", "content": "Use the fund's reporting policy." },
+                { "role": "user", "content": "Summarize today's risk." },
+            ],
+        })))
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(OPENAI_COMPATIBLE_TEXT_STREAM)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let chunks = rstructor::OpenAIClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("gpt-4.1-mini")
+        .with_system("Use the fund's reporting policy.")
+        .generate_stream("Summarize today's risk.")
+        .collect::<Vec<_>>()
+        .await;
+
+    assert_eq!(
+        chunks
+            .into_iter()
+            .collect::<rstructor::Result<Vec<_>>>()
+            .unwrap(),
+        vec!["Risk is within limits."]
+    );
+    request.assert_async().await;
+}
+
+#[cfg(all(feature = "anthropic", feature = "streaming"))]
+#[tokio::test]
+async fn anthropic_stream_keeps_the_top_level_system_field() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/messages")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "stream": true,
+            "system": "Use the fund's reporting policy.",
+            "messages": [
+                { "role": "user", "content": "Summarize today's risk." },
+            ],
+        })))
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(include_str!(
+            "fixtures/streaming/anthropic_text_complete.sse"
+        ))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let chunks = rstructor::AnthropicClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("claude-sonnet-4-5-20250929")
+        .with_system("Use the fund's reporting policy.")
+        .generate_stream("Summarize today's risk.")
+        .collect::<Vec<_>>()
+        .await;
+
+    assert_eq!(
+        chunks
+            .into_iter()
+            .collect::<rstructor::Result<Vec<_>>>()
+            .unwrap(),
+        vec!["Net delta: $18.4mm"]
+    );
+    request.assert_async().await;
+}
+
+#[cfg(all(feature = "gemini", feature = "streaming"))]
+#[tokio::test]
+async fn gemini_stream_keeps_system_instruction_separate() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/models/test-model:streamGenerateContent")
+        .match_query(mockito::Matcher::AllOf(vec![
+            mockito::Matcher::UrlEncoded("alt".to_string(), "sse".to_string()),
+            mockito::Matcher::UrlEncoded("key".to_string(), "test-key".to_string()),
+        ]))
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "systemInstruction": {
+                "parts": [{ "text": "Use the fund's reporting policy." }],
+            },
+            "contents": [{
+                "role": "user",
+                "parts": [{ "text": "Summarize today's risk." }],
+            }],
+        })))
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(include_str!("fixtures/streaming/gemini_text_complete.sse"))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let chunks = rstructor::GeminiClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("test-model")
+        .with_system("Use the fund's reporting policy.")
+        .generate_stream("Summarize today's risk.")
+        .collect::<Vec<_>>()
+        .await;
+
+    assert_eq!(
+        chunks
+            .into_iter()
+            .collect::<rstructor::Result<Vec<_>>>()
+            .unwrap(),
+        vec!["VaR: $2.1mm"]
+    );
+    request.assert_async().await;
+}
+
+#[cfg(all(feature = "grok", feature = "streaming"))]
+#[tokio::test]
+async fn grok_stream_keeps_the_system_message_separate() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("POST", "/chat/completions")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "stream": true,
+            "messages": [
+                { "role": "system", "content": "Use the fund's reporting policy." },
+                { "role": "user", "content": "Summarize today's risk." },
+            ],
+        })))
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(OPENAI_COMPATIBLE_TEXT_STREAM)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let chunks = rstructor::GrokClient::new("test-key")
+        .unwrap()
+        .base_url(server.url())
+        .model("grok-4.1-fast")
+        .with_system("Use the fund's reporting policy.")
+        .generate_stream("Summarize today's risk.")
+        .collect::<Vec<_>>()
+        .await;
+
+    assert_eq!(
+        chunks
+            .into_iter()
+            .collect::<rstructor::Result<Vec<_>>>()
+            .unwrap(),
+        vec!["Risk is within limits."]
+    );
+    request.assert_async().await;
+}


### PR DESCRIPTION
## Summary

Fixes #72.

`Request::with_system` previously concatenated the system text into the user
prompt for `materialize`, `generate`, streaming, and `run` without tools. Only
the tool loop used a native system field/message. Besides changing provider
instruction semantics, that made the supposedly stable prefix vary with every
user prompt and prevented compatible prompt caches from matching it.

This PR:

- routes system instructions through every built-in provider's native request
  shape for every request-builder terminal;
- preserves the exact `[system, user]` prefix across structured-output retries;
- keeps `AnyClient`, media requests, streaming, attempt ledgers, and tool-less
  `run` on the same path;
- retains the old concatenation behavior as the default hook implementation for
  third-party `LLMClient` implementations, so existing custom clients continue
  to compile and behave as before;
- exposes provider-reported prompt-cache reads and writes through
  `TokenUsage::{cached_input_tokens, cache_write_input_tokens}` and aggregates
  them in `RunUsage`;
- fixes Anthropic accounting when cache metadata is present: its base
  `input_tokens` excludes cache reads and creations, so all three counters are
  now combined into rstructor's total input count;
- documents cache behavior and deliberately does not enable paid/explicit cache
  creation by default.

## Provider request shapes

| Provider | System instruction |
|---|---|
| OpenAI and OpenAI-compatible endpoints | Initial `messages[].role = "system"` |
| xAI/Grok | Initial `messages[].role = "system"` |
| Anthropic | Top-level `system` |
| Gemini | Top-level `systemInstruction` |

## Usage example

```rust
use rstructor::{LLMClient, OpenAIClient, RequestExt};

const RISK_POLICY: &str =
    "Use the fund's base currency. Report exposure as a multiple of NAV.";

let client = OpenAIClient::from_env()?;
let report = client
    .with_system(RISK_POLICY)
    .materialize_with_attempts::<Portfolio>(daily_positions)
    .await?;

if let Some(usage) = report.cumulative_usage {
    println!(
        "{} of {} input tokens came from cache",
        usage.cached_input_tokens,
        usage.input_tokens,
    );
}
```

The public request-builder syntax is unchanged. The wire behavior changes from
one combined user message to a native system instruction plus a user message.

## Prompt-caching scope

OpenAI, Gemini, and xAI can use implicit prefix caching for eligible requests,
so preserving a stable native system prefix is immediately useful. Anthropic
requires cache-control configuration to create caches. This PR does **not**
silently enable Anthropic cache writes, OpenAI cache-routing keys/options, or
Gemini explicit cache objects because those controls can affect billing,
retention, and routing behavior.

Cache read/write counters are subsets of `input_tokens`; `total_tokens()` does
not double-count them.

Provider references:

- https://developers.openai.com/api/docs/guides/prompt-caching
- https://platform.claude.com/docs/en/build-with-claude/prompt-caching
- https://ai.google.dev/gemini-api/docs/caching
- https://docs.x.ai/developers/advanced-api-usage/prompt-caching

## Regression coverage

- 15 mocked request-shape tests cover all four providers, structured and raw
  terminals, streaming, media, `AnyClient`, attempt ledgers, and `run` without
  tools.
- Retry-history unit coverage verifies that the system/user prefix remains byte
  stable while assistant output and validation feedback are appended.
- Four provider-shaped response fixtures verify OpenAI, Anthropic, Gemini, and
  xAI cache-token accounting.
- Run-level tests cover per-model cache aggregation and saturating overflow.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib --all-features` (299 passed)
- `cargo test --test system_prompt_request_tests --all-features` (15 passed)
- `cargo test --test prompt_cache_usage_tests --all-features` (4 passed)
- `cargo test --test documentation_gallery_tests --all-features` (5 passed)
- `cargo test --doc --all-features` (82 passed)
- schema-only builds with `derive` and `derive,mock`
