### PR TITLE
[codex] Unify structured extraction reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,12 @@ const RISK_POLICY: &str =
     "Use the fund's base currency. Report exposure as a multiple of NAV.";
 
 let client = OpenAIClient::from_env()?;
-let result = client
+let extraction = client
     .with_system(RISK_POLICY)
-    .materialize_with_attempts::<Portfolio>(daily_positions)
+    .extract_with_report::<Portfolio>(daily_positions)
     .await?;
 
-if let Some(usage) = result.cumulative_usage {
+if let Some(usage) = extraction.report.cumulative_usage {
     println!(
         "{} of {} input tokens came from cache",
         usage.cached_input_tokens,
@@ -642,9 +642,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 `MediaFile::new(uri, mime_type)` is also available for URL/URI-based media input.
-The lower-level `LLMClient::materialize_with_media(prompt, &media)` method does
-the same thing in one call when you do not need the builder. Attached media is
-honored by `materialize`, `generate`, and tool `run` alike.
+Attached media is honored by `extract`, `generate`, and tool `run` alike. The
+request builder is the primary way to combine media with system instructions or
+run reporting.
 
 PDFs are supported too: pass `"application/pdf"` as the MIME type and the
 attachment is routed to each provider's documented document format (OpenAI
@@ -674,34 +674,19 @@ let client = OpenAIClient::from_env()?
 // Levels: Off, Minimal, Low, Medium, High
 ```
 
-## Token Usage
+## Extraction Reports and Token Usage
 
-`materialize_with_metadata` preserves its original behavior: `usage` describes
-only the final successful provider response.
-
-```rust
-let result = client.materialize_with_metadata::<Movie>("...").await?;
-println!("Movie: {}", result.data.title);
-if let Some(usage) = result.usage {
-    println!("Tokens: {} in, {} out", usage.input_tokens, usage.output_tokens);
-    println!(
-        "Prompt cache: {} read, {} written",
-        usage.cached_input_tokens,
-        usage.cache_write_input_tokens,
-    );
-}
-```
-
-Use `materialize_with_attempts` when retry cost or failure observability matters.
-It returns an ordered ledger plus cumulative known usage, including provider
-responses that failed decoding or validation:
+Use `extract_with_report` when retry cost or failure observability matters. The
+same `ExtractionReport` shape is attached to success and failure, including an
+ordered attempt ledger and cumulative known usage from provider responses that
+failed decoding or validation:
 
 ```rust
-match client.materialize_with_attempts::<Portfolio>("Reconcile the fund book").await {
-    Ok(report) => {
-        println!("Portfolio: {:?}", report.data);
-        println!("Provider attempts: {}", report.attempts.len());
-        if let Some(usage) = report.cumulative_usage {
+match client.extract_with_report::<Portfolio>("Reconcile the fund book").await {
+    Ok(extraction) => {
+        println!("Portfolio: {:?}", extraction.data);
+        println!("Provider attempts: {}", extraction.report.attempts.len());
+        if let Some(usage) = extraction.report.cumulative_usage {
             println!("Known run tokens: {}", usage.total_tokens());
             for (model, model_usage) in usage.by_model {
                 println!("{model}: {} tokens", model_usage.total_tokens());
@@ -710,8 +695,8 @@ match client.materialize_with_attempts::<Portfolio>("Reconcile the fund book").a
     }
     Err(failure) => {
         eprintln!("Final error: {}", failure.error());
-        eprintln!("Attempts made: {}", failure.attempts.len());
-        if let Some(usage) = failure.cumulative_usage {
+        eprintln!("Attempts made: {}", failure.report.attempts.len());
+        if let Some(usage) = failure.report.cumulative_usage {
             eprintln!("Known tokens before failure: {}", usage.total_tokens());
         }
     }
@@ -723,9 +708,9 @@ token metadata, while cumulative totals include only responses with reported
 usage. Local schema/media preflight failures record zero provider attempts.
 Cache read and write counters are provider-reported subsets of input usage, so
 they provide cache observability without inflating `total_tokens()`.
-Built-in clients and `MockClient` set `attempts_complete` to `true`; the default
-implementation for custom clients sets it to `false` rather than inventing
-provider attempts it cannot observe.
+Built-in clients and `MockClient` set `report.attempts_complete` to `true`; the
+compatibility fallback for custom clients sets it to `false` rather than
+inventing provider attempts it cannot observe.
 See `examples/retry_attempt_ledger.rs` for a complete success-and-failure
 example.
 
@@ -734,7 +719,7 @@ example.
 ```rust
 use rstructor::{ApiErrorKind, RStructorError};
 
-match client.materialize::<Movie>("...").await {
+match client.extract::<Movie>("...").await {
     Ok(movie) => println!("{:?}", movie),
     Err(e) if e.is_retryable() => {
         println!("Transient error: {}", e);

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -438,8 +438,9 @@ request because strict provider schemas must be reference-free.
 ## Inspect cumulative retry cost
 
 The [attempt-ledger example](../examples/retry_attempt_ledger.rs) shows both
-success and terminal-failure reporting. `materialize_with_attempts` preserves
-every provider attempt and sums all usage the provider reported.
+success and terminal-failure reporting. `extract_with_report` attaches the same
+report shape to both outcomes, preserving every provider attempt and summing all
+usage the provider reported.
 
 ```rust
 use rstructor::{AttemptOutcome, Instructor, LLMClient};
@@ -461,13 +462,13 @@ struct Position {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = rstructor::client("openai/gpt-5.6-sol")?;
     match client
-        .materialize_with_attempts::<Portfolio>(
+        .extract_with_report::<Portfolio>(
             "HF-ALPHA-001: short 240 ESU6 and long 125,000 AAPL",
         )
         .await
     {
-        Ok(report) => {
-            for attempt in &report.attempts {
+        Ok(extraction) => {
+            for attempt in &extraction.report.attempts {
                 println!(
                     "attempt {}: {:?}, {:?}, usage={:?}",
                     attempt.number, attempt.kind, attempt.outcome, attempt.usage
@@ -476,13 +477,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     eprintln!("provider failure: {message}");
                 }
             }
-            println!("known cumulative usage: {:?}", report.cumulative_usage);
-            println!("portfolio: {:#?}", report.data);
+            println!(
+                "known cumulative usage: {:?}",
+                extraction.report.cumulative_usage
+            );
+            println!("portfolio: {:#?}", extraction.data);
         }
         Err(failure) => {
             eprintln!("final error: {}", failure.error());
-            eprintln!("attempts: {:#?}", failure.attempts);
-            eprintln!("known cumulative usage: {:?}", failure.cumulative_usage);
+            eprintln!("attempts: {:#?}", failure.report.attempts);
+            eprintln!(
+                "known cumulative usage: {:?}",
+                failure.report.cumulative_usage
+            );
         }
     }
     Ok(())
@@ -518,14 +525,14 @@ struct RiskSummary {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = OpenAIClient::from_env()?;
-    let report = client
+    let extraction = client
         .with_system(RISK_POLICY)
-        .materialize_with_attempts::<RiskSummary>(
+        .extract_with_report::<RiskSummary>(
             "NAV USD 100mm; long USD 92mm; short USD 50mm",
         )
         .await?;
 
-    if let Some(usage) = report.cumulative_usage {
+    if let Some(usage) = extraction.report.cumulative_usage {
         println!(
             "input={} cache_read={} cache_write={}",
             usage.input_tokens,
@@ -533,7 +540,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             usage.cache_write_input_tokens,
         );
     }
-    println!("{:#?}", report.data);
+    println!("{:#?}", extraction.data);
     Ok(())
 }
 ```

--- a/examples/retry_attempt_ledger.rs
+++ b/examples/retry_attempt_ledger.rs
@@ -1,4 +1,4 @@
-//! Inspect every retry plus cumulative known token usage for a materialization run.
+//! Inspect every retry plus cumulative known token usage for an extraction run.
 
 use rstructor::{AttemptOutcome, AttemptRecord, Instructor, LLMClient, OpenAIClient, RunUsage};
 use serde::{Deserialize, Serialize};
@@ -64,16 +64,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         AAPL: long 125,000 shares, market value $29,750,000
     ";
 
-    match client.materialize_with_attempts::<Portfolio>(prompt).await {
-        Ok(report) => {
-            println!("{:#?}", report.data);
-            println!("complete attempt history: {}", report.attempts_complete);
-            print_attempts(&report.attempts, report.cumulative_usage.as_ref());
+    match client.extract_with_report::<Portfolio>(prompt).await {
+        Ok(extraction) => {
+            println!("{:#?}", extraction.data);
+            println!(
+                "complete attempt history: {}",
+                extraction.report.attempts_complete
+            );
+            print_attempts(
+                &extraction.report.attempts,
+                extraction.report.cumulative_usage.as_ref(),
+            );
         }
         Err(failure) => {
-            eprintln!("materialization failed: {}", failure.error());
-            eprintln!("complete attempt history: {}", failure.attempts_complete);
-            print_attempts(&failure.attempts, failure.cumulative_usage.as_ref());
+            eprintln!("extraction failed: {}", failure.error());
+            eprintln!(
+                "complete attempt history: {}",
+                failure.report.attempts_complete
+            );
+            print_attempts(
+                &failure.report.attempts,
+                failure.report.cumulative_usage.as_ref(),
+            );
         }
     }
 

--- a/examples/token_usage_example.rs
+++ b/examples/token_usage_example.rs
@@ -1,4 +1,4 @@
-//! Example demonstrating token usage tracking with materialize_with_metadata.
+//! Example demonstrating token usage tracking with a uniform extraction report.
 //!
 //! This is useful for monitoring API costs and understanding token consumption.
 
@@ -31,20 +31,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let prompt = "Summarize the book '1984' by George Orwell";
 
-    // Use materialize_with_metadata to get token usage information
-    let result = client
-        .materialize_with_metadata::<BookSummary>(prompt)
-        .await?;
+    let extraction = client.extract_with_report::<BookSummary>(prompt).await?;
 
     // Access the extracted data
-    println!("Book: {} by {}", result.data.title, result.data.author);
-    println!("Summary: {}", result.data.summary);
-    println!("Themes: {:?}", result.data.themes);
+    println!(
+        "Book: {} by {}",
+        extraction.data.title, extraction.data.author
+    );
+    println!("Summary: {}", extraction.data.summary);
+    println!("Themes: {:?}", extraction.data.themes);
 
-    // Access token usage for cost tracking
-    if let Some(usage) = result.usage {
+    // Access cumulative usage across retries for cost tracking.
+    if let Some(usage) = extraction.report.cumulative_usage {
         println!("\n--- Token Usage ---");
-        println!("Model: {}", usage.model);
         println!("Input tokens: {}", usage.input_tokens);
         println!("Output tokens: {}", usage.output_tokens);
         println!("Total tokens: {}", usage.total_tokens());

--- a/src/backend/client.rs
+++ b/src/backend/client.rs
@@ -3,7 +3,8 @@ use serde::de::DeserializeOwned;
 
 use crate::backend::ModelInfo;
 use crate::backend::usage::{
-    GenerateResult, MaterializeFailure, MaterializeReport, MaterializeResult,
+    Extraction, ExtractionError, ExtractionResult, GenerateResult, MaterializeFailure,
+    MaterializeReport, MaterializeResult,
 };
 use crate::error::Result;
 use crate::model::Instructor;
@@ -232,6 +233,48 @@ pub trait LLMClient {
         self.materialize(prompt).await
     }
 
+    /// Extract a structured value with one report shape on success and failure.
+    ///
+    /// Use this when attempt history or cumulative usage matters. Both variants
+    /// of [`ExtractionResult<T>`] carry an
+    /// [`ExtractionReport`](crate::ExtractionReport), so accounting code does
+    /// not need to switch between unrelated metadata types.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use rstructor::{Instructor, LLMClient, OpenAIClient};
+    /// # use serde::{Deserialize, Serialize};
+    /// # #[derive(Debug, Instructor, Serialize, Deserialize)]
+    /// # struct Position { symbol: String, quantity: i64 }
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = OpenAIClient::from_env()?;
+    /// match client
+    ///     .extract_with_report::<Position>("AAPL: 1,000 shares")
+    ///     .await
+    /// {
+    ///     Ok(extraction) => {
+    ///         println!("{:?}", extraction.data);
+    ///         println!("attempts={}", extraction.report.attempts.len());
+    ///     }
+    ///     Err(failure) => {
+    ///         eprintln!("{}", failure.error());
+    ///         eprintln!("attempts={}", failure.report.attempts.len());
+    ///     }
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn extract_with_report<T>(&self, prompt: &str) -> ExtractionResult<T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        self.materialize_with_attempts(prompt)
+            .await
+            .map(Extraction::from)
+            .map_err(ExtractionError::from)
+    }
+
     /// Materialize a structured object of type T from a prompt.
     ///
     /// This is the original name for [`extract`](Self::extract). It takes a
@@ -241,7 +284,8 @@ pub trait LLMClient {
     /// the client will automatically retry up to 3 times (configurable via `.max_retries()`
     /// or disabled via `.no_retries()`).
     ///
-    /// For token usage information, use [`materialize_with_metadata`](Self::materialize_with_metadata).
+    /// For token usage and attempt history, use
+    /// [`extract_with_report`](Self::extract_with_report).
     ///
     /// # Example
     ///
@@ -268,6 +312,7 @@ pub trait LLMClient {
     /// [`RStructorError::Unsupported`](crate::RStructorError::Unsupported) so that
     /// media is never silently dropped. Providers with media support override this
     /// method. All four built-in clients (OpenAI, Anthropic, Grok, Gemini) support media.
+    #[doc(hidden)]
     async fn materialize_with_media<T>(&self, prompt: &str, media: &[MediaFile]) -> Result<T>
     where
         T: Instructor + DeserializeOwned + Send + 'static,
@@ -305,9 +350,15 @@ pub trait LLMClient {
     /// # Ok(())
     /// # }
     /// ```
+    #[doc(hidden)]
     async fn materialize_with_metadata<T>(&self, prompt: &str) -> Result<MaterializeResult<T>>
     where
-        T: Instructor + DeserializeOwned + Send + 'static;
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        self.materialize(prompt)
+            .await
+            .map(MaterializeResult::from_data)
+    }
 
     /// Materialize a structured object with a complete attempt ledger.
     ///
@@ -343,6 +394,7 @@ pub trait LLMClient {
     /// # Ok(())
     /// # }
     /// ```
+    #[doc(hidden)]
     async fn materialize_with_attempts<T>(
         &self,
         prompt: &str,
@@ -362,6 +414,7 @@ pub trait LLMClient {
     /// [`materialize_with_attempts`](Self::materialize_with_attempts). The
     /// default implementation preserves compatibility for custom clients but
     /// cannot recover per-attempt metadata hidden by their existing media method.
+    #[doc(hidden)]
     async fn materialize_with_media_and_attempts<T>(
         &self,
         prompt: &str,
@@ -459,7 +512,11 @@ pub trait LLMClient {
     /// # Ok(())
     /// # }
     /// ```
-    async fn generate_with_metadata(&self, prompt: &str) -> Result<GenerateResult>;
+    async fn generate_with_metadata(&self, prompt: &str) -> Result<GenerateResult> {
+        self.generate(prompt)
+            .await
+            .map(|text| GenerateResult::new(text, None))
+    }
 
     /// Stream a raw text completion as a sequence of token deltas.
     ///

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -52,8 +52,9 @@ pub use streaming::{ItemStream, ObjectStream, StreamedObject, TextStream};
 #[cfg(feature = "tools")]
 pub use tools::{DynTool, FnTool, Tool, ToolRunner, Toolbox};
 pub use usage::{
-    AttemptKind, AttemptOutcome, AttemptRecord, GenerateResult, MaterializeFailure,
-    MaterializeReport, MaterializeResult, RetryDisposition, RunUsage, TokenUsage,
+    AttemptKind, AttemptOutcome, AttemptRecord, Extraction, ExtractionError, ExtractionReport,
+    ExtractionResult, GenerateResult, MaterializeFailure, MaterializeReport, MaterializeResult,
+    RetryDisposition, RunUsage, TokenUsage,
 };
 
 /// Information about an available model from an LLM provider.

--- a/src/backend/request.rs
+++ b/src/backend/request.rs
@@ -23,7 +23,10 @@
 
 use serde::de::DeserializeOwned;
 
-use crate::backend::{LLMClient, MaterializeFailure, MaterializeReport, MediaFile};
+use crate::backend::{
+    Extraction, ExtractionError, ExtractionResult, LLMClient, MaterializeFailure,
+    MaterializeReport, MediaFile,
+};
 #[cfg(feature = "streaming")]
 use crate::error::RStructorError;
 use crate::error::Result;
@@ -107,6 +110,18 @@ impl<C: LLMClient + Sync + ?Sized> Request<'_, C> {
         self.materialize(prompt).await
     }
 
+    /// Extract a structured `T` with one report shape on success and failure.
+    pub async fn extract_with_report<T>(self, prompt: &str) -> ExtractionResult<T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        self.client
+            .materialize_request_with_attempts(self.system.as_deref(), prompt, &self.media)
+            .await
+            .map(Extraction::from)
+            .map_err(ExtractionError::from)
+    }
+
     /// Materialize a structured `T`, applying any attached system context and media.
     ///
     /// This is the original name for [`extract`](Self::extract).
@@ -120,6 +135,7 @@ impl<C: LLMClient + Sync + ?Sized> Request<'_, C> {
     }
 
     /// Materialize a structured `T` with cumulative usage and every provider attempt.
+    #[doc(hidden)]
     pub async fn materialize_with_attempts<T>(
         self,
         prompt: &str,

--- a/src/backend/usage.rs
+++ b/src/backend/usage.rs
@@ -286,6 +286,151 @@ impl AttemptRecord {
     }
 }
 
+/// Run metadata shared by successful and failed structured extractions.
+///
+/// The same report shape is available on [`Extraction<T>`] and
+/// [`ExtractionError`], so callers can inspect attempts and usage without
+/// maintaining separate success and failure accounting code.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ExtractionReport {
+    /// Usage from the final provider response, when it was reported.
+    ///
+    /// On failure this is taken from the final recorded attempt. A transport
+    /// failure or provider response that omitted usage leaves it as `None`.
+    pub final_usage: Option<TokenUsage>,
+    /// Cumulative known usage across every provider response in this run.
+    pub cumulative_usage: Option<RunUsage>,
+    /// Ordered, one-indexed attempt ledger.
+    pub attempts: Vec<AttemptRecord>,
+    /// Whether `attempts` and `cumulative_usage` cover the complete run.
+    ///
+    /// Built-in providers and the optional `MockClient` set this to `true`.
+    /// Compatibility fallbacks for custom clients set it to `false` rather
+    /// than inventing attempts they cannot observe.
+    pub attempts_complete: bool,
+}
+
+impl ExtractionReport {
+    fn from_success<T>(report: MaterializeReport<T>) -> (T, Self) {
+        let MaterializeReport {
+            data,
+            final_usage,
+            cumulative_usage,
+            attempts,
+            attempts_complete,
+        } = report;
+        (
+            data,
+            Self {
+                final_usage,
+                cumulative_usage,
+                attempts,
+                attempts_complete,
+            },
+        )
+    }
+
+    fn from_failure(failure: MaterializeFailure) -> (Box<RStructorError>, Self) {
+        let MaterializeFailure {
+            error,
+            cumulative_usage,
+            attempts,
+            attempts_complete,
+        } = failure;
+        let final_usage = attempts.last().and_then(|attempt| attempt.usage.clone());
+        (
+            error,
+            Self {
+                final_usage,
+                cumulative_usage,
+                attempts,
+                attempts_complete,
+            },
+        )
+    }
+}
+
+/// A validated value and its complete available extraction report.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct Extraction<T> {
+    /// Deserialized and validated data.
+    pub data: T,
+    /// Usage and attempt metadata for the run.
+    pub report: ExtractionReport,
+}
+
+impl<T> Extraction<T> {
+    /// Map the extracted value while preserving the run report.
+    pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> Extraction<U> {
+        Extraction {
+            data: f(self.data),
+            report: self.report,
+        }
+    }
+
+    /// Consume the extraction and return its validated value.
+    #[must_use]
+    pub fn into_data(self) -> T {
+        self.data
+    }
+}
+
+impl<T> From<MaterializeReport<T>> for Extraction<T> {
+    fn from(report: MaterializeReport<T>) -> Self {
+        let (data, report) = ExtractionReport::from_success(report);
+        Self { data, report }
+    }
+}
+
+/// A failed extraction and the same report shape returned on success.
+#[derive(Debug)]
+pub struct ExtractionError {
+    error: Box<RStructorError>,
+    /// Usage and attempt metadata collected before the failure.
+    pub report: ExtractionReport,
+}
+
+impl ExtractionError {
+    /// Return the original final error.
+    #[must_use]
+    pub fn error(&self) -> &RStructorError {
+        &self.error
+    }
+
+    /// Consume the extraction error and return the original final error.
+    #[must_use]
+    pub fn into_error(self) -> RStructorError {
+        *self.error
+    }
+}
+
+impl From<MaterializeFailure> for ExtractionError {
+    fn from(failure: MaterializeFailure) -> Self {
+        let (error, report) = ExtractionReport::from_failure(failure);
+        Self { error, report }
+    }
+}
+
+impl fmt::Display for ExtractionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.error().fmt(formatter)
+    }
+}
+
+impl std::error::Error for ExtractionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.error())
+    }
+}
+
+/// The advanced structured-extraction result type.
+///
+/// Both variants carry an [`ExtractionReport`]: success through
+/// [`Extraction::report`] and failure through [`ExtractionError::report`].
+pub type ExtractionResult<T> = std::result::Result<Extraction<T>, ExtractionError>;
+
 /// Successful structured-output run with usage and available attempt metadata.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
@@ -581,5 +726,70 @@ mod tests {
         assert!(failure.cumulative_usage.is_none());
         assert!(!failure.attempts_complete);
         assert!(matches!(failure.error(), RStructorError::SchemaError(_)));
+    }
+
+    #[test]
+    fn extraction_success_uses_the_shared_report_and_maps_data() {
+        let final_usage = TokenUsage::new("risk-model-v2", 120, 18);
+        let cumulative_usage = RunUsage::from_response(final_usage.clone());
+        let legacy = MaterializeReport::new(
+            "HF-ALPHA-001",
+            Some(final_usage.clone()),
+            Some(cumulative_usage.clone()),
+            vec![AttemptRecord::succeeded(1, Some(final_usage.clone()))],
+        );
+
+        let extraction = Extraction::from(legacy).map(str::len);
+
+        assert_eq!(extraction.data, 12);
+        assert_eq!(extraction.report.final_usage, Some(final_usage));
+        assert_eq!(extraction.report.cumulative_usage, Some(cumulative_usage));
+        assert_eq!(extraction.report.attempts.len(), 1);
+        assert!(extraction.report.attempts_complete);
+    }
+
+    #[test]
+    fn extraction_failure_uses_the_same_report_shape_and_final_attempt_usage() {
+        let first_usage = TokenUsage::new("risk-model-v1", 90, 15);
+        let final_usage = TokenUsage::new("risk-model-v2", 100, 12);
+        let mut cumulative_usage = RunUsage::new();
+        cumulative_usage.record(first_usage.clone());
+        cumulative_usage.record(final_usage.clone());
+        let final_error = RStructorError::OutputDecodeError {
+            path: "$.positions[1].quantity".into(),
+            message: "invalid type: string, expected i64".into(),
+        };
+        let failure = MaterializeFailure::new(
+            final_error,
+            Some(cumulative_usage.clone()),
+            vec![
+                AttemptRecord::failed(
+                    1,
+                    AttemptKind::Semantic,
+                    &RStructorError::ValidationError("invalid quantity".into()),
+                    RetryDisposition::Retried,
+                    Some(first_usage),
+                ),
+                AttemptRecord::failed(
+                    2,
+                    AttemptKind::Semantic,
+                    &RStructorError::ValidationError("invalid quantity".into()),
+                    RetryDisposition::BudgetExhausted,
+                    Some(final_usage.clone()),
+                ),
+            ],
+        );
+
+        let error = ExtractionError::from(failure);
+
+        assert!(matches!(
+            error.error(),
+            RStructorError::OutputDecodeError { path, .. }
+                if path == "$.positions[1].quantity"
+        ));
+        assert_eq!(error.report.final_usage, Some(final_usage));
+        assert_eq!(error.report.cumulative_usage, Some(cumulative_usage));
+        assert_eq!(error.report.attempts.len(), 2);
+        assert!(error.report.attempts_complete);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,9 +86,9 @@ pub use backend::{
     AnyClient, Provider, Request, RequestExt, client, client_from_env, parse_client_spec,
 };
 pub use backend::{
-    AttemptKind, AttemptOutcome, AttemptRecord, ChatMessage, ChatRole, GenerateResult,
-    MaterializeFailure, MaterializeReport, MaterializeResult, MediaFile, RetryDisposition,
-    RunUsage, TokenUsage,
+    AttemptKind, AttemptOutcome, AttemptRecord, ChatMessage, ChatRole, Extraction, ExtractionError,
+    ExtractionReport, ExtractionResult, GenerateResult, MaterializeFailure, MaterializeReport,
+    MaterializeResult, MediaFile, RetryDisposition, RunUsage, TokenUsage,
 };
 #[cfg(feature = "_client")]
 pub use backend::{DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT};

--- a/tests/core_ergonomics_test.rs
+++ b/tests/core_ergonomics_test.rs
@@ -59,6 +59,55 @@ impl LLMClient for NoMediaClient {
     }
 }
 
+/// A minimal custom client only implements the four core operations. Metadata,
+/// media, and reporting behavior comes from compatibility defaults.
+struct MinimalClient;
+
+#[async_trait]
+impl LLMClient for MinimalClient {
+    async fn materialize<T>(&self, _prompt: &str) -> Result<T>
+    where
+        T: Instructor + DeserializeOwned + Send + 'static,
+    {
+        Err(RStructorError::ValidationError("minimal-extract".into()))
+    }
+
+    async fn generate(&self, prompt: &str) -> Result<String> {
+        Ok(format!("minimal:{prompt}"))
+    }
+
+    fn from_env() -> Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Self)
+    }
+
+    async fn list_models(&self) -> Result<Vec<ModelInfo>> {
+        Ok(Vec::new())
+    }
+}
+
+#[tokio::test]
+async fn minimal_custom_client_inherits_metadata_and_report_defaults() {
+    let client = MinimalClient;
+
+    let generated = client.generate_with_metadata("status").await.unwrap();
+    assert_eq!(generated.text, "minimal:status");
+    assert!(generated.usage.is_none());
+
+    let failure = client
+        .extract_with_report::<Dummy>("position")
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        failure.error(),
+        RStructorError::ValidationError(message) if message == "minimal-extract"
+    ));
+    assert!(failure.report.attempts.is_empty());
+    assert!(!failure.report.attempts_complete);
+}
+
 #[tokio::test]
 async fn extract_alias_delegates_to_materialize_for_custom_clients() {
     let client = NoMediaClient;
@@ -67,6 +116,21 @@ async fn extract_alias_delegates_to_materialize_for_custom_clients() {
         matches!(result, Err(RStructorError::ValidationError(message)) if message == "materialize-called"),
         "extract() must preserve compatibility with existing custom clients"
     );
+}
+
+#[tokio::test]
+async fn extract_report_fallback_is_honest_for_custom_clients() {
+    let client = NoMediaClient;
+    let failure = client.extract_with_report::<Dummy>("hi").await.unwrap_err();
+
+    assert!(matches!(
+        failure.error(),
+        RStructorError::ValidationError(message) if message == "materialize-called"
+    ));
+    assert!(failure.report.attempts.is_empty());
+    assert!(failure.report.final_usage.is_none());
+    assert!(failure.report.cumulative_usage.is_none());
+    assert!(!failure.report.attempts_complete);
 }
 
 #[tokio::test]
@@ -188,6 +252,32 @@ mod builder {
         let request = client.last_request().unwrap();
         assert_eq!(request.kind, RequestKind::Materialize);
         assert_eq!(request.prompt, "CTX\n\nhello");
+    }
+
+    #[tokio::test]
+    async fn extract_report_preserves_builder_system_and_media_routing() {
+        let client = MockClient::new().with_response(r#"{"value":"risk chart"}"#);
+        let media = [MediaFile::new(
+            "https://example.com/risk-chart.png",
+            "image/png",
+        )];
+
+        let extraction = client
+            .with_system("Use the fund's base currency.")
+            .media(media.to_vec())
+            .extract_with_report::<Dummy>("read the chart")
+            .await
+            .unwrap();
+
+        assert_eq!(extraction.data.value, "risk chart");
+        assert_eq!(extraction.report.attempts.len(), 1);
+        let request = client.last_request().unwrap();
+        assert_eq!(request.kind, RequestKind::MaterializeWithMediaAndAttempts);
+        assert_eq!(
+            request.prompt,
+            "Use the fund's base currency.\n\nread the chart"
+        );
+        assert_eq!(request.media.len(), 1);
     }
 
     #[tokio::test]

--- a/tests/extraction_report_tests.rs
+++ b/tests/extraction_report_tests.rs
@@ -1,0 +1,111 @@
+//! End-to-end coverage for the uniform extraction report using sanitized
+//! real-world portfolio fixtures.
+
+#![cfg(feature = "mock")]
+
+use rstructor::{
+    AttemptOutcome, Instructor, LLMClient, MockClient, RStructorError, RetryDisposition, TokenUsage,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Instructor, PartialEq, Serialize)]
+struct Portfolio {
+    portfolio_id: String,
+    positions: Vec<Position>,
+}
+
+#[derive(Debug, Deserialize, Instructor, PartialEq, Serialize)]
+struct Position {
+    symbol: String,
+    quantity: i64,
+}
+
+#[tokio::test]
+async fn successful_reask_returns_value_and_shared_report() {
+    let client = MockClient::new()
+        .with_response_and_usage(
+            include_str!("fixtures/structured/portfolio_invalid_quantity.json"),
+            TokenUsage::new("mock-risk-router-v1", 90, 15),
+        )
+        .with_response_and_usage(
+            include_str!("fixtures/structured/portfolio_valid.json"),
+            TokenUsage::new("mock-risk-router-v2", 120, 18),
+        )
+        .with_retries(1);
+
+    let extraction = client
+        .extract_with_report::<Portfolio>("reconcile positions")
+        .await
+        .unwrap();
+
+    assert_eq!(extraction.data.portfolio_id, "HF-ALPHA-001");
+    assert_eq!(extraction.data.positions[1].quantity, -240);
+    assert_eq!(extraction.report.attempts.len(), 2);
+    assert!(matches!(
+        extraction.report.attempts[0].outcome,
+        AttemptOutcome::Failed {
+            disposition: RetryDisposition::Retried,
+            ..
+        }
+    ));
+    assert_eq!(
+        extraction.report.attempts[1].outcome,
+        AttemptOutcome::Succeeded
+    );
+    assert_eq!(
+        extraction
+            .report
+            .cumulative_usage
+            .as_ref()
+            .unwrap()
+            .total_tokens(),
+        243
+    );
+    assert_eq!(
+        extraction.report.final_usage.as_ref().unwrap().model,
+        "mock-risk-router-v2"
+    );
+    assert!(extraction.report.attempts_complete);
+}
+
+#[tokio::test]
+async fn exhausted_reask_returns_the_same_report_shape_with_the_error() {
+    let invalid = include_str!("fixtures/structured/portfolio_invalid_quantity.json");
+    let client = MockClient::new()
+        .with_response_and_usage(invalid, TokenUsage::new("mock-risk-router-v1", 80, 10))
+        .with_response_and_usage(invalid, TokenUsage::new("mock-risk-router-v2", 100, 12))
+        .with_retries(1);
+
+    let failure = client
+        .extract_with_report::<Portfolio>("reconcile positions")
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error(),
+        RStructorError::OutputDecodeError { path, .. }
+            if path == "$.positions[1].quantity"
+    ));
+    assert_eq!(failure.report.attempts.len(), 2);
+    assert!(matches!(
+        failure.report.attempts[1].outcome,
+        AttemptOutcome::Failed {
+            disposition: RetryDisposition::BudgetExhausted,
+            ..
+        }
+    ));
+    assert_eq!(
+        failure
+            .report
+            .cumulative_usage
+            .as_ref()
+            .unwrap()
+            .total_tokens(),
+        202
+    );
+    assert_eq!(
+        failure.report.final_usage.as_ref().unwrap().model,
+        "mock-risk-router-v2"
+    );
+    assert!(failure.report.attempts_complete);
+}


### PR DESCRIPTION
## Why

Structured extraction exposed separate success, metadata, attempt-report, media, and failure types. Callers that needed observability had to write different accounting code for success and failure, and custom `LLMClient` implementations had to provide metadata methods even when they did not have metadata to report.

## What changed

- adds `extract_with_report` as the single advanced structured-extraction terminal on clients and fluent requests
- introduces `Extraction<T>` and `ExtractionError`, both carrying the same `ExtractionReport`
- places final usage, cumulative usage, ordered attempts, and completeness in that shared report
- derives failed-run `final_usage` from the final recorded provider attempt when available
- keeps the existing `MaterializeResult`, `MaterializeReport`, and `MaterializeFailure` APIs callable for compatibility while removing specialized materialization variants from the primary generated-doc surface
- gives metadata methods honest no-metadata defaults, reducing a minimal custom client to four required operations
- updates the README, cookbook, and usage examples to use the converged report path

The provider implementations and retry engine continue to produce the existing internal attempt ledger. Conversion into the new public envelope is lossless, so this change does not fork retry or accounting behavior.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --target-dir tmp/pr1-target -- -D warnings`
- `cargo test --doc --all-features --target-dir tmp/pr1-target`
- deterministic all-feature test matrix, excluding only credentialed live-provider modules
- targeted live Gemini tagged-enum integration test
- schema-only checks with `--no-default-features --features derive` and `--features derive,mock`

New tests use the sanitized `HF-ALPHA-001` portfolio fixtures to verify both a corrected two-attempt success and an exhausted two-attempt failure. They assert identical report fields, path-aware failure preservation, final-attempt usage, cumulative usage, and retry dispositions. Additional tests cover request-builder system/media routing and minimal third-party client defaults.

One sequential live-provider run encountered a transient five-minute Gemini timeout after earlier provider calls. The exact test passed in 6 seconds when rerun in isolation; the deterministic suite and changed paths remained green.
