### PR TITLE
Add observable provider attempt metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,62 @@ inventing provider attempts it cannot observe.
 See `examples/retry_attempt_ledger.rs` for a complete success-and-failure
 example.
 
+### Provider response diagnostics
+
+Every built-in extraction attempt retains the exact HTTP status and recognized
+provider request-ID headers. The metadata has the same location on success and
+failure:
+
+```rust
+let result = client
+    .extract_with_report::<Portfolio>("Reconcile the fund book")
+    .await;
+let report = match &result {
+    Ok(extraction) => &extraction.report,
+    Err(failure) => &failure.report,
+};
+
+for attempt in &report.attempts {
+    if let Some(response) = &attempt.response {
+        println!("status={} request_id={:?}", response.status, response.request_id());
+    }
+}
+```
+
+Provider errors also expose `status_code()`, `request_id()`, and
+`response_metadata()` directly. Response bodies are never stored by default.
+Opting in requires an explicit sanitizer callback; only the callback's bounded
+output is retained:
+
+```rust
+use rstructor::ResponseBodyCapture;
+
+let account_id = account_id.to_owned();
+let capture = ResponseBodyCapture::new(move |body| {
+    body.replace(&account_id, "[ACCOUNT]")
+}).max_bytes(8 * 1024);
+let client = OpenAIClient::from_env()?.capture_response_bodies(capture);
+```
+
+Treat the callback as a privacy boundary: remove prompts, generated content,
+personal data, credentials, and internal identifiers that are not safe for your
+logs or fixtures.
+
+### OpenTelemetry GenAI spans
+
+Built-in non-streaming extraction and generation calls emit one `tracing` span
+per provider attempt using the OpenTelemetry GenAI inference-client fields. An
+application can export those spans through its existing
+`tracing-opentelemetry` layer; rstructor does not install a global subscriber or
+pull an OpenTelemetry SDK into the library dependency graph.
+
+The spans include operation, provider, requested and response models, endpoint,
+token/cache usage, response ID when supplied, and a low-cardinality error type.
+Prompt text, system instructions, model output, and tool content are never
+recorded. The upstream GenAI semantic conventions are currently marked
+development-stability; `rstructor::telemetry::GEN_AI_SEMCONV_STABILITY` exposes
+that status explicitly.
+
 ## Error Handling
 
 ```rust

--- a/src/backend/anthropic.rs
+++ b/src/backend/anthropic.rs
@@ -3,19 +3,19 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::time::Duration;
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{Instrument, debug, error, info, instrument, trace, warn};
 
 use crate::backend::model_macro::define_model_enum;
 use crate::backend::{
     AnthropicMessageContent, ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient,
     MaterializeAttemptError, MaterializeFailure, MaterializeInternalOutput, MaterializeReport,
     MaterializeResult, ModelInfo, StrictSchemaProvider, ThinkingLevel, TokenUsage,
-    build_anthropic_message_content, build_http_client, check_response_status,
+    build_anthropic_message_content, build_http_client, check_response_status_with_capture,
     compile_strict_schema, generate_with_retry_attempts_with_history,
     generate_with_retry_attempts_with_initial_messages, generate_with_retry_with_history,
     generate_with_retry_with_initial_messages, handle_http_error, materialize_request_error,
     materialize_with_media_and_attempts_with_retry, materialize_with_media_with_retry,
-    parse_validate_and_create_output, request_messages,
+    parse_json_response, parse_validate_and_create_output, request_messages,
 };
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
@@ -88,6 +88,8 @@ pub struct AnthropicConfig {
     /// Thinking level for Claude 4.x models (Sonnet 4, Opus 4, etc.)
     /// When enabled, temperature is automatically set to 1.0 as required by the API
     pub thinking_level: Option<ThinkingLevel>,
+    /// Opt-in caller-sanitized provider response capture.
+    pub response_body_capture: Option<crate::ResponseBodyCapture>,
 }
 
 /// Anthropic client for generating completions
@@ -238,6 +240,7 @@ impl UsageInfo {
 
 #[derive(Debug, Deserialize)]
 struct CompletionResponse {
+    id: Option<String>,
     content: Vec<ContentBlock>,
     model: Option<String>,
     usage: Option<UsageInfo>,
@@ -280,6 +283,7 @@ impl AnthropicClient {
             max_retries: Some(3),                   // Default: 3 retries with error feedback
             base_url: None,                         // Default: use official Anthropic API
             thinking_level: None, // Default: no extended thinking (faster responses)
+            response_body_capture: None,
         };
 
         debug!("Anthropic client created with default configuration");
@@ -322,6 +326,7 @@ impl AnthropicClient {
             max_retries: Some(3),                   // Default: 3 retries with error feedback
             base_url: None,                         // Default: use official Anthropic API
             thinking_level: None, // Default: no extended thinking (faster responses)
+            response_body_capture: None,
         };
 
         debug!("Anthropic client created with default configuration");
@@ -424,6 +429,14 @@ impl AnthropicClient {
             .as_deref()
             .unwrap_or("https://api.anthropic.com/v1");
         let url = format!("{}/messages", base_url);
+        let gen_ai_span = crate::telemetry::inference_span(
+            "anthropic",
+            "chat",
+            self.config.model.as_str(),
+            &url,
+            Some(f64::from(effective_temp)),
+            Some(u64::from(request.max_tokens)),
+        );
         debug!(url = %url, "Using Anthropic API endpoint");
         let response = self
             .client
@@ -434,18 +447,35 @@ impl AnthropicClient {
             .header("Content-Type", "application/json")
             .json(&request)
             .send()
+            .instrument(gen_ai_span.clone())
             .await
-            .map_err(|error| materialize_request_error(error, "Anthropic"))?;
+            .map_err(|error| {
+                crate::telemetry::record_http_client_error(&gen_ai_span, &error);
+                materialize_request_error(error, "Anthropic")
+            })?;
 
         // Parse the response
-        let response = check_response_status(response, "Anthropic")
-            .await
-            .map_err(MaterializeAttemptError::transport)?;
+        let response = check_response_status_with_capture(
+            response,
+            "Anthropic",
+            self.config.response_body_capture.as_ref(),
+        )
+        .await
+        .map_err(|error| {
+            crate::telemetry::record_error(&gen_ai_span, &error);
+            MaterializeAttemptError::transport(error)
+        })?;
 
         debug!("Successfully received response from Anthropic");
-        let completion: CompletionResponse = response.json().await.map_err(|e| {
-            error!(error = %e, "Failed to parse JSON response from Anthropic");
-            MaterializeAttemptError::transport(RStructorError::from(e))
+        let (completion, response_metadata): (CompletionResponse, _) = parse_json_response(
+            response,
+            "Anthropic",
+            self.config.response_body_capture.as_ref(),
+        )
+        .await
+        .map_err(|error| {
+            crate::telemetry::record_error(&gen_ai_span, &error);
+            MaterializeAttemptError::transport(error)
         })?;
 
         // Extract usage info
@@ -474,22 +504,35 @@ impl AnthropicClient {
             }
             None => {
                 error!("No text content in Anthropic response");
-                return Err(MaterializeAttemptError::transport_with_usage(
-                    RStructorError::api_error(
-                        "Anthropic",
-                        ApiErrorKind::UnexpectedResponse {
-                            details: "No text content in response".to_string(),
-                        },
-                    ),
-                    usage,
-                ));
+                let error = RStructorError::api_error_with_response(
+                    "Anthropic",
+                    ApiErrorKind::UnexpectedResponse {
+                        details: "No text content in response".to_string(),
+                    },
+                    response_metadata.clone(),
+                );
+                crate::telemetry::record_error(&gen_ai_span, &error);
+                return Err(MaterializeAttemptError::transport_with_usage(error, usage)
+                    .with_response(response_metadata));
             }
         };
 
+        crate::telemetry::record_success(
+            &gen_ai_span,
+            completion.id.as_deref(),
+            Some(&model_name),
+            usage.as_ref(),
+        );
+
         // Parse the JSON content directly using shared utility
         // With native structured outputs, the response is guaranteed to be valid JSON
-        trace!(json = %raw_response, "Parsing structured output response");
+        trace!(
+            response_bytes = raw_response.len(),
+            "Parsing structured output response"
+        );
         parse_validate_and_create_output(raw_response, usage)
+            .map(|output| output.with_response(response_metadata.clone()))
+            .map_err(|error| error.with_response(response_metadata))
     }
 
     /// Internal implementation of raw text generation (no structured output).
@@ -547,6 +590,14 @@ impl AnthropicClient {
             .as_deref()
             .unwrap_or("https://api.anthropic.com/v1");
         let url = format!("{}/messages", base_url);
+        let gen_ai_span = crate::telemetry::inference_span(
+            "anthropic",
+            "chat",
+            self.config.model.as_str(),
+            &url,
+            Some(f64::from(effective_temp)),
+            Some(u64::from(request.max_tokens)),
+        );
         debug!(url = %url, "Using Anthropic API endpoint");
         let response = self
             .client
@@ -556,24 +607,40 @@ impl AnthropicClient {
             .header("Content-Type", "application/json")
             .json(&request)
             .send()
+            .instrument(gen_ai_span.clone())
             .await
-            .map_err(|e| handle_http_error(e, "Anthropic"))?;
+            .map_err(|error| {
+                crate::telemetry::record_http_client_error(&gen_ai_span, &error);
+                handle_http_error(error, "Anthropic")
+            })?;
 
         // Parse the response
-        let response = check_response_status(response, "Anthropic").await?;
+        let response = check_response_status_with_capture(
+            response,
+            "Anthropic",
+            self.config.response_body_capture.as_ref(),
+        )
+        .await
+        .inspect_err(|error| crate::telemetry::record_error(&gen_ai_span, error))?;
 
         debug!("Successfully received response from Anthropic");
-        let completion: CompletionResponse = response.json().await.map_err(|e| {
-            error!(error = %e, "Failed to parse JSON response from Anthropic");
-            e
-        })?;
+        let (completion, response_metadata): (CompletionResponse, _) = parse_json_response(
+            response,
+            "Anthropic",
+            self.config.response_body_capture.as_ref(),
+        )
+        .await
+        .inspect_err(|error| crate::telemetry::record_error(&gen_ai_span, error))?;
 
         // Extract usage info
         let model_name = completion
             .model
             .clone()
             .unwrap_or_else(|| self.config.model.as_str().to_string());
-        let usage = completion.usage.as_ref().map(|u| u.token_usage(model_name));
+        let usage = completion
+            .usage
+            .as_ref()
+            .map(|u| u.token_usage(model_name.clone()));
 
         // Extract the content
         debug!("Extracting text content from response blocks");
@@ -587,14 +654,23 @@ impl AnthropicClient {
 
         if content.is_empty() {
             error!("No text content in Anthropic response");
-            return Err(RStructorError::api_error(
+            let error = RStructorError::api_error_with_response(
                 "Anthropic",
                 ApiErrorKind::UnexpectedResponse {
                     details: "No text content in response".to_string(),
                 },
-            ));
+                response_metadata,
+            );
+            crate::telemetry::record_error(&gen_ai_span, &error);
+            return Err(error);
         }
 
+        crate::telemetry::record_success(
+            &gen_ai_span,
+            completion.id.as_deref(),
+            Some(&model_name),
+            usage.as_ref(),
+        );
         debug!(
             content_len = content.len(),
             "Successfully extracted text content"
@@ -723,6 +799,7 @@ impl AnthropicClient {
     ) -> impl std::future::Future<Output = Result<reqwest::Response>> + Send + 'static {
         let client = self.client.clone();
         let api_key = self.config.api_key.clone();
+        let response_body_capture = self.config.response_body_capture.clone();
         let base_url = self
             .config
             .base_url
@@ -740,7 +817,8 @@ impl AnthropicClient {
                 .send()
                 .await
                 .map_err(|e| handle_http_error(e, "Anthropic"))?;
-            check_response_status(resp, "Anthropic").await
+            check_response_status_with_capture(resp, "Anthropic", response_body_capture.as_ref())
+                .await
         }
     }
 }
@@ -1156,7 +1234,12 @@ impl LLMClient for AnthropicClient {
             .await
             .map_err(|e| handle_http_error(e, "Anthropic"))?;
 
-        let response = check_response_status(response, "Anthropic").await?;
+        let response = check_response_status_with_capture(
+            response,
+            "Anthropic",
+            self.config.response_body_capture.as_ref(),
+        )
+        .await?;
 
         let json: serde_json::Value = response.json().await.map_err(|e| {
             error!(error = %e, "Failed to parse models response from Anthropic");

--- a/src/backend/gemini.rs
+++ b/src/backend/gemini.rs
@@ -3,17 +3,18 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::time::Duration;
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{Instrument, debug, error, info, instrument, trace, warn};
 
 use crate::backend::model_macro::define_model_enum;
 use crate::backend::{
     ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient, MaterializeAttemptError,
     MaterializeFailure, MaterializeInternalOutput, MaterializeReport, MaterializeResult, ModelInfo,
-    ThinkingLevel, TokenUsage, build_http_client, check_response_status,
+    ThinkingLevel, TokenUsage, build_http_client, check_response_status_with_capture,
     generate_with_retry_attempts_with_history, generate_with_retry_attempts_with_initial_messages,
     generate_with_retry_with_history, generate_with_retry_with_initial_messages, handle_http_error,
     materialize_request_error, materialize_with_media_and_attempts_with_retry,
-    materialize_with_media_with_retry, parse_validate_and_create_output, request_messages,
+    materialize_with_media_with_retry, parse_json_response, parse_validate_and_create_output,
+    request_messages,
 };
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
@@ -104,6 +105,8 @@ pub struct GeminiConfig {
     /// Thinking level for Gemini 3.x models
     /// Controls the depth of reasoning applied to prompts
     pub thinking_level: Option<ThinkingLevel>,
+    /// Opt-in caller-sanitized provider response capture.
+    pub response_body_capture: Option<crate::ResponseBodyCapture>,
 }
 
 /// Gemini client for generating completions
@@ -197,6 +200,8 @@ impl UsageMetadata {
 
 #[derive(Debug, Deserialize)]
 struct GenerateContentResponse {
+    #[serde(rename = "responseId")]
+    response_id: Option<String>,
     candidates: Vec<Candidate>,
     #[serde(rename = "usageMetadata")]
     usage_metadata: Option<UsageMetadata>,
@@ -313,6 +318,7 @@ impl GeminiClient {
             max_retries: Some(3),                   // Default: 3 retries with error feedback
             base_url: None,                         // Default: use official Gemini API
             thinking_level: Some(ThinkingLevel::Low), // Default to Low thinking for Gemini 3.x
+            response_body_capture: None,
         };
 
         let client = build_http_client(DEFAULT_REQUEST_TIMEOUT);
@@ -358,6 +364,7 @@ impl GeminiClient {
             max_retries: Some(3),                   // Default: 3 retries with error feedback
             base_url: None,                         // Default: use official Gemini API
             thinking_level: Some(ThinkingLevel::Low), // Default to Low thinking for Gemini 3.x
+            response_body_capture: None,
         };
 
         let client = build_http_client(DEFAULT_REQUEST_TIMEOUT);
@@ -445,6 +452,14 @@ impl GeminiClient {
             base_url,
             self.config.model.as_str()
         );
+        let gen_ai_span = crate::telemetry::inference_span(
+            "gcp.gemini",
+            "generate_content",
+            self.config.model.as_str(),
+            &url,
+            Some(f64::from(self.config.temperature)),
+            self.config.max_tokens.map(u64::from),
+        );
         debug!(
             url = %url,
             model = %self.config.model.as_str(),
@@ -458,17 +473,34 @@ impl GeminiClient {
             .header("Content-Type", "application/json")
             .json(&request)
             .send()
+            .instrument(gen_ai_span.clone())
             .await
-            .map_err(|error| materialize_request_error(error, "Gemini"))?;
+            .map_err(|error| {
+                crate::telemetry::record_http_client_error(&gen_ai_span, &error);
+                materialize_request_error(error, "Gemini")
+            })?;
 
-        let response = check_response_status(response, "Gemini")
-            .await
-            .map_err(MaterializeAttemptError::transport)?;
+        let response = check_response_status_with_capture(
+            response,
+            "Gemini",
+            self.config.response_body_capture.as_ref(),
+        )
+        .await
+        .map_err(|error| {
+            crate::telemetry::record_error(&gen_ai_span, &error);
+            MaterializeAttemptError::transport(error)
+        })?;
 
         debug!("Successfully received response from Gemini API");
-        let completion: GenerateContentResponse = response.json().await.map_err(|e| {
-            error!(error = %e, "Failed to parse JSON response from Gemini API");
-            MaterializeAttemptError::transport(RStructorError::from(e))
+        let (completion, response_metadata): (GenerateContentResponse, _) = parse_json_response(
+            response,
+            "Gemini",
+            self.config.response_body_capture.as_ref(),
+        )
+        .await
+        .map_err(|error| {
+            crate::telemetry::record_error(&gen_ai_span, &error);
+            MaterializeAttemptError::transport(error)
         })?;
 
         // Extract usage before validating the envelope so protocol failures can
@@ -484,15 +516,16 @@ impl GeminiClient {
 
         if completion.candidates.is_empty() {
             error!("Gemini API returned empty candidates array");
-            return Err(MaterializeAttemptError::transport_with_usage(
-                RStructorError::api_error(
-                    "Gemini",
-                    ApiErrorKind::UnexpectedResponse {
-                        details: "No completion candidates returned".to_string(),
-                    },
-                ),
-                usage,
-            ));
+            let error = RStructorError::api_error_with_response(
+                "Gemini",
+                ApiErrorKind::UnexpectedResponse {
+                    details: "No completion candidates returned".to_string(),
+                },
+                response_metadata.clone(),
+            );
+            crate::telemetry::record_error(&gen_ai_span, &error);
+            return Err(MaterializeAttemptError::transport_with_usage(error, usage)
+                .with_response(response_metadata));
         }
 
         let candidate = &completion.candidates[0];
@@ -502,10 +535,19 @@ impl GeminiClient {
         debug!(parts = parts.len(), "Processing candidate content parts");
         for part in parts {
             if let Some(text) = &part.text {
+                crate::telemetry::record_success(
+                    &gen_ai_span,
+                    completion.response_id.as_deref(),
+                    Some(&model_name),
+                    usage.as_ref(),
+                );
                 let mut raw_response = text.clone();
                 debug!(content_len = raw_response.len(), "Processing text part");
                 // With native responseJsonSchema, the response is guaranteed to be valid JSON
-                trace!(json = %raw_response, "Parsing structured output response");
+                trace!(
+                    response_bytes = raw_response.len(),
+                    "Parsing structured output response"
+                );
 
                 // Transform internally tagged enums back to adjacently tagged format if needed
                 if let Some(ref enum_info) = adjacently_tagged_info
@@ -520,20 +562,23 @@ impl GeminiClient {
                 }
 
                 // Parse and validate the response using shared utility
-                return parse_validate_and_create_output(raw_response, usage);
+                return parse_validate_and_create_output(raw_response, usage)
+                    .map(|output| output.with_response(response_metadata.clone()))
+                    .map_err(|error| error.with_response(response_metadata));
             }
         }
 
         error!("No text content in Gemini response");
-        Err(MaterializeAttemptError::transport_with_usage(
-            RStructorError::api_error(
-                "Gemini",
-                ApiErrorKind::UnexpectedResponse {
-                    details: "No text content in response".to_string(),
-                },
-            ),
-            usage,
-        ))
+        let error = RStructorError::api_error_with_response(
+            "Gemini",
+            ApiErrorKind::UnexpectedResponse {
+                details: "No text content in response".to_string(),
+            },
+            response_metadata.clone(),
+        );
+        crate::telemetry::record_error(&gen_ai_span, &error);
+        Err(MaterializeAttemptError::transport_with_usage(error, usage)
+            .with_response(response_metadata))
     }
 
     /// Internal implementation of raw text generation (no structured output).
@@ -582,6 +627,14 @@ impl GeminiClient {
             base_url,
             self.config.model.as_str()
         );
+        let gen_ai_span = crate::telemetry::inference_span(
+            "gcp.gemini",
+            "generate_content",
+            self.config.model.as_str(),
+            &url,
+            Some(f64::from(self.config.temperature)),
+            self.config.max_tokens.map(u64::from),
+        );
         debug!(
             url = %url,
             model = %self.config.model.as_str(),
@@ -594,26 +647,42 @@ impl GeminiClient {
             .header("Content-Type", "application/json")
             .json(&request)
             .send()
+            .instrument(gen_ai_span.clone())
             .await
-            .map_err(|e| handle_http_error(e, "Gemini"))?;
+            .map_err(|error| {
+                crate::telemetry::record_http_client_error(&gen_ai_span, &error);
+                handle_http_error(error, "Gemini")
+            })?;
 
         // Parse the response
-        let response = check_response_status(response, "Gemini").await?;
+        let response = check_response_status_with_capture(
+            response,
+            "Gemini",
+            self.config.response_body_capture.as_ref(),
+        )
+        .await
+        .inspect_err(|error| crate::telemetry::record_error(&gen_ai_span, error))?;
 
         debug!("Successfully received response from Gemini API");
-        let completion: GenerateContentResponse = response.json().await.map_err(|e| {
-            error!(error = %e, "Failed to parse JSON response from Gemini API");
-            e
-        })?;
+        let (completion, response_metadata): (GenerateContentResponse, _) = parse_json_response(
+            response,
+            "Gemini",
+            self.config.response_body_capture.as_ref(),
+        )
+        .await
+        .inspect_err(|error| crate::telemetry::record_error(&gen_ai_span, error))?;
 
         if completion.candidates.is_empty() {
             error!("Gemini API returned empty candidates array");
-            return Err(RStructorError::api_error(
+            let error = RStructorError::api_error_with_response(
                 "Gemini",
                 ApiErrorKind::UnexpectedResponse {
                     details: "No completion candidates returned".to_string(),
                 },
-            ));
+                response_metadata,
+            );
+            crate::telemetry::record_error(&gen_ai_span, &error);
+            return Err(error);
         }
 
         // Extract usage info
@@ -624,7 +693,7 @@ impl GeminiClient {
         let usage = completion
             .usage_metadata
             .as_ref()
-            .map(|u| u.token_usage(model_name));
+            .map(|u| u.token_usage(model_name.clone()));
 
         let candidate = &completion.candidates[0];
         trace!(finish_reason = %candidate.finish_reason, "Completion finish reason");
@@ -637,6 +706,12 @@ impl GeminiClient {
             .and_then(|p| p.text.as_ref())
         {
             Some(text) => {
+                crate::telemetry::record_success(
+                    &gen_ai_span,
+                    completion.response_id.as_deref(),
+                    Some(&model_name),
+                    usage.as_ref(),
+                );
                 debug!(
                     content_len = text.len(),
                     "Successfully extracted text content from response"
@@ -645,12 +720,15 @@ impl GeminiClient {
             }
             None => {
                 error!("No text content in Gemini response");
-                Err(RStructorError::api_error(
+                let error = RStructorError::api_error_with_response(
                     "Gemini",
                     ApiErrorKind::UnexpectedResponse {
                         details: "No text content in response".to_string(),
                     },
-                ))
+                    response_metadata,
+                );
+                crate::telemetry::record_error(&gen_ai_span, &error);
+                Err(error)
             }
         }
     }
@@ -776,6 +854,7 @@ impl GeminiClient {
     ) -> impl std::future::Future<Output = Result<reqwest::Response>> + Send + 'static {
         let client = self.client.clone();
         let api_key = self.config.api_key.clone();
+        let response_body_capture = self.config.response_body_capture.clone();
         let base_url = self
             .config
             .base_url
@@ -792,7 +871,7 @@ impl GeminiClient {
                 .send()
                 .await
                 .map_err(|e| handle_http_error(e, "Gemini"))?;
-            check_response_status(resp, "Gemini").await
+            check_response_status_with_capture(resp, "Gemini", response_body_capture.as_ref()).await
         }
     }
 }
@@ -1137,7 +1216,7 @@ impl LLMClient for GeminiClient {
                 crate::backend::utils::transform_internally_to_adjacently_tagged(&mut value, info);
                 json = serde_json::to_string(&value).unwrap_or(json);
             }
-            crate::backend::utils::parse_and_validate_response::<T>(&json).map_err(|(e, _)| e)
+            crate::backend::utils::parse_and_validate_response::<T>(&json).map_err(|(e, _)| *e)
         };
 
         crate::backend::streaming::object_stream_with(
@@ -1224,7 +1303,12 @@ impl LLMClient for GeminiClient {
             .await
             .map_err(|e| handle_http_error(e, "Gemini"))?;
 
-        let response = check_response_status(response, "Gemini").await?;
+        let response = check_response_status_with_capture(
+            response,
+            "Gemini",
+            self.config.response_body_capture.as_ref(),
+        )
+        .await?;
 
         let json: serde_json::Value = response.json().await.map_err(|e| {
             error!(error = %e, "Failed to parse models response from Gemini");

--- a/src/backend/grok.rs
+++ b/src/backend/grok.rs
@@ -1,19 +1,20 @@
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 use std::time::Duration;
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{Instrument, debug, error, info, instrument, trace, warn};
 
 use crate::backend::model_macro::define_model_enum;
 use crate::backend::{
     ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient, MaterializeAttemptError,
     MaterializeFailure, MaterializeInternalOutput, MaterializeReport, MaterializeResult, ModelInfo,
     OpenAICompatibleChatCompletionRequest, OpenAICompatibleChatCompletionResponse, ResponseFormat,
-    StrictSchemaProvider, build_http_client, check_response_status, compile_strict_schema,
-    convert_openai_compatible_chat_messages, generate_with_retry_attempts_with_history,
-    generate_with_retry_attempts_with_initial_messages, generate_with_retry_with_history,
-    generate_with_retry_with_initial_messages, handle_http_error, materialize_request_error,
-    materialize_with_media_and_attempts_with_retry, materialize_with_media_with_retry,
-    parse_validate_and_create_output, request_messages,
+    StrictSchemaProvider, build_http_client, check_response_status_with_capture,
+    compile_strict_schema, convert_openai_compatible_chat_messages,
+    generate_with_retry_attempts_with_history, generate_with_retry_attempts_with_initial_messages,
+    generate_with_retry_with_history, generate_with_retry_with_initial_messages, handle_http_error,
+    materialize_request_error, materialize_with_media_and_attempts_with_retry,
+    materialize_with_media_with_retry, parse_json_response, parse_validate_and_create_output,
+    request_messages,
 };
 #[cfg(feature = "streaming")]
 use crate::backend::{OpenAICompatibleChatMessage, OpenAICompatibleMessageContent};
@@ -74,6 +75,8 @@ pub struct GrokConfig {
     /// Custom base URL for Grok-compatible APIs (e.g., local LLMs, proxy endpoints)
     /// Defaults to "https://api.x.ai/v1" if not set
     pub base_url: Option<String>,
+    /// Opt-in caller-sanitized provider response capture.
+    pub response_body_capture: Option<crate::ResponseBodyCapture>,
 }
 
 /// Grok client for generating completions
@@ -122,6 +125,7 @@ impl GrokClient {
             timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
             max_retries: Some(3),                   // Default: 3 retries with error feedback
             base_url: None,                         // Default: use official Grok API
+            response_body_capture: None,
         };
 
         debug!("Grok client created with default configuration");
@@ -162,6 +166,7 @@ impl GrokClient {
             timeout: Some(DEFAULT_REQUEST_TIMEOUT), // Default: 5-minute request timeout
             max_retries: Some(3),                   // Default: 3 retries with error feedback
             base_url: None,                         // Default: use official Grok API
+            response_body_capture: None,
         };
 
         debug!("Grok client created with default configuration");
@@ -231,6 +236,14 @@ impl GrokClient {
             .as_deref()
             .unwrap_or("https://api.x.ai/v1");
         let url = format!("{}/chat/completions", base_url);
+        let gen_ai_span = crate::telemetry::inference_span(
+            "x_ai",
+            "chat",
+            self.config.model.as_str(),
+            &url,
+            Some(f64::from(self.config.temperature)),
+            self.config.max_tokens.map(u64::from),
+        );
         debug!(url = %url, "Sending request to Grok API with structured outputs");
         let response = self
             .client
@@ -239,19 +252,32 @@ impl GrokClient {
             .header("Content-Type", "application/json")
             .json(&request)
             .send()
+            .instrument(gen_ai_span.clone())
             .await
-            .map_err(|error| materialize_request_error(error, "Grok"))?;
+            .map_err(|error| {
+                crate::telemetry::record_http_client_error(&gen_ai_span, &error);
+                materialize_request_error(error, "Grok")
+            })?;
 
-        let response = check_response_status(response, "Grok")
-            .await
-            .map_err(MaterializeAttemptError::transport)?;
+        let response = check_response_status_with_capture(
+            response,
+            "Grok",
+            self.config.response_body_capture.as_ref(),
+        )
+        .await
+        .map_err(|error| {
+            crate::telemetry::record_error(&gen_ai_span, &error);
+            MaterializeAttemptError::transport(error)
+        })?;
 
         debug!("Successfully received response from Grok API");
-        let completion: OpenAICompatibleChatCompletionResponse =
-            response.json().await.map_err(|e| {
-                error!(error = %e, "Failed to parse JSON response from Grok API");
-                MaterializeAttemptError::transport(RStructorError::from(e))
-            })?;
+        let (completion, response_metadata): (OpenAICompatibleChatCompletionResponse, _) =
+            parse_json_response(response, "Grok", self.config.response_body_capture.as_ref())
+                .await
+                .map_err(|error| {
+                    crate::telemetry::record_error(&gen_ai_span, &error);
+                    MaterializeAttemptError::transport(error)
+                })?;
 
         // Extract usage before validating the envelope so protocol failures can
         // still report provider-billed tokens.
@@ -266,15 +292,16 @@ impl GrokClient {
 
         if completion.choices.is_empty() {
             error!("Grok API returned empty choices array");
-            return Err(MaterializeAttemptError::transport_with_usage(
-                RStructorError::api_error(
-                    "Grok",
-                    ApiErrorKind::UnexpectedResponse {
-                        details: "No completion choices returned".to_string(),
-                    },
-                ),
-                usage,
-            ));
+            let error = RStructorError::api_error_with_response(
+                "Grok",
+                ApiErrorKind::UnexpectedResponse {
+                    details: "No completion choices returned".to_string(),
+                },
+                response_metadata.clone(),
+            );
+            crate::telemetry::record_error(&gen_ai_span, &error);
+            return Err(MaterializeAttemptError::transport_with_usage(error, usage)
+                .with_response(response_metadata));
         }
 
         let message = &completion.choices[0].message;
@@ -282,6 +309,12 @@ impl GrokClient {
 
         // With native structured outputs, the response is in message.content as guaranteed JSON
         if let Some(content) = &message.content {
+            crate::telemetry::record_success(
+                &gen_ai_span,
+                completion.id.as_deref(),
+                Some(&model_name),
+                usage.as_ref(),
+            );
             let raw_response = content.clone();
             debug!(
                 content_len = raw_response.len(),
@@ -289,19 +322,25 @@ impl GrokClient {
             );
 
             // Parse and validate the response using shared utility
-            trace!(json = %raw_response, "Parsing structured output response");
+            trace!(
+                response_bytes = raw_response.len(),
+                "Parsing structured output response"
+            );
             parse_validate_and_create_output(raw_response, usage)
+                .map(|output| output.with_response(response_metadata.clone()))
+                .map_err(|error| error.with_response(response_metadata))
         } else {
             error!("No content in Grok API response");
-            Err(MaterializeAttemptError::transport_with_usage(
-                RStructorError::api_error(
-                    "Grok",
-                    ApiErrorKind::UnexpectedResponse {
-                        details: "No content in response".to_string(),
-                    },
-                ),
-                usage,
-            ))
+            let error = RStructorError::api_error_with_response(
+                "Grok",
+                ApiErrorKind::UnexpectedResponse {
+                    details: "No content in response".to_string(),
+                },
+                response_metadata.clone(),
+            );
+            crate::telemetry::record_error(&gen_ai_span, &error);
+            Err(MaterializeAttemptError::transport_with_usage(error, usage)
+                .with_response(response_metadata))
         }
     }
 
@@ -332,6 +371,14 @@ impl GrokClient {
             .as_deref()
             .unwrap_or("https://api.x.ai/v1");
         let url = format!("{}/chat/completions", base_url);
+        let gen_ai_span = crate::telemetry::inference_span(
+            "x_ai",
+            "chat",
+            self.config.model.as_str(),
+            &url,
+            Some(f64::from(self.config.temperature)),
+            self.config.max_tokens.map(u64::from),
+        );
         debug!(url = %url, "Sending request to Grok API");
         let response = self
             .client
@@ -340,27 +387,39 @@ impl GrokClient {
             .header("Content-Type", "application/json")
             .json(&request)
             .send()
+            .instrument(gen_ai_span.clone())
             .await
-            .map_err(|e| handle_http_error(e, "Grok"))?;
+            .map_err(|error| {
+                crate::telemetry::record_http_client_error(&gen_ai_span, &error);
+                handle_http_error(error, "Grok")
+            })?;
 
         // Parse the response
-        let response = check_response_status(response, "Grok").await?;
+        let response = check_response_status_with_capture(
+            response,
+            "Grok",
+            self.config.response_body_capture.as_ref(),
+        )
+        .await
+        .inspect_err(|error| crate::telemetry::record_error(&gen_ai_span, error))?;
 
         debug!("Successfully received response from Grok API");
-        let completion: OpenAICompatibleChatCompletionResponse =
-            response.json().await.map_err(|e| {
-                error!(error = %e, "Failed to parse JSON response from Grok API");
-                e
-            })?;
+        let (completion, response_metadata): (OpenAICompatibleChatCompletionResponse, _) =
+            parse_json_response(response, "Grok", self.config.response_body_capture.as_ref())
+                .await
+                .inspect_err(|error| crate::telemetry::record_error(&gen_ai_span, error))?;
 
         if completion.choices.is_empty() {
             error!("Grok API returned empty choices array");
-            return Err(RStructorError::api_error(
+            let error = RStructorError::api_error_with_response(
                 "Grok",
                 ApiErrorKind::UnexpectedResponse {
                     details: "No completion choices returned".to_string(),
                 },
-            ));
+                response_metadata,
+            );
+            crate::telemetry::record_error(&gen_ai_span, &error);
+            return Err(error);
         }
 
         // Extract usage info
@@ -368,12 +427,21 @@ impl GrokClient {
             .model
             .clone()
             .unwrap_or_else(|| self.config.model.as_str().to_string());
-        let usage = completion.usage.as_ref().map(|u| u.token_usage(model_name));
+        let usage = completion
+            .usage
+            .as_ref()
+            .map(|u| u.token_usage(model_name.clone()));
 
         let message = &completion.choices[0].message;
         trace!(finish_reason = %completion.choices[0].finish_reason, "Completion finish reason");
 
         if let Some(content) = &message.content {
+            crate::telemetry::record_success(
+                &gen_ai_span,
+                completion.id.as_deref(),
+                Some(&model_name),
+                usage.as_ref(),
+            );
             debug!(
                 content_len = content.len(),
                 "Successfully extracted content from response"
@@ -381,12 +449,15 @@ impl GrokClient {
             Ok(GenerateResult::new(content.clone(), usage))
         } else {
             error!("No content in Grok API response");
-            Err(RStructorError::api_error(
+            let error = RStructorError::api_error_with_response(
                 "Grok",
                 ApiErrorKind::UnexpectedResponse {
                     details: "No content in response".to_string(),
                 },
-            ))
+                response_metadata,
+            );
+            crate::telemetry::record_error(&gen_ai_span, &error);
+            Err(error)
         }
     }
 }
@@ -459,6 +530,7 @@ impl GrokClient {
     ) -> impl std::future::Future<Output = Result<reqwest::Response>> + Send + 'static {
         let client = self.client.clone();
         let api_key = self.config.api_key.clone();
+        let response_body_capture = self.config.response_body_capture.clone();
         let base_url = self
             .config
             .base_url
@@ -474,7 +546,7 @@ impl GrokClient {
                 .send()
                 .await
                 .map_err(|e| handle_http_error(e, "Grok"))?;
-            check_response_status(resp, "Grok").await
+            check_response_status_with_capture(resp, "Grok", response_body_capture.as_ref()).await
         }
     }
 }
@@ -886,7 +958,12 @@ impl LLMClient for GrokClient {
             .await
             .map_err(|e| handle_http_error(e, "Grok"))?;
 
-        let response = check_response_status(response, "Grok").await?;
+        let response = check_response_status_with_capture(
+            response,
+            "Grok",
+            self.config.response_body_capture.as_ref(),
+        )
+        .await?;
 
         let json: serde_json::Value = response.json().await.map_err(|e| {
             error!(error = %e, "Failed to parse models response from Grok");

--- a/src/backend/messages.rs
+++ b/src/backend/messages.rs
@@ -131,6 +131,8 @@ pub struct MaterializeInternalOutput<T> {
     pub raw_response: String,
     /// Token usage information if available
     pub usage: Option<crate::backend::TokenUsage>,
+    /// Provider response diagnostics for this attempt.
+    pub response: Option<crate::ResponseMetadata>,
 }
 
 #[cfg(feature = "_client")]
@@ -141,7 +143,15 @@ impl<T> MaterializeInternalOutput<T> {
             data,
             raw_response,
             usage,
+            response: None,
         }
+    }
+
+    /// Attach provider response diagnostics to this successful attempt.
+    #[must_use]
+    pub(crate) fn with_response(mut self, response: crate::ResponseMetadata) -> Self {
+        self.response = Some(response);
+        self
     }
 }
 
@@ -179,12 +189,14 @@ pub(crate) enum MaterializeAttemptError {
     Transport {
         error: Box<crate::RStructorError>,
         usage: Option<crate::backend::TokenUsage>,
+        response: Option<Box<crate::ResponseMetadata>>,
     },
     /// Structured output reached decoding or custom validation and failed there.
     Semantic {
         error: Box<crate::RStructorError>,
         context: ValidationFailureContext,
         usage: Option<crate::backend::TokenUsage>,
+        response: Option<Box<crate::ResponseMetadata>>,
     },
 }
 
@@ -198,6 +210,7 @@ impl MaterializeAttemptError {
         Self::Transport {
             error: Box::new(error),
             usage: None,
+            response: None,
         }
     }
 
@@ -208,6 +221,7 @@ impl MaterializeAttemptError {
         Self::Transport {
             error: Box::new(error),
             usage,
+            response: None,
         }
     }
 
@@ -220,6 +234,17 @@ impl MaterializeAttemptError {
             error: Box::new(error),
             context,
             usage,
+            response: None,
         }
+    }
+
+    pub(crate) fn with_response(mut self, response_metadata: crate::ResponseMetadata) -> Self {
+        match &mut self {
+            Self::Preflight(_) => {}
+            Self::Transport { response, .. } | Self::Semantic { response, .. } => {
+                *response = Some(Box::new(response_metadata));
+            }
+        }
+        self
     }
 }

--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -119,9 +119,14 @@ impl From<String> for MockResponse {
 /// once, so we best-effort clone the clonable variants and stringify the rest.
 fn clone_error(e: &RStructorError) -> RStructorError {
     match e {
-        RStructorError::ApiError { provider, kind } => RStructorError::ApiError {
+        RStructorError::ApiError {
+            provider,
+            kind,
+            response,
+        } => RStructorError::ApiError {
             provider: provider.clone(),
             kind: kind.clone(),
+            response: response.clone(),
         },
         RStructorError::ValidationError(s) => RStructorError::ValidationError(s.clone()),
         RStructorError::SchemaError(s) => RStructorError::SchemaError(s.clone()),

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -99,17 +99,19 @@ pub(crate) use openai_compatible::{
 };
 #[cfg(feature = "_client")]
 pub(crate) use schema_compatibility::{StrictSchemaProvider, compile_strict_schema};
+#[cfg(feature = "tools")]
+pub(crate) use utils::check_response_status;
 #[cfg(all(test, feature = "schemars"))]
 pub(crate) use utils::prepare_gemini_schema;
 #[cfg(feature = "_client")]
 pub use utils::{DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT};
 #[cfg(feature = "_client")]
 pub(crate) use utils::{
-    ResponseFormat, build_http_client, check_response_status,
+    ResponseFormat, build_http_client, check_response_status_with_capture,
     generate_with_retry_attempts_with_history, generate_with_retry_attempts_with_initial_messages,
     generate_with_retry_with_history, generate_with_retry_with_initial_messages, handle_http_error,
     materialize_request_error, materialize_with_media_and_attempts_with_retry,
-    materialize_with_media_with_retry, parse_validate_and_create_output,
+    materialize_with_media_with_retry, parse_json_response, parse_validate_and_create_output,
 };
 
 /// Thinking level configuration for models that support extended reasoning.

--- a/src/backend/openai.rs
+++ b/src/backend/openai.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 use std::time::Duration;
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{Instrument, debug, error, info, instrument, trace, warn};
 
 use crate::backend::model_macro::define_model_enum;
 use crate::backend::routing::{
@@ -12,12 +12,13 @@ use crate::backend::{
     ChatMessage, DEFAULT_REQUEST_TIMEOUT, GenerateResult, LLMClient, MaterializeAttemptError,
     MaterializeFailure, MaterializeInternalOutput, MaterializeReport, MaterializeResult, ModelInfo,
     OpenAICompatibleChatCompletionRequest, OpenAICompatibleChatCompletionResponse, ResponseFormat,
-    StrictSchemaProvider, ThinkingLevel, build_http_client, check_response_status,
+    StrictSchemaProvider, ThinkingLevel, build_http_client, check_response_status_with_capture,
     compile_strict_schema, convert_openai_compatible_chat_messages,
     generate_with_retry_attempts_with_history, generate_with_retry_attempts_with_initial_messages,
     generate_with_retry_with_history, generate_with_retry_with_initial_messages, handle_http_error,
     materialize_request_error, materialize_with_media_and_attempts_with_retry,
-    materialize_with_media_with_retry, parse_validate_and_create_output, request_messages,
+    materialize_with_media_with_retry, parse_json_response, parse_validate_and_create_output,
+    request_messages,
 };
 #[cfg(feature = "streaming")]
 use crate::backend::{OpenAICompatibleChatMessage, OpenAICompatibleMessageContent};
@@ -128,6 +129,8 @@ pub struct OpenAIConfig {
     /// Thinking level for GPT-5.x models (reasoning effort)
     /// Controls the depth of reasoning applied to prompts
     pub thinking_level: Option<ThinkingLevel>,
+    /// Opt-in caller-sanitized provider response capture.
+    pub response_body_capture: Option<crate::ResponseBodyCapture>,
 }
 
 /// OpenAI client for generating completions
@@ -151,6 +154,7 @@ impl OpenAIClient {
             max_retries: Some(3),                   // Default: 3 retries with error feedback
             base_url: None,                         // Default: use official OpenAI API
             thinking_level: Some(ThinkingLevel::Medium), // GPT-5.6 defaults to medium reasoning
+            response_body_capture: None,
         };
 
         Self {
@@ -511,24 +515,49 @@ impl OpenAIClient {
             .as_deref()
             .unwrap_or("https://api.openai.com/v1");
         let url = format!("{}/chat/completions", base_url);
+        let gen_ai_span = crate::telemetry::inference_span(
+            "openai",
+            "chat",
+            self.config.model.as_str(),
+            &url,
+            Some(f64::from(effective_temp)),
+            self.config.max_tokens.map(u64::from),
+        );
         debug!(url = %url, "Sending request to OpenAI API");
         let response = optional_bearer_auth(self.client.post(&url), &self.config.api_key)
             .header("Content-Type", "application/json")
             .json(&request)
             .send()
+            .instrument(gen_ai_span.clone())
             .await
-            .map_err(|error| materialize_request_error(error, "OpenAI"))?;
+            .map_err(|error| {
+                crate::telemetry::record_http_client_error(&gen_ai_span, &error);
+                materialize_request_error(error, "OpenAI")
+            })?;
 
         // Parse the response
-        let response = check_response_status(response, "OpenAI")
-            .await
-            .map_err(MaterializeAttemptError::transport)?;
+        let response = check_response_status_with_capture(
+            response,
+            "OpenAI",
+            self.config.response_body_capture.as_ref(),
+        )
+        .await
+        .map_err(|error| {
+            crate::telemetry::record_error(&gen_ai_span, &error);
+            MaterializeAttemptError::transport(error)
+        })?;
 
         debug!("Successfully received response from OpenAI");
-        let completion: OpenAICompatibleChatCompletionResponse =
-            response.json().await.map_err(|e| {
-                error!(error = %e, "Failed to parse JSON response from OpenAI");
-                MaterializeAttemptError::transport(RStructorError::from(e))
+        let (completion, response_metadata): (OpenAICompatibleChatCompletionResponse, _) =
+            parse_json_response(
+                response,
+                "OpenAI",
+                self.config.response_body_capture.as_ref(),
+            )
+            .await
+            .map_err(|error| {
+                crate::telemetry::record_error(&gen_ai_span, &error);
+                MaterializeAttemptError::transport(error)
             })?;
 
         // Extract usage before validating the envelope so protocol failures can
@@ -544,15 +573,16 @@ impl OpenAIClient {
 
         if completion.choices.is_empty() {
             error!("OpenAI returned empty choices array");
-            return Err(MaterializeAttemptError::transport_with_usage(
-                RStructorError::api_error(
-                    "OpenAI",
-                    ApiErrorKind::UnexpectedResponse {
-                        details: "No completion choices returned".to_string(),
-                    },
-                ),
-                usage,
-            ));
+            let error = RStructorError::api_error_with_response(
+                "OpenAI",
+                ApiErrorKind::UnexpectedResponse {
+                    details: "No completion choices returned".to_string(),
+                },
+                response_metadata.clone(),
+            );
+            crate::telemetry::record_error(&gen_ai_span, &error);
+            return Err(MaterializeAttemptError::transport_with_usage(error, usage)
+                .with_response(response_metadata));
         }
 
         let message = &completion.choices[0].message;
@@ -560,6 +590,12 @@ impl OpenAIClient {
 
         // With structured outputs, the response is in message.content as guaranteed-valid JSON
         if let Some(content) = &message.content {
+            crate::telemetry::record_success(
+                &gen_ai_span,
+                completion.id.as_deref(),
+                Some(&model_name),
+                usage.as_ref(),
+            );
             let raw_response = content.clone();
             debug!(
                 content_len = raw_response.len(),
@@ -568,17 +604,20 @@ impl OpenAIClient {
 
             // Parse and validate the response using shared utility
             parse_validate_and_create_output(raw_response, usage)
+                .map(|output| output.with_response(response_metadata.clone()))
+                .map_err(|error| error.with_response(response_metadata))
         } else {
             error!("No content in OpenAI response");
-            Err(MaterializeAttemptError::transport_with_usage(
-                RStructorError::api_error(
-                    "OpenAI",
-                    ApiErrorKind::UnexpectedResponse {
-                        details: "No content in response".to_string(),
-                    },
-                ),
-                usage,
-            ))
+            let error = RStructorError::api_error_with_response(
+                "OpenAI",
+                ApiErrorKind::UnexpectedResponse {
+                    details: "No content in response".to_string(),
+                },
+                response_metadata.clone(),
+            );
+            crate::telemetry::record_error(&gen_ai_span, &error);
+            Err(MaterializeAttemptError::transport_with_usage(error, usage)
+                .with_response(response_metadata))
         }
     }
 
@@ -625,32 +664,56 @@ impl OpenAIClient {
             .as_deref()
             .unwrap_or("https://api.openai.com/v1");
         let url = format!("{}/chat/completions", base_url);
+        let gen_ai_span = crate::telemetry::inference_span(
+            "openai",
+            "chat",
+            self.config.model.as_str(),
+            &url,
+            Some(f64::from(effective_temp)),
+            self.config.max_tokens.map(u64::from),
+        );
         debug!(url = %url, "Sending request to OpenAI API");
         let response = optional_bearer_auth(self.client.post(&url), &self.config.api_key)
             .header("Content-Type", "application/json")
             .json(&request)
             .send()
+            .instrument(gen_ai_span.clone())
             .await
-            .map_err(|e| handle_http_error(e, "OpenAI"))?;
+            .map_err(|error| {
+                crate::telemetry::record_http_client_error(&gen_ai_span, &error);
+                handle_http_error(error, "OpenAI")
+            })?;
 
         // Parse the response
-        let response = check_response_status(response, "OpenAI").await?;
+        let response = check_response_status_with_capture(
+            response,
+            "OpenAI",
+            self.config.response_body_capture.as_ref(),
+        )
+        .await
+        .inspect_err(|error| crate::telemetry::record_error(&gen_ai_span, error))?;
 
         debug!("Successfully received response from OpenAI");
-        let completion: OpenAICompatibleChatCompletionResponse =
-            response.json().await.map_err(|e| {
-                error!(error = %e, "Failed to parse JSON response from OpenAI");
-                e
-            })?;
+        let (completion, response_metadata): (OpenAICompatibleChatCompletionResponse, _) =
+            parse_json_response(
+                response,
+                "OpenAI",
+                self.config.response_body_capture.as_ref(),
+            )
+            .await
+            .inspect_err(|error| crate::telemetry::record_error(&gen_ai_span, error))?;
 
         if completion.choices.is_empty() {
             error!("OpenAI returned empty choices array");
-            return Err(RStructorError::api_error(
+            let error = RStructorError::api_error_with_response(
                 "OpenAI",
                 ApiErrorKind::UnexpectedResponse {
                     details: "No completion choices returned".to_string(),
                 },
-            ));
+                response_metadata,
+            );
+            crate::telemetry::record_error(&gen_ai_span, &error);
+            return Err(error);
         }
 
         // Extract usage info
@@ -658,12 +721,21 @@ impl OpenAIClient {
             .model
             .clone()
             .unwrap_or_else(|| self.config.model.as_str().to_string());
-        let usage = completion.usage.as_ref().map(|u| u.token_usage(model_name));
+        let usage = completion
+            .usage
+            .as_ref()
+            .map(|u| u.token_usage(model_name.clone()));
 
         let message = &completion.choices[0].message;
         trace!(finish_reason = %completion.choices[0].finish_reason, "Completion finish reason");
 
         if let Some(content) = &message.content {
+            crate::telemetry::record_success(
+                &gen_ai_span,
+                completion.id.as_deref(),
+                Some(&model_name),
+                usage.as_ref(),
+            );
             debug!(
                 content_len = content.len(),
                 "Successfully extracted content from response"
@@ -671,12 +743,15 @@ impl OpenAIClient {
             Ok(GenerateResult::new(content.clone(), usage))
         } else {
             error!("No content in OpenAI response");
-            Err(RStructorError::api_error(
+            let error = RStructorError::api_error_with_response(
                 "OpenAI",
                 ApiErrorKind::UnexpectedResponse {
                     details: "No content in response".to_string(),
                 },
-            ))
+                response_metadata,
+            );
+            crate::telemetry::record_error(&gen_ai_span, &error);
+            Err(error)
         }
     }
 }
@@ -735,6 +810,7 @@ impl OpenAIClient {
     ) -> impl std::future::Future<Output = Result<reqwest::Response>> + Send + 'static {
         let client = self.client.clone();
         let api_key = self.config.api_key.clone();
+        let response_body_capture = self.config.response_body_capture.clone();
         let base_url = self
             .config
             .base_url
@@ -748,7 +824,7 @@ impl OpenAIClient {
                 .send()
                 .await
                 .map_err(|e| handle_http_error(e, "OpenAI"))?;
-            check_response_status(resp, "OpenAI").await
+            check_response_status_with_capture(resp, "OpenAI", response_body_capture.as_ref()).await
         }
     }
 }
@@ -1182,7 +1258,12 @@ impl LLMClient for OpenAIClient {
             .await
             .map_err(|e| handle_http_error(e, "OpenAI"))?;
 
-        let response = check_response_status(response, "OpenAI").await?;
+        let response = check_response_status_with_capture(
+            response,
+            "OpenAI",
+            self.config.response_body_capture.as_ref(),
+        )
+        .await?;
 
         let json: serde_json::Value = response.json().await.map_err(|e| {
             error!(error = %e, "Failed to parse models response from OpenAI");

--- a/src/backend/openai_compatible.rs
+++ b/src/backend/openai_compatible.rs
@@ -86,6 +86,7 @@ impl OpenAICompatibleUsageInfo {
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct OpenAICompatibleChatCompletionResponse {
+    pub id: Option<String>,
     pub choices: Vec<OpenAICompatibleChatCompletionChoice>,
     pub usage: Option<OpenAICompatibleUsageInfo>,
     pub model: Option<String>,

--- a/src/backend/streaming.rs
+++ b/src/backend/streaming.rs
@@ -331,7 +331,7 @@ where
     F: Fn(&Value) -> Result<ProviderStreamEvent> + Send + 'a,
 {
     object_stream_with(send, extract, marker, |raw: &str| {
-        super::utils::parse_and_validate_response::<T>(raw).map_err(|(err, _ctx)| err)
+        super::utils::parse_and_validate_response::<T>(raw).map_err(|(err, _ctx)| *err)
     })
 }
 

--- a/src/backend/usage.rs
+++ b/src/backend/usage.rs
@@ -253,26 +253,50 @@ pub struct AttemptRecord {
     pub outcome: AttemptOutcome,
     /// Per-response token usage, when reported by the provider.
     pub usage: Option<TokenUsage>,
+    /// HTTP response diagnostics, when the attempt reached a provider.
+    pub response: Option<crate::ResponseMetadata>,
 }
 
 impl AttemptRecord {
-    #[cfg(any(feature = "_client", feature = "mock"))]
+    #[cfg(any(test, feature = "mock"))]
     pub(crate) fn succeeded(number: usize, usage: Option<TokenUsage>) -> Self {
+        Self::succeeded_with_response(number, usage, None)
+    }
+
+    #[cfg(any(feature = "_client", feature = "mock"))]
+    pub(crate) fn succeeded_with_response(
+        number: usize,
+        usage: Option<TokenUsage>,
+        response: Option<crate::ResponseMetadata>,
+    ) -> Self {
         Self {
             number,
             kind: AttemptKind::Semantic,
             outcome: AttemptOutcome::Succeeded,
             usage,
+            response,
         }
     }
 
-    #[cfg(any(feature = "_client", feature = "mock"))]
+    #[cfg(any(test, feature = "mock"))]
     pub(crate) fn failed(
         number: usize,
         kind: AttemptKind,
         error: &RStructorError,
         disposition: RetryDisposition,
         usage: Option<TokenUsage>,
+    ) -> Self {
+        Self::failed_with_response(number, kind, error, disposition, usage, None)
+    }
+
+    #[cfg(any(feature = "_client", feature = "mock"))]
+    pub(crate) fn failed_with_response(
+        number: usize,
+        kind: AttemptKind,
+        error: &RStructorError,
+        disposition: RetryDisposition,
+        usage: Option<TokenUsage>,
+        response: Option<crate::ResponseMetadata>,
     ) -> Self {
         Self {
             number,
@@ -282,6 +306,7 @@ impl AttemptRecord {
                 disposition,
             },
             usage,
+            response,
         }
     }
 }

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -5,6 +5,7 @@ use crate::backend::{
 };
 use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
+use crate::{ResponseBodyCapture, ResponseMetadata};
 use reqwest::Response;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -984,7 +985,7 @@ impl ResponseFormat {
 /// The parsed and validated data, or an error with validation context
 pub fn parse_and_validate_response<T>(
     raw_response: &str,
-) -> std::result::Result<T, (RStructorError, Option<ValidationFailureContext>)>
+) -> std::result::Result<T, (Box<RStructorError>, Option<ValidationFailureContext>)>
 where
     T: Instructor + DeserializeOwned,
 {
@@ -995,7 +996,7 @@ where
             let error_msg = error.to_string();
             error!(error = %error, "Structured output decoding failed");
             return Err((
-                error,
+                Box::new(error),
                 Some(ValidationFailureContext::new(
                     error_msg,
                     raw_response.to_string(),
@@ -1009,7 +1010,7 @@ where
         error!(error = ?e, "Custom validation failed");
         let error_msg = e.to_string();
         return Err((
-            e,
+            Box::new(e),
             Some(ValidationFailureContext::new(
                 error_msg,
                 raw_response.to_string(),
@@ -1046,9 +1047,9 @@ where
             Ok(MaterializeInternalOutput::new(result, raw_response, usage))
         }
         Err((error, Some(context))) => {
-            Err(MaterializeAttemptError::semantic(error, context, usage))
+            Err(MaterializeAttemptError::semantic(*error, context, usage))
         }
-        Err((error, None)) => Err(MaterializeAttemptError::transport_with_usage(error, usage)),
+        Err((error, None)) => Err(MaterializeAttemptError::transport_with_usage(*error, usage)),
     }
 }
 
@@ -1215,9 +1216,20 @@ fn truncate_message(msg: &str, max_len: usize) -> String {
 ///
 /// This function classifies errors into actionable types (rate limit, auth failure, etc.)
 /// and provides user-friendly error messages with suggested actions.
+#[cfg(feature = "tools")]
 pub async fn check_response_status(response: Response, provider_name: &str) -> Result<Response> {
+    check_response_status_with_capture(response, provider_name, None).await
+}
+
+/// Check HTTP response status while optionally retaining a caller-sanitized body.
+pub(crate) async fn check_response_status_with_capture(
+    response: Response,
+    provider_name: &str,
+    body_capture: Option<&ResponseBodyCapture>,
+) -> Result<Response> {
     if !response.status().is_success() {
         let status = response.status();
+        let mut metadata = response_metadata(&response);
 
         // Extract retry-after header if present
         let retry_after = response
@@ -1227,19 +1239,80 @@ pub async fn check_response_status(response: Response, provider_name: &str) -> R
             .and_then(parse_retry_after);
 
         let error_text = response.text().await?;
+        capture_response_body(&mut metadata, &error_text, body_capture);
 
         let kind = classify_api_error(status, &error_text, retry_after, None);
 
         error!(
             status = %status,
-            error = %error_text,
-            kind = %kind,
+            response_body_bytes = error_text.len(),
+            retryable = kind.is_retryable(),
             "{} API returned error response", provider_name
         );
 
-        return Err(RStructorError::api_error(provider_name, kind));
+        return Err(RStructorError::api_error_with_response(
+            provider_name,
+            kind,
+            metadata,
+        ));
     }
     Ok(response)
+}
+
+const REQUEST_ID_HEADERS: &[&str] = &[
+    "x-request-id",
+    "request-id",
+    "anthropic-request-id",
+    "openai-request-id",
+    "x-goog-request-id",
+    "x-amzn-requestid",
+    "x-amz-request-id",
+];
+
+pub(crate) fn response_metadata(response: &Response) -> ResponseMetadata {
+    let mut metadata = ResponseMetadata::new(response.status().as_u16());
+    for name in REQUEST_ID_HEADERS {
+        if let Some(value) = response
+            .headers()
+            .get(*name)
+            .and_then(|value| value.to_str().ok())
+        {
+            metadata
+                .request_ids
+                .insert((*name).to_string(), value.to_string());
+        }
+    }
+    metadata
+}
+
+pub(crate) fn capture_response_body(
+    metadata: &mut ResponseMetadata,
+    raw_body: &str,
+    body_capture: Option<&ResponseBodyCapture>,
+) {
+    metadata.sanitized_body = body_capture.map(|capture| capture.capture(raw_body));
+}
+
+/// Decode a successful JSON response while retaining its diagnostics.
+pub(crate) async fn parse_json_response<T: DeserializeOwned>(
+    response: Response,
+    provider_name: &str,
+    body_capture: Option<&ResponseBodyCapture>,
+) -> Result<(T, ResponseMetadata)> {
+    let mut metadata = response_metadata(&response);
+    let body = response.text().await?;
+    capture_response_body(&mut metadata, &body, body_capture);
+
+    let parsed = serde_json::from_str(&body).map_err(|error| {
+        RStructorError::api_error_with_response(
+            provider_name,
+            ApiErrorKind::UnexpectedResponse {
+                details: format!("response body was not valid JSON: {error}"),
+            },
+            metadata.clone(),
+        )
+    })?;
+    Ok((parsed, metadata))
 }
 
 /// Builds the user-role feedback message sent back to the LLM when a response
@@ -1423,12 +1496,17 @@ where
         match generate_fn(messages.clone()).await {
             Ok(result) => {
                 let final_usage = result.usage;
+                let response = result.response;
                 if let Some(usage) = final_usage.clone() {
                     cumulative_usage
                         .get_or_insert_with(RunUsage::new)
                         .record(usage);
                 }
-                attempts.push(AttemptRecord::succeeded(attempt + 1, final_usage.clone()));
+                attempts.push(AttemptRecord::succeeded_with_response(
+                    attempt + 1,
+                    final_usage.clone(),
+                    response,
+                ));
 
                 if attempt > 0 {
                     info!(
@@ -1456,6 +1534,7 @@ where
                 error: attempt_error,
                 context,
                 usage,
+                response,
             }) => {
                 let is_last_attempt = attempt >= max_attempts - 1;
                 let disposition = if is_last_attempt {
@@ -1468,12 +1547,13 @@ where
                         .get_or_insert_with(RunUsage::new)
                         .record(response_usage);
                 }
-                attempts.push(AttemptRecord::failed(
+                attempts.push(AttemptRecord::failed_with_response(
                     attempt + 1,
                     AttemptKind::Semantic,
                     &attempt_error,
                     disposition,
                     usage,
+                    response.map(|response| *response),
                 ));
 
                 if disposition == RetryDisposition::Retried {
@@ -1508,6 +1588,7 @@ where
             Err(MaterializeAttemptError::Transport {
                 error: attempt_error,
                 usage,
+                response,
             }) => {
                 let is_last_attempt = attempt >= max_attempts - 1;
                 let retryable = attempt_error.is_retryable();
@@ -1523,12 +1604,16 @@ where
                         .get_or_insert_with(RunUsage::new)
                         .record(response_usage);
                 }
-                attempts.push(AttemptRecord::failed(
+                let response = response
+                    .map(|response| *response)
+                    .or_else(|| attempt_error.response_metadata().cloned());
+                attempts.push(AttemptRecord::failed_with_response(
                     attempt + 1,
                     AttemptKind::Transport,
                     &attempt_error,
                     disposition,
                     usage,
+                    response,
                 ));
 
                 if disposition == RetryDisposition::Retried {
@@ -1733,6 +1818,21 @@ macro_rules! impl_client_builder_methods {
                     "Disabling retries"
                 );
                 self.config.max_retries = Some(0);
+                self
+            }
+
+            /// Retain caller-sanitized provider response bodies in diagnostics.
+            ///
+            /// Status codes and recognized request IDs are always retained for
+            /// structured extraction reports. Bodies are disabled by default;
+            /// enabling them requires a sanitizer callback via
+            /// [`ResponseBodyCapture`](crate::ResponseBodyCapture).
+            #[must_use]
+            pub fn capture_response_bodies(
+                mut self,
+                capture: $crate::ResponseBodyCapture,
+            ) -> Self {
+                self.config.response_body_capture = Some(capture);
                 self
             }
         }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,162 @@
+//! Privacy-aware diagnostics for provider responses.
+
+use std::collections::BTreeMap;
+#[cfg(feature = "_client")]
+use std::{fmt, sync::Arc};
+
+/// A response body that has passed through a caller-provided sanitizer.
+///
+/// rstructor never stores provider response bodies by default. When capture is
+/// explicitly enabled, the sanitizer runs before the value is retained and the
+/// sanitized value is bounded by the configured byte limit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SanitizedResponseBody {
+    /// Sanitized response text retained for diagnostics.
+    pub text: String,
+    /// Whether the sanitized text exceeded the capture limit and was truncated.
+    pub truncated: bool,
+}
+
+/// HTTP metadata retained for one provider response.
+///
+/// Status and recognized request-ID headers are captured for both successful
+/// and failed structured-output attempts. Response bodies remain absent unless
+/// the client was configured with opt-in response body capture.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ResponseMetadata {
+    /// Exact HTTP status code returned by the provider.
+    pub status: u16,
+    /// Recognized request-ID headers, keyed by their lowercase header name.
+    pub request_ids: BTreeMap<String, String>,
+    /// Optional caller-sanitized response body.
+    pub sanitized_body: Option<SanitizedResponseBody>,
+}
+
+impl ResponseMetadata {
+    /// Create response metadata with no request IDs or body capture.
+    #[must_use]
+    pub fn new(status: u16) -> Self {
+        Self {
+            status,
+            request_ids: BTreeMap::new(),
+            sanitized_body: None,
+        }
+    }
+
+    /// Return a preferred request ID when the provider supplied one.
+    ///
+    /// All recognized IDs remain available in [`request_ids`](Self::request_ids).
+    #[must_use]
+    pub fn request_id(&self) -> Option<&str> {
+        const PREFERRED_HEADERS: &[&str] = &[
+            "x-request-id",
+            "request-id",
+            "anthropic-request-id",
+            "openai-request-id",
+            "x-goog-request-id",
+            "x-amzn-requestid",
+            "x-amz-request-id",
+        ];
+
+        PREFERRED_HEADERS
+            .iter()
+            .find_map(|header| self.request_ids.get(*header).map(String::as_str))
+            .or_else(|| self.request_ids.values().next().map(String::as_str))
+    }
+}
+
+#[cfg(feature = "_client")]
+type Sanitizer = dyn Fn(&str) -> String + Send + Sync + 'static;
+
+/// Opt-in, caller-controlled response-body capture.
+///
+/// The callback is the privacy boundary: it receives the body transiently and
+/// must return only content safe to retain in errors, reports, logs, or test
+/// fixtures. rstructor stores only the callback's bounded output.
+#[derive(Clone)]
+#[cfg(feature = "_client")]
+pub struct ResponseBodyCapture {
+    max_bytes: usize,
+    sanitizer: Arc<Sanitizer>,
+}
+
+#[cfg(feature = "_client")]
+impl ResponseBodyCapture {
+    /// Default maximum number of sanitized bytes retained per response.
+    pub const DEFAULT_MAX_BYTES: usize = 16 * 1024;
+
+    /// Enable response-body capture with a caller-provided sanitizer.
+    ///
+    /// The sanitizer is mandatory so enabling diagnostics cannot accidentally
+    /// become a boolean switch that stores raw model output.
+    pub fn new<F>(sanitizer: F) -> Self
+    where
+        F: Fn(&str) -> String + Send + Sync + 'static,
+    {
+        Self {
+            max_bytes: Self::DEFAULT_MAX_BYTES,
+            sanitizer: Arc::new(sanitizer),
+        }
+    }
+
+    /// Set the maximum number of sanitized bytes retained per response.
+    #[must_use]
+    pub fn max_bytes(mut self, max_bytes: usize) -> Self {
+        self.max_bytes = max_bytes;
+        self
+    }
+
+    pub(crate) fn capture(&self, raw_body: &str) -> SanitizedResponseBody {
+        let sanitized = (self.sanitizer)(raw_body);
+        let boundary = sanitized.floor_char_boundary(self.max_bytes.min(sanitized.len()));
+        let truncated = boundary < sanitized.len();
+        SanitizedResponseBody {
+            text: sanitized[..boundary].to_string(),
+            truncated,
+        }
+    }
+}
+
+#[cfg(feature = "_client")]
+impl fmt::Debug for ResponseBodyCapture {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ResponseBodyCapture")
+            .field("max_bytes", &self.max_bytes)
+            .field("sanitizer", &"<caller-provided>")
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "_client")]
+    #[test]
+    fn capture_sanitizes_before_retaining_and_truncates_on_utf8_boundary() {
+        let capture =
+            ResponseBodyCapture::new(|body| body.replace("secret", "[REDACTED]")).max_bytes(13);
+
+        let body = capture.capture("secret тест");
+
+        assert_eq!(body.text, "[REDACTED] т");
+        assert!(body.truncated);
+        assert!(!body.text.contains("secret"));
+    }
+
+    #[test]
+    fn preferred_request_id_is_deterministic() {
+        let mut metadata = ResponseMetadata::new(200);
+        metadata
+            .request_ids
+            .insert("request-id".to_string(), "fallback".to_string());
+        metadata
+            .request_ids
+            .insert("x-request-id".to_string(), "preferred".to_string());
+
+        assert_eq!(metadata.request_id(), Some("preferred"));
+    }
+}

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,6 +1,8 @@
 use std::{fmt, time::Duration};
 use thiserror::Error;
 
+use crate::ResponseMetadata;
+
 /// Classification of API errors for better handling and retry logic.
 ///
 /// This enum categorizes HTTP errors from LLM providers into actionable types,
@@ -357,6 +359,8 @@ pub enum RStructorError {
         provider: String,
         /// The classified error kind
         kind: ApiErrorKind,
+        /// HTTP response diagnostics, when the provider returned a response.
+        response: Option<Box<ResponseMetadata>>,
     },
 
     /// Error validating data against schema or business rules
@@ -478,6 +482,20 @@ impl RStructorError {
         RStructorError::ApiError {
             provider: provider.into(),
             kind,
+            response: None,
+        }
+    }
+
+    /// Create a classified API error with the provider's HTTP response metadata.
+    pub fn api_error_with_response(
+        provider: impl Into<String>,
+        kind: ApiErrorKind,
+        response: ResponseMetadata,
+    ) -> Self {
+        RStructorError::ApiError {
+            provider: provider.into(),
+            kind,
+            response: Some(Box::new(response)),
         }
     }
 
@@ -496,6 +514,28 @@ impl RStructorError {
             RStructorError::ApiError { kind, .. } => Some(kind),
             _ => None,
         }
+    }
+
+    /// Return HTTP response metadata when this error came from a provider response.
+    #[must_use]
+    pub fn response_metadata(&self) -> Option<&ResponseMetadata> {
+        match self {
+            RStructorError::ApiError { response, .. } => response.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Return the provider's exact HTTP status code, when available.
+    #[must_use]
+    pub fn status_code(&self) -> Option<u16> {
+        self.response_metadata().map(|response| response.status)
+    }
+
+    /// Return a preferred provider request ID, when available.
+    #[must_use]
+    pub fn request_id(&self) -> Option<&str> {
+        self.response_metadata()
+            .and_then(ResponseMetadata::request_id)
     }
 
     /// Returns whether this error is potentially retryable.
@@ -563,12 +603,14 @@ impl PartialEq for RStructorError {
                 Self::ApiError {
                     provider: p1,
                     kind: k1,
+                    response: r1,
                 },
                 Self::ApiError {
                     provider: p2,
                     kind: k2,
+                    response: r2,
                 },
-            ) => p1 == p2 && k1 == k2,
+            ) => p1 == p2 && k1 == k2 && r1 == r2,
             (Self::ValidationError(a), Self::ValidationError(b)) => a == b,
             (Self::SchemaError(a), Self::SchemaError(b)) => a == b,
             (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ extern crate self as rstructor;
 mod backend;
 #[cfg(any(feature = "_client", feature = "mock"))]
 mod decode;
+mod diagnostics;
 pub mod error;
 #[cfg(feature = "logging")]
 pub mod logging;
@@ -55,8 +56,13 @@ pub mod model;
 pub mod schema;
 #[cfg(feature = "schemars")]
 mod schemars_bridge;
+#[cfg(feature = "_client")]
+pub mod telemetry;
 
 // Re-exports for convenience
+#[cfg(feature = "_client")]
+pub use diagnostics::ResponseBodyCapture;
+pub use diagnostics::{ResponseMetadata, SanitizedResponseBody};
 pub use error::{ApiErrorKind, RStructorError, Result, StreamErrorKind};
 pub use model::Instructor;
 pub use schema::{CustomTypeSchema, Schema, SchemaBuilder, SchemaType};

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,293 @@
+//! OpenTelemetry-compatible GenAI tracing fields.
+//!
+//! Built-in non-streaming extraction and generation calls emit `tracing` spans
+//! that follow the OpenTelemetry GenAI inference-client semantic conventions.
+//! Applications can export them with their existing `tracing-opentelemetry`
+//! layer; rstructor does not install a global subscriber or add an
+//! OpenTelemetry SDK dependency.
+//!
+//! The GenAI conventions are currently development-stability. Prompt, system,
+//! response, and tool content attributes are deliberately never emitted.
+
+use tracing::{Span, field, info_span};
+
+use crate::{ApiErrorKind, RStructorError, TokenUsage};
+
+/// Stability of the implemented OpenTelemetry GenAI semantic conventions.
+pub const GEN_AI_SEMCONV_STABILITY: &str = "development";
+
+/// Create one GenAI client span for one remote inference attempt.
+pub(crate) fn inference_span(
+    provider: &'static str,
+    operation: &'static str,
+    model: &str,
+    endpoint: &str,
+    temperature: Option<f64>,
+    max_tokens: Option<u64>,
+) -> Span {
+    let otel_name = format!("{operation} {model}");
+    let span = info_span!(
+        "gen_ai.client.inference",
+        otel.name = %otel_name,
+        otel.kind = "client",
+        otel.status_code = field::Empty,
+        gen_ai.provider.name = provider,
+        gen_ai.operation.name = operation,
+        gen_ai.request.model = model,
+        gen_ai.request.temperature = field::Empty,
+        gen_ai.request.max_tokens = field::Empty,
+        gen_ai.output.type = "json",
+        gen_ai.response.id = field::Empty,
+        gen_ai.response.model = field::Empty,
+        gen_ai.usage.input_tokens = field::Empty,
+        gen_ai.usage.output_tokens = field::Empty,
+        gen_ai.usage.cache_read.input_tokens = field::Empty,
+        gen_ai.usage.cache_creation.input_tokens = field::Empty,
+        server.address = field::Empty,
+        server.port = field::Empty,
+        error.type = field::Empty,
+    );
+
+    if let Some(temperature) = temperature {
+        span.record("gen_ai.request.temperature", temperature);
+    }
+    if let Some(max_tokens) = max_tokens {
+        span.record("gen_ai.request.max_tokens", max_tokens);
+    }
+    if let Ok(url) = reqwest::Url::parse(endpoint) {
+        if let Some(host) = url.host_str() {
+            span.record("server.address", host);
+        }
+        if let Some(port) = url.port_or_known_default() {
+            span.record("server.port", u64::from(port));
+        }
+    }
+
+    span
+}
+
+pub(crate) fn record_success(
+    span: &Span,
+    response_id: Option<&str>,
+    response_model: Option<&str>,
+    usage: Option<&TokenUsage>,
+) {
+    if let Some(response_id) = response_id {
+        span.record("gen_ai.response.id", response_id);
+    }
+    if let Some(response_model) = response_model {
+        span.record("gen_ai.response.model", response_model);
+    }
+    if let Some(usage) = usage {
+        span.record("gen_ai.usage.input_tokens", usage.input_tokens);
+        span.record("gen_ai.usage.output_tokens", usage.output_tokens);
+        span.record(
+            "gen_ai.usage.cache_read.input_tokens",
+            usage.cached_input_tokens,
+        );
+        span.record(
+            "gen_ai.usage.cache_creation.input_tokens",
+            usage.cache_write_input_tokens,
+        );
+    }
+}
+
+pub(crate) fn record_error(span: &Span, error: &RStructorError) {
+    let error_type = error_type(error);
+    span.record("error.type", error_type.as_str());
+    span.record("otel.status_code", "ERROR");
+}
+
+pub(crate) fn record_http_client_error(span: &Span, error: &reqwest::Error) {
+    let error_type = if error.is_timeout() {
+        "timeout"
+    } else if error.is_connect() {
+        "connection_error"
+    } else if error.is_builder() {
+        "request_build_error"
+    } else {
+        "http_error"
+    };
+    span.record("error.type", error_type);
+    span.record("otel.status_code", "ERROR");
+}
+
+fn error_type(error: &RStructorError) -> String {
+    if let Some(status) = error.status_code() {
+        return status.to_string();
+    }
+
+    match error {
+        RStructorError::ApiError { kind, .. } => match kind {
+            ApiErrorKind::RateLimited { .. } => "rate_limit",
+            ApiErrorKind::InvalidModel { .. } => "invalid_model",
+            ApiErrorKind::ServiceUnavailable => "service_unavailable",
+            ApiErrorKind::GatewayError { .. } => "gateway_error",
+            ApiErrorKind::AuthenticationFailed => "authentication_error",
+            ApiErrorKind::PermissionDenied => "permission_denied",
+            ApiErrorKind::RequestTooLarge => "request_too_large",
+            ApiErrorKind::BadRequest { .. } => "bad_request",
+            ApiErrorKind::ServerError { .. } => "server_error",
+            ApiErrorKind::Other { .. } => "api_error",
+            ApiErrorKind::UnexpectedResponse { .. } => "unexpected_response",
+        },
+        RStructorError::ValidationError(_) => "validation_error",
+        RStructorError::SchemaError(_) | RStructorError::SchemaCompatibilityError { .. } => {
+            "schema_error"
+        }
+        RStructorError::SerializationError(_)
+        | RStructorError::OutputDecodeError { .. }
+        | RStructorError::ToolArgumentDecodeError { .. }
+        | RStructorError::JsonError(_) => "decode_error",
+        RStructorError::StreamingError { .. } => "stream_error",
+        RStructorError::Timeout => "timeout",
+        RStructorError::Unsupported(_) => "unsupported",
+        RStructorError::HttpError(error) if error.is_connect() => "connection_error",
+        RStructorError::HttpError(_) => "http_error",
+    }
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "logging")]
+    use std::{collections::BTreeMap, sync::Arc};
+    #[cfg(feature = "logging")]
+    use tracing::{Subscriber, field::Visit, span};
+    #[cfg(feature = "logging")]
+    use tracing_subscriber::{Layer, layer::Context, prelude::*, registry::LookupSpan};
+
+    #[test]
+    fn http_status_is_the_low_cardinality_error_type_when_available() {
+        let error = RStructorError::api_error_with_response(
+            "OpenAI",
+            ApiErrorKind::RateLimited { retry_after: None },
+            crate::ResponseMetadata::new(429),
+        );
+
+        assert_eq!(error_type(&error), "429");
+    }
+
+    #[test]
+    fn internal_errors_have_stable_categories() {
+        assert_eq!(error_type(&RStructorError::Timeout), "timeout");
+        assert_eq!(
+            error_type(&RStructorError::OutputDecodeError {
+                path: "$.quantity".to_string(),
+                message: "invalid type".to_string(),
+            }),
+            "decode_error"
+        );
+    }
+
+    #[cfg(feature = "logging")]
+    struct FieldVisitor<'a> {
+        fields: &'a mut BTreeMap<String, String>,
+    }
+
+    #[cfg(feature = "logging")]
+    impl Visit for FieldVisitor<'_> {
+        fn record_debug(&mut self, field: &field::Field, value: &dyn std::fmt::Debug) {
+            self.fields
+                .insert(field.name().to_string(), format!("{value:?}"));
+        }
+
+        fn record_str(&mut self, field: &field::Field, value: &str) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_u64(&mut self, field: &field::Field, value: u64) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_f64(&mut self, field: &field::Field, value: f64) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+    }
+
+    #[cfg(feature = "logging")]
+    #[derive(Clone)]
+    struct CaptureLayer(Arc<std::sync::Mutex<BTreeMap<String, String>>>);
+
+    #[cfg(feature = "logging")]
+    impl<S> Layer<S> for CaptureLayer
+    where
+        S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    {
+        fn on_new_span(
+            &self,
+            attributes: &span::Attributes<'_>,
+            _id: &span::Id,
+            _context: Context<'_, S>,
+        ) {
+            attributes.record(&mut FieldVisitor {
+                fields: &mut self.0.lock().unwrap(),
+            });
+        }
+
+        fn on_record(&self, _id: &span::Id, values: &span::Record<'_>, _context: Context<'_, S>) {
+            values.record(&mut FieldVisitor {
+                fields: &mut self.0.lock().unwrap(),
+            });
+        }
+    }
+
+    #[cfg(feature = "logging")]
+    #[test]
+    fn span_uses_gen_ai_semantic_fields_without_sensitive_content() {
+        let fields = Arc::new(std::sync::Mutex::new(BTreeMap::new()));
+        let subscriber = tracing_subscriber::registry().with(CaptureLayer(fields.clone()));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = inference_span(
+                "openai",
+                "chat",
+                "gpt-5",
+                "https://api.openai.com/v1/chat/completions",
+                Some(0.2),
+                Some(512),
+            );
+            record_success(
+                &span,
+                Some("resp_123"),
+                Some("gpt-5-2026-07-01"),
+                Some(&TokenUsage::new("gpt-5", 21, 8).with_cache_tokens(5, 3)),
+            );
+        });
+
+        let fields = fields.lock().unwrap();
+        assert_eq!(fields.get("otel.kind").map(String::as_str), Some("client"));
+        assert_eq!(
+            fields.get("gen_ai.provider.name").map(String::as_str),
+            Some("openai")
+        );
+        assert_eq!(
+            fields.get("gen_ai.operation.name").map(String::as_str),
+            Some("chat")
+        );
+        assert_eq!(
+            fields.get("gen_ai.response.id").map(String::as_str),
+            Some("resp_123")
+        );
+        assert_eq!(
+            fields.get("gen_ai.usage.input_tokens").map(String::as_str),
+            Some("21")
+        );
+        assert_eq!(
+            fields
+                .get("gen_ai.usage.cache_read.input_tokens")
+                .map(String::as_str),
+            Some("5")
+        );
+        assert!(!fields.keys().any(|key| {
+            key.contains("input.messages")
+                || key.contains("output.messages")
+                || key.contains("system_instructions")
+        }));
+    }
+}

--- a/tests/anyclient_env_tests.rs
+++ b/tests/anyclient_env_tests.rs
@@ -214,7 +214,7 @@ fn anyclient_from_env_detection_precedence_and_per_provider() {
         "no-key from_env should yield AuthenticationFailed, got {err:?}"
     );
     match &err {
-        RStructorError::ApiError { provider, kind } => {
+        RStructorError::ApiError { provider, kind, .. } => {
             assert_eq!(
                 provider, "AnyClient",
                 "no-key from_env must report the synthetic provider label \"AnyClient\""

--- a/tests/attempt_ledger_provider_tests.rs
+++ b/tests/attempt_ledger_provider_tests.rs
@@ -33,6 +33,7 @@ fn assert_single_success(
     assert_eq!(report.attempts.len(), 1);
     assert_eq!(report.attempts[0].kind, AttemptKind::Semantic);
     assert_eq!(report.attempts[0].outcome, AttemptOutcome::Succeeded);
+    assert_eq!(report.attempts[0].response.as_ref().unwrap().status, 200);
     assert_eq!(report.final_usage.as_ref().unwrap().model, expected_model);
     assert_eq!(
         report.cumulative_usage.as_ref().unwrap().total_tokens(),
@@ -50,6 +51,7 @@ fn assert_usage_bearing_protocol_failure(failure: MaterializeFailure, expected_t
             ..
         }
     ));
+    assert_eq!(failure.attempts[0].response.as_ref().unwrap().status, 200);
     assert_eq!(
         failure.attempts[0].usage.as_ref().unwrap().total_tokens(),
         expected_tokens
@@ -78,6 +80,12 @@ fn assert_semantic_retry_success(
         }
     ));
     assert_eq!(report.attempts[1].outcome, AttemptOutcome::Succeeded);
+    assert!(
+        report
+            .attempts
+            .iter()
+            .all(|attempt| attempt.response.as_ref().unwrap().status == 200)
+    );
     assert_eq!(
         report.final_usage.as_ref().unwrap().model,
         expected_final_model

--- a/tests/http_mock_tests.rs
+++ b/tests/http_mock_tests.rs
@@ -9,7 +9,7 @@
 
 use rstructor::{
     AnyClient, ApiErrorKind, AttemptKind, AttemptOutcome, Instructor, LLMClient, MediaFile,
-    OpenAIClient, RStructorError,
+    OpenAIClient, RStructorError, ResponseBodyCapture,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -189,6 +189,101 @@ async fn materialize_parses_a_real_response() {
         }
     );
     m.assert_async().await;
+}
+
+#[tokio::test]
+async fn extraction_report_preserves_status_and_request_id_without_body_by_default() {
+    let mut server = mockito::Server::new_async().await;
+    let response = server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_header("x-request-id", "req_success_123")
+        .with_body(chat_completion(r#"{"title":"Inception","year":2010}"#))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let extraction = client(&server)
+        .extract_with_report::<Movie>("a film")
+        .await
+        .unwrap();
+    let metadata = extraction.report.attempts[0]
+        .response
+        .as_ref()
+        .expect("successful provider response metadata");
+
+    assert_eq!(metadata.status, 200);
+    assert_eq!(metadata.request_id(), Some("req_success_123"));
+    assert!(metadata.sanitized_body.is_none());
+    response.assert_async().await;
+}
+
+#[tokio::test]
+async fn opt_in_capture_retains_only_sanitized_bounded_response_body() {
+    let mut server = mockito::Server::new_async().await;
+    let response = server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_header("request-id", "req_capture_456")
+        .with_body(chat_completion(r#"{"title":"Inception","year":2010}"#))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let capture =
+        ResponseBodyCapture::new(|body| body.replace("Inception", "[REDACTED]")).max_bytes(96);
+    let extraction = client(&server)
+        .capture_response_bodies(capture)
+        .extract_with_report::<Movie>("a film")
+        .await
+        .unwrap();
+    let metadata = extraction.report.attempts[0].response.as_ref().unwrap();
+    let body = metadata.sanitized_body.as_ref().unwrap();
+
+    assert_eq!(metadata.request_id(), Some("req_capture_456"));
+    assert!(body.text.contains("[REDACTED]"));
+    assert!(!body.text.contains("Inception"));
+    assert!(body.truncated);
+    response.assert_async().await;
+}
+
+#[tokio::test]
+async fn provider_error_preserves_raw_status_request_id_and_sanitized_body() {
+    let mut server = mockito::Server::new_async().await;
+    let response = server
+        .mock("POST", "/chat/completions")
+        .with_status(429)
+        .with_header("retry-after", "0")
+        .with_header("x-request-id", "req_rate_limit_789")
+        .with_body(r#"{"error":{"message":"quota for acct-123 exhausted"}}"#)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let capture = ResponseBodyCapture::new(|body| body.replace("acct-123", "[ACCOUNT]"));
+    let failure = client(&server)
+        .no_retries()
+        .capture_response_bodies(capture)
+        .extract_with_report::<Movie>("a film")
+        .await
+        .unwrap_err();
+
+    assert_eq!(failure.error().status_code(), Some(429));
+    assert_eq!(failure.error().request_id(), Some("req_rate_limit_789"));
+    let error_metadata = failure.error().response_metadata().unwrap();
+    assert!(
+        error_metadata
+            .sanitized_body
+            .as_ref()
+            .unwrap()
+            .text
+            .contains("[ACCOUNT]")
+    );
+    assert_eq!(
+        failure.report.attempts[0].response.as_ref().unwrap().status,
+        429
+    );
+    response.assert_async().await;
 }
 
 #[tokio::test]
@@ -844,7 +939,12 @@ async fn malformed_usage_with_valid_content_preserves_legacy_fail_fast_error() {
         .await
         .unwrap_err();
 
-    assert!(matches!(error, RStructorError::HttpError(_)));
+    assert!(matches!(
+        error.api_error_kind(),
+        Some(ApiErrorKind::UnexpectedResponse { .. })
+    ));
+    assert_eq!(error.status_code(), Some(200));
+    assert!(!error.is_retryable());
     response.assert_async().await;
 }
 
@@ -879,7 +979,12 @@ async fn malformed_usage_with_invalid_content_is_not_reclassified_as_retryable()
         .await
         .unwrap_err();
 
-    assert!(matches!(error, RStructorError::HttpError(_)));
+    assert!(matches!(
+        error.api_error_kind(),
+        Some(ApiErrorKind::UnexpectedResponse { .. })
+    ));
+    assert_eq!(error.status_code(), Some(200));
+    assert!(!error.is_retryable());
     response.assert_async().await;
 }
 


### PR DESCRIPTION
## Summary

- preserve exact HTTP status codes and recognized provider request IDs on every extraction attempt and provider error
- add opt-in bounded response-body capture behind a mandatory caller-supplied sanitizer
- emit one content-free OpenTelemetry GenAI semantic-convention span per non-streaming extraction or generation attempt through the existing `tracing` facade
- classify malformed successful provider envelopes as typed `UnexpectedResponse` errors while retaining their HTTP diagnostics

## API notes

- `AttemptRecord::response` carries the uniform `ResponseMetadata` sidecar on both success and failure
- `RStructorError::{status_code, request_id, response_metadata}` expose terminal diagnostics without matching provider-specific variants
- `ResponseBodyCapture` never stores a body unless the caller explicitly opts in and supplies the sanitizer
- applications keep control of their tracing subscriber and OpenTelemetry SDK/exporter

`RStructorError::ApiError` has a new response metadata field. Exact downstream struct-pattern matches should add `..`; normal matches and accessor-based code are unchanged.

The GenAI semantic conventions are still marked development upstream, so the instrumentation exports `GEN_AI_SEMCONV_STABILITY` and isolates field construction in one module for future convention updates.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --all-features --target-dir tmp/pr3-target -- -D warnings`
- `cargo check --no-default-features --features derive,mock --target-dir tmp/pr3-min-target`
- deterministic all-feature integration matrix (credentialed live-provider modules skipped)
- commit-hook unit suite: 219 passed
- all-feature library suite: 306 passed
- HTTP mock suite: 44 passed
