### PR TITLE
Make the default package intentionally small

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         run: cargo test --all-features --no-fail-fast
 
   schema-only:
-    name: Schema-only build (dependency-light, no API keys)
+    name: Minimal feature surfaces
     runs-on: ubuntu-latest
 
     steps:
@@ -49,10 +49,31 @@ jobs:
           shared-key: "ci-schema-only"
           cache-on-failure: true
 
-      # `--all-features` (the test job above) can't catch breakage in the
-      # advertised dependency-light build (no tokio/reqwest/network), so guard it.
-      - name: Build (derive only)
-        run: cargo build --no-default-features --features derive
+      - name: Lint default (derive + OpenAI only)
+        run: cargo clippy --all-targets -- -D warnings
 
-      - name: Build (derive + mock)
-        run: cargo build --no-default-features --features "derive,mock"
+      # `--all-features` (the test job above) cannot catch breakage in the
+      # advertised dependency-light or single-provider builds, so guard each one.
+      - name: Lint (derive only)
+        run: cargo clippy --all-targets --no-default-features --features derive -- -D warnings
+
+      - name: Lint library (mock only, no derive)
+        run: cargo clippy --lib --no-default-features --features mock -- -D warnings
+
+      - name: Lint library (mock + schemars, no derive)
+        run: cargo clippy --lib --no-default-features --features "mock,schemars" -- -D warnings
+
+      - name: Lint (derive + mock)
+        run: cargo clippy --all-targets --no-default-features --features "derive,mock" -- -D warnings
+
+      - name: Lint (derive + Anthropic only)
+        run: cargo clippy --all-targets --no-default-features --features "derive,anthropic" -- -D warnings
+
+      - name: Lint (derive + Gemini only)
+        run: cargo clippy --all-targets --no-default-features --features "derive,gemini" -- -D warnings
+
+      - name: Lint (derive + Grok only)
+        run: cargo clippy --all-targets --no-default-features --features "derive,grok" -- -D warnings
+
+      - name: Validate crates.io package contents
+        run: cargo package

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,25 +8,13 @@ repository = "https://github.com/clifton/rstructor"
 authors = ["Clifton King <cliftonk@gmail.com>"]
 readme = "README.md"
 documentation = "https://docs.rs/rstructor"
-exclude = [
-  # Release and development scripts
-  "release.sh",
-  "*.sh",
-  # Documentation that shouldn't be in the crate
-  "CLAUDE.md",
-  "EXAMPLES.md",
-  # GitHub workflows
-  ".github/",
-  # CI/CD configs
-  ".gitignore",
-  ".gitattributes",
-  # Claude/LLM generated or temporary files
-  ".claude/",
-  # Temporary files directory (ad-hoc scripts, temporary markdown, etc.)
-  "tmp/",
-  # Backup files from sed/editors
-  "*.orig",
-  "*.bak",
+include = [
+  "/src/**",
+  "/examples/**",
+  "/docs/COOKBOOK.md",
+  "/Cargo.toml",
+  "/README.md",
+  "/LICENSE",
 ]
 keywords = ["llm", "structured-output", "json-schema", "openai", "anthropic"]
 categories = [
@@ -69,7 +57,9 @@ async-stream = { version = "0.3.6", optional = true }
 
 # Feature flags
 [features]
-default = ["openai", "anthropic", "grok", "gemini", "derive", "logging"]
+default = ["derive", "openai"]
+# Convenience bundle for applications that select providers at runtime.
+all-providers = ["openai", "anthropic", "grok", "gemini"]
 # Each provider pulls in the shared networking + media stack via `_client`.
 openai = ["_client"]
 anthropic = ["_client"]
@@ -95,6 +85,9 @@ tools = ["_client"]
 # only the path-aware decoder and works without `_client`; the streaming and tool
 # overrides additionally require the `streaming` / `tools` features.
 mock = ["dep:serde_path_to_error"]
+
+[package.metadata.docs.rs]
+all-features = true
 
 [[example]]
 name = "streaming_example"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 ```
 
+The default is intentionally useful and narrow: the derive macro plus the
+OpenAI client. Other providers, logging setup, streaming, tools, schemars
+interop, mocks, and fixture replay remain opt-in.
+
 ## 60-Second Extraction
 
 Set the API key for your provider—for this example, `OPENAI_API_KEY`—then
@@ -924,7 +928,7 @@ network or API key. `MockClient` implements `LLMClient`, so it drops into any
 
 ```toml
 [dev-dependencies]
-rstructor = { version = "0.5.1", features = ["mock"] }
+rstructor = { version = "0.5.1", default-features = false, features = ["derive", "mock"] }
 ```
 
 ```rust
@@ -1003,17 +1007,28 @@ key-free round trip based on a real 10-K metric.
 
 ```toml
 [dependencies]
-rstructor = { version = "0.5.1", features = ["openai", "anthropic", "grok", "gemini"] }
+rstructor = { version = "0.5.1", features = ["all-providers"] }
 ```
 
-- `openai`, `anthropic`, `grok`, `gemini` — Provider backends (each pulls in the shared HTTP/`tokio` stack)
-- `derive` — Derive macro (default)
-- `logging` — Tracing integration
+- `derive`, `openai` — The only default features: typed schemas plus one immediately usable provider
+- `anthropic`, `grok`, `gemini` — Additional provider backends; every provider shares the same HTTP/`tokio` stack
+- `all-providers` — Convenience bundle for runtime provider selection
+- `logging` — Subscriber setup helpers (the core `tracing` spans do not require it)
 - `streaming` — Streaming via `generate_stream` / `materialize_iter` / `materialize_stream` (opt-in)
 - `tools` — Tool/function calling via `Toolbox` + `client.with_tools(..).run(..)` (opt-in)
+- `schemars` — Adapter for types that already derive `schemars::JsonSchema` (opt-in)
 - `mock` — `MockClient` plus record/sanitize/replay fixtures for offline testing (opt-in; see [Testing](#testing-offline))
 
-All features are on by default. For a **schema-only build** — generate JSON Schema from your types with no networking, `tokio`, or `reqwest` — disable the providers:
+For a single non-default provider with no unused client modules, disable defaults
+and select `derive` plus that provider:
+
+```toml
+[dependencies]
+rstructor = { version = "0.5.1", default-features = false, features = ["derive", "anthropic"] }
+```
+
+For a **schema-only build** — generate JSON Schema from your types with no
+networking, `tokio`, or `reqwest` — enable only `derive`:
 
 ```toml
 [dependencies]
@@ -1029,10 +1044,10 @@ See `examples/` for complete working examples:
 ```bash
 export OPENAI_API_KEY=your_key
 cargo run --example structured_movie_info
-cargo run --example nested_objects_example
+cargo run --example nested_objects_example --features gemini
 cargo run --example enum_with_data_example
 cargo run --example serde_rename_example
-cargo run --example gemini_multimodal_example
+cargo run --example gemini_multimodal_example --features gemini
 cargo run --example retry_attempt_ledger --features openai
 ```
 

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -150,7 +150,7 @@ the self-contained demo; production can pass an `AnyClient` to the same generic
 ```toml
 [dependencies]
 axum = { version = "0.8", features = ["json"] }
-rstructor = { version = "0.5.1", features = ["mock"] }
+rstructor = { version = "0.5.1", default-features = false, features = ["derive", "mock"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt"] }
@@ -257,7 +257,7 @@ success, validation failure, recorded-request, and re-ask paths. Enable the
 off-by-default `mock` feature:
 
 ```toml
-rstructor = { version = "0.5.1", features = ["mock"] }
+rstructor = { version = "0.5.1", default-features = false, features = ["derive", "mock"] }
 ```
 
 ```rust
@@ -424,7 +424,7 @@ proves that no `Instructor` derive is needed. Enable both `schemars` and `mock`
 for this offline version:
 
 ```toml
-rstructor = { version = "0.5.1", features = ["mock", "schemars"] }
+rstructor = { version = "0.5.1", default-features = false, features = ["mock", "schemars"] }
 schemars = "1"
 ```
 

--- a/src/backend/any_client.rs
+++ b/src/backend/any_client.rs
@@ -154,7 +154,7 @@ fn provider_feature_disabled(provider: &str, feature: &str) -> RStructorError {
 /// }
 ///
 /// // Provider decided at runtime.
-/// let provider = Provider::Anthropic;
+/// let provider = Provider::OpenAI;
 /// let client = AnyClient::from_env_for(provider)?;
 ///
 /// let movie: Movie = client.materialize("Describe Inception").await?;

--- a/src/backend/client.rs
+++ b/src/backend/client.rs
@@ -173,6 +173,8 @@ impl MediaFile {
 ///
 /// ```no_run
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// # #[cfg(feature = "anthropic")]
+/// # {
 /// use rstructor::{LLMClient, Instructor, AnthropicClient, AnthropicModel};
 /// use serde::{Serialize, Deserialize};
 /// use std::time::Duration;
@@ -197,6 +199,7 @@ impl MediaFile {
 /// println!("Movie: {}", review.movie_title);
 /// println!("Rating: {}/10", review.rating);
 /// println!("Review: {}", review.review);
+/// # }
 /// # Ok(())
 /// # }
 /// ```

--- a/src/backend/media.rs
+++ b/src/backend/media.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use crate::backend::ChatMessage;
 use crate::error::{ApiErrorKind, RStructorError, Result};
 
+#[cfg(any(feature = "openai", feature = "grok"))]
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub(crate) enum OpenAICompatibleMessageContent {
@@ -10,6 +11,7 @@ pub(crate) enum OpenAICompatibleMessageContent {
     Parts(Vec<OpenAICompatibleMessagePart>),
 }
 
+#[cfg(any(feature = "openai", feature = "grok"))]
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub(crate) enum OpenAICompatibleMessagePart {
@@ -18,6 +20,7 @@ pub(crate) enum OpenAICompatibleMessagePart {
     File { file: OpenAICompatibleFile },
 }
 
+#[cfg(any(feature = "openai", feature = "grok"))]
 #[derive(Debug, Serialize)]
 pub(crate) struct OpenAICompatibleImageUrl {
     pub(crate) url: String,
@@ -29,12 +32,14 @@ pub(crate) struct OpenAICompatibleImageUrl {
 ///
 /// See <https://platform.openai.com/docs/guides/pdf-files>: the part is
 /// `{"type": "file", "file": {"filename": ..., "file_data": "data:application/pdf;base64,..."}}`.
+#[cfg(any(feature = "openai", feature = "grok"))]
 #[derive(Debug, Serialize)]
 pub(crate) struct OpenAICompatibleFile {
     pub(crate) filename: String,
     pub(crate) file_data: String,
 }
 
+#[cfg(feature = "anthropic")]
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub(crate) enum AnthropicMessageContent {
@@ -42,6 +47,7 @@ pub(crate) enum AnthropicMessageContent {
     Blocks(Vec<AnthropicContentBlock>),
 }
 
+#[cfg(feature = "anthropic")]
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub(crate) enum AnthropicContentBlock {
@@ -61,6 +67,7 @@ pub(crate) enum AnthropicContentBlock {
 }
 
 /// Source of an Anthropic `image` or `document` block (both share this shape).
+#[cfg(feature = "anthropic")]
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub(crate) enum AnthropicMediaSource {
@@ -68,6 +75,7 @@ pub(crate) enum AnthropicMediaSource {
     Url { url: String },
 }
 
+#[cfg(any(feature = "openai", feature = "grok"))]
 pub(crate) fn build_openai_compatible_message_content(
     msg: &ChatMessage,
     provider_name: &str,
@@ -104,6 +112,7 @@ pub(crate) fn build_openai_compatible_message_content(
 
 /// Build the PDF content part for an OpenAI-compatible chat completions request,
 /// or a clear error for providers/sources without a documented PDF pathway.
+#[cfg(any(feature = "openai", feature = "grok"))]
 fn openai_compatible_pdf_part(
     media: &crate::backend::client::MediaFile,
     provider_name: &str,
@@ -186,6 +195,7 @@ fn unsupported_media_type(
     )
 }
 
+#[cfg(feature = "anthropic")]
 pub(crate) fn build_anthropic_message_content(
     msg: &ChatMessage,
 ) -> Result<AnthropicMessageContent> {
@@ -252,6 +262,7 @@ pub(crate) fn build_anthropic_message_content(
     Ok(AnthropicMessageContent::Blocks(blocks))
 }
 
+#[cfg(any(feature = "openai", feature = "grok"))]
 fn media_to_url(media: &crate::backend::client::MediaFile, provider_name: &str) -> Result<String> {
     if let Some(data) = media.data.as_ref() {
         if data.is_empty() {
@@ -288,6 +299,7 @@ mod tests {
     use super::*;
     use crate::backend::MediaFile;
 
+    #[cfg(any(feature = "openai", feature = "grok"))]
     #[test]
     fn test_openai_compatible_content_text_only() {
         let msg = ChatMessage::user("hello");
@@ -297,6 +309,7 @@ mod tests {
         assert_eq!(json, serde_json::json!("hello"));
     }
 
+    #[cfg(any(feature = "openai", feature = "grok"))]
     #[test]
     fn test_openai_compatible_content_with_media() {
         let msg = ChatMessage::user_with_media(
@@ -311,6 +324,7 @@ mod tests {
         assert_eq!(json[1]["image_url"]["url"], "data:image/png;base64,YWJj");
     }
 
+    #[cfg(feature = "anthropic")]
     #[test]
     fn test_anthropic_content_text_only() {
         let msg = ChatMessage::user("hello");
@@ -319,6 +333,7 @@ mod tests {
         assert_eq!(json, serde_json::json!("hello"));
     }
 
+    #[cfg(feature = "anthropic")]
     #[test]
     fn test_anthropic_content_with_inline_media() {
         let msg = ChatMessage::user_with_media(
@@ -334,6 +349,7 @@ mod tests {
         assert_eq!(json[1]["source"]["data"], "YWJj");
     }
 
+    #[cfg(feature = "anthropic")]
     #[test]
     fn test_anthropic_content_with_url_image() {
         let msg = ChatMessage::user_with_media(
@@ -351,6 +367,7 @@ mod tests {
 
     // ---- PDF routing: OpenAI ----
 
+    #[cfg(any(feature = "openai", feature = "grok"))]
     #[test]
     fn test_openai_inline_pdf_becomes_file_part() {
         let msg = ChatMessage::user_with_media(
@@ -373,6 +390,7 @@ mod tests {
         );
     }
 
+    #[cfg(any(feature = "openai", feature = "grok"))]
     #[test]
     fn test_openai_url_pdf_is_a_clear_error() {
         let msg = ChatMessage::user_with_media(
@@ -391,6 +409,7 @@ mod tests {
         );
     }
 
+    #[cfg(any(feature = "openai", feature = "grok"))]
     #[test]
     fn test_openai_non_image_non_pdf_is_a_clear_error() {
         let msg = ChatMessage::user_with_media(
@@ -408,6 +427,7 @@ mod tests {
 
     // ---- PDF routing: Grok ----
 
+    #[cfg(feature = "grok")]
     #[test]
     fn test_grok_inline_pdf_is_a_clear_error_not_an_image_url() {
         let msg = ChatMessage::user_with_media(
@@ -423,6 +443,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "grok")]
     #[test]
     fn test_grok_url_pdf_is_a_clear_error() {
         let msg = ChatMessage::user_with_media(
@@ -440,6 +461,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "grok")]
     #[test]
     fn test_grok_images_still_use_image_url() {
         let msg = ChatMessage::user_with_media(
@@ -455,6 +477,7 @@ mod tests {
 
     // ---- PDF routing: Anthropic ----
 
+    #[cfg(feature = "anthropic")]
     #[test]
     fn test_anthropic_inline_pdf_becomes_document_block() {
         let msg = ChatMessage::user_with_media(
@@ -477,6 +500,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "anthropic")]
     #[test]
     fn test_anthropic_url_pdf_becomes_url_document_block() {
         let msg = ChatMessage::user_with_media(
@@ -500,6 +524,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "anthropic")]
     #[test]
     fn test_anthropic_non_image_non_pdf_is_a_clear_error() {
         let msg = ChatMessage::user_with_media(

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3,20 +3,25 @@ mod any_client;
 pub mod client;
 #[cfg(feature = "mock")]
 mod fixture;
-#[cfg(feature = "_client")]
+#[cfg(any(feature = "openai", feature = "anthropic", feature = "grok"))]
 mod media;
 mod messages;
 #[cfg(feature = "mock")]
 pub mod mock;
 #[cfg(feature = "_client")]
 mod model_macro;
-#[cfg(feature = "_client")]
+#[cfg(any(feature = "openai", feature = "grok"))]
 mod openai_compatible;
 #[cfg(feature = "_client")]
 mod request;
 #[cfg(feature = "_client")]
 mod routing;
-#[cfg(feature = "_client")]
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "grok",
+    feature = "tools"
+))]
 mod schema_compatibility;
 #[cfg(feature = "streaming")]
 pub mod streaming;
@@ -91,20 +96,26 @@ pub struct ModelInfo {
     /// Description of the model's capabilities
     pub description: Option<String>,
 }
-#[cfg(feature = "_client")]
-pub(crate) use media::{
-    AnthropicMessageContent, OpenAICompatibleMessageContent, build_anthropic_message_content,
-    build_openai_compatible_message_content,
-};
-#[cfg(feature = "streaming")]
+#[cfg(feature = "anthropic")]
+pub(crate) use media::{AnthropicMessageContent, build_anthropic_message_content};
+#[cfg(any(feature = "openai", feature = "grok"))]
+pub(crate) use media::{OpenAICompatibleMessageContent, build_openai_compatible_message_content};
+#[cfg(all(feature = "streaming", any(feature = "openai", feature = "grok")))]
 pub(crate) use openai_compatible::OpenAICompatibleChatMessage;
-#[cfg(feature = "_client")]
+#[cfg(any(feature = "openai", feature = "grok"))]
 pub(crate) use openai_compatible::{
     OpenAICompatibleChatCompletionRequest, OpenAICompatibleChatCompletionResponse,
     convert_openai_compatible_chat_messages,
 };
-#[cfg(feature = "_client")]
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "grok",
+    feature = "tools"
+))]
 pub(crate) use schema_compatibility::{StrictSchemaProvider, compile_strict_schema};
+#[cfg(any(feature = "openai", feature = "grok"))]
+pub(crate) use utils::ResponseFormat;
 #[cfg(feature = "tools")]
 pub(crate) use utils::check_response_status;
 #[cfg(all(test, feature = "schemars"))]
@@ -113,7 +124,7 @@ pub(crate) use utils::prepare_gemini_schema;
 pub use utils::{DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT};
 #[cfg(feature = "_client")]
 pub(crate) use utils::{
-    ResponseFormat, build_http_client, check_response_status_with_capture,
+    build_http_client, check_response_status_with_capture,
     generate_with_retry_attempts_with_history, generate_with_retry_attempts_with_initial_messages,
     generate_with_retry_with_history, generate_with_retry_with_initial_messages, handle_http_error,
     materialize_request_error, materialize_with_media_and_attempts_with_retry,
@@ -134,7 +145,7 @@ pub(crate) use utils::{
 /// # Examples
 ///
 /// ```rust
-/// use rstructor::{OpenAIClient, GeminiClient, ThinkingLevel};
+/// use rstructor::{OpenAIClient, ThinkingLevel};
 ///
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// // OpenAI with low thinking (default)
@@ -143,10 +154,6 @@ pub(crate) use utils::{
 /// // Enable high thinking for complex tasks
 /// # let client = OpenAIClient::new("key")?;
 /// let client = client.thinking_level(ThinkingLevel::High);
-///
-/// // Gemini with custom thinking level
-/// # let client = GeminiClient::new("key")?;
-/// let client = client.thinking_level(ThinkingLevel::Medium);
 /// # Ok(())
 /// # }
 /// ```

--- a/src/backend/schema_compatibility.rs
+++ b/src/backend/schema_compatibility.rs
@@ -16,16 +16,22 @@ use crate::schema::Schema;
 /// Providers whose constrained-output dialect closes every object.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum StrictSchemaProvider {
+    #[cfg(any(feature = "openai", feature = "tools", test))]
     OpenAI,
+    #[cfg(any(feature = "anthropic", feature = "tools", test))]
     Anthropic,
+    #[cfg(any(feature = "grok", feature = "tools", test))]
     Grok,
 }
 
 impl fmt::Display for StrictSchemaProvider {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(match self {
+            #[cfg(any(feature = "openai", feature = "tools", test))]
             Self::OpenAI => "OpenAI",
+            #[cfg(any(feature = "anthropic", feature = "tools", test))]
             Self::Anthropic => "Anthropic",
+            #[cfg(any(feature = "grok", feature = "tools", test))]
             Self::Grok => "Grok",
         })
     }

--- a/src/backend/usage.rs
+++ b/src/backend/usage.rs
@@ -265,7 +265,7 @@ impl AttemptRecord {
         Self::succeeded_with_response(number, usage, None)
     }
 
-    #[cfg(any(feature = "_client", feature = "mock"))]
+    #[cfg(any(test, feature = "_client", feature = "mock"))]
     pub(crate) fn succeeded_with_response(
         number: usize,
         usage: Option<TokenUsage>,
@@ -291,7 +291,7 @@ impl AttemptRecord {
         Self::failed_with_response(number, kind, error, disposition, usage, None)
     }
 
-    #[cfg(any(feature = "_client", feature = "mock"))]
+    #[cfg(any(test, feature = "_client", feature = "mock"))]
     pub(crate) fn failed_with_response(
         number: usize,
         kind: AttemptKind,
@@ -479,7 +479,7 @@ pub struct MaterializeReport<T> {
 }
 
 impl<T> MaterializeReport<T> {
-    #[cfg(any(feature = "_client", feature = "mock"))]
+    #[cfg(any(test, feature = "_client", feature = "mock"))]
     pub(crate) fn new(
         data: T,
         final_usage: Option<TokenUsage>,
@@ -562,7 +562,7 @@ pub struct MaterializeFailure {
 }
 
 impl MaterializeFailure {
-    #[cfg(any(feature = "_client", feature = "mock"))]
+    #[cfg(any(test, feature = "_client", feature = "mock"))]
     pub(crate) fn new(
         error: RStructorError,
         cumulative_usage: Option<RunUsage>,

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -7,6 +7,7 @@ use crate::error::{ApiErrorKind, RStructorError, Result};
 use crate::model::Instructor;
 use crate::{ResponseBodyCapture, ResponseMetadata};
 use reqwest::Response;
+#[cfg(any(feature = "openai", feature = "grok", test))]
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
@@ -90,6 +91,12 @@ pub fn build_http_client(timeout: Duration) -> reqwest::Client {
 /// # Returns
 ///
 /// A new schema Value with strict mode requirements added to all objects
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "grok",
+    feature = "tools"
+))]
 pub fn prepare_strict_schema(schema: &crate::schema::Schema) -> Value {
     let mut schema_json = schema.to_json();
     add_additional_properties_false(&mut schema_json);
@@ -101,6 +108,13 @@ pub fn prepare_strict_schema(schema: &crate::schema::Schema) -> Value {
 /// 2. `null` to the schemas of properties absent from the original `required`
 ///    array (optional fields), so constrained decoding can emit `null` for them
 /// 3. `required` array with all property keys (overriding any existing array)
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "grok",
+    feature = "tools",
+    test
+))]
 fn add_additional_properties_false(schema: &mut Value) {
     if let Some(obj) = schema.as_object_mut() {
         // Check if this is an object type schema (the type may already be a
@@ -252,6 +266,13 @@ fn add_additional_properties_false(schema: &mut Value) {
 }
 
 /// Returns true if a schema branch explicitly admits `null` via its `type` keyword.
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "grok",
+    feature = "tools",
+    test
+))]
 fn schema_branch_admits_null(branch: &Value) -> bool {
     match branch.get("type") {
         Some(Value::String(t)) => t == "null",
@@ -277,6 +298,13 @@ fn schema_branch_admits_null(branch: &Value) -> bool {
 ///
 /// Schemas without any of these keywords (e.g. `{}`) already admit `null` and
 /// are left untouched.
+#[cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "grok",
+    feature = "tools",
+    test
+))]
 fn make_schema_nullable(schema: &mut Value) {
     let Some(obj) = schema.as_object_mut() else {
         return;
@@ -327,6 +355,7 @@ fn make_schema_nullable(schema: &mut Value) {
 }
 
 /// Information about adjacently tagged enum transformations for response conversion
+#[cfg(any(feature = "gemini", feature = "tools", test))]
 #[derive(Debug, Clone)]
 pub struct AdjacentlyTaggedEnumInfo {
     pub tag_key: String,
@@ -336,6 +365,7 @@ pub struct AdjacentlyTaggedEnumInfo {
 
 /// Extract adjacently tagged enum info from a schema (before Gemini transformation)
 /// Searches recursively through the schema tree
+#[cfg(any(feature = "gemini", feature = "tools", test))]
 pub fn extract_adjacently_tagged_info(schema: &Value) -> Option<AdjacentlyTaggedEnumInfo> {
     // First check if this level has enum disjunction variants
     for key in ["oneOf", "anyOf"] {
@@ -376,6 +406,7 @@ pub fn extract_adjacently_tagged_info(schema: &Value) -> Option<AdjacentlyTagged
     None
 }
 
+#[cfg(any(feature = "gemini", feature = "tools", test))]
 fn extract_adjacently_tagged_info_from_variants(
     variants: &[Value],
 ) -> Option<AdjacentlyTaggedEnumInfo> {
@@ -405,6 +436,7 @@ fn extract_adjacently_tagged_info_from_variants(
 }
 
 /// Transform internally tagged JSON back to adjacently tagged format
+#[cfg(any(feature = "gemini", feature = "tools", test))]
 pub fn transform_internally_to_adjacently_tagged(
     json: &mut Value,
     enum_info: &AdjacentlyTaggedEnumInfo,
@@ -468,6 +500,7 @@ pub fn transform_internally_to_adjacently_tagged(
 ///
 /// A new schema value with unsupported keywords removed, or a local
 /// compatibility error when preserving the canonical schema is impossible.
+#[cfg(any(feature = "gemini", feature = "tools", test))]
 pub fn prepare_gemini_schema(
     schema: &crate::schema::Schema,
     context: impl Into<String>,
@@ -479,6 +512,7 @@ pub fn prepare_gemini_schema(
 }
 
 /// Recursively removes keywords unsupported by Gemini's structured outputs.
+#[cfg(any(feature = "gemini", feature = "tools", test))]
 fn strip_gemini_unsupported_keywords(schema: &mut Value, context: &str) -> Result<()> {
     resolve_refs_for_gemini(schema, context)?;
     strip_gemini_unsupported_keywords_recursive(schema);
@@ -491,6 +525,7 @@ fn strip_gemini_unsupported_keywords(schema: &mut Value, context: &str) -> Resul
 /// rejected before any HTTP request because Gemini's schema transport cannot
 /// preserve an unbounded cycle, and finite-depth expansion would silently
 /// widen the accepted values at the cutoff.
+#[cfg(any(feature = "gemini", feature = "tools", test))]
 fn resolve_refs_for_gemini(schema: &mut Value, context: &str) -> Result<()> {
     let definitions = schema
         .get("$defs")
@@ -509,6 +544,7 @@ fn resolve_refs_for_gemini(schema: &mut Value, context: &str) -> Result<()> {
     Ok(())
 }
 
+#[cfg(any(feature = "gemini", feature = "tools", test))]
 fn inline_refs_for_gemini(
     schema: &mut Value,
     definitions: &serde_json::Map<String, Value>,
@@ -587,6 +623,7 @@ fn inline_refs_for_gemini(
     Ok(())
 }
 
+#[cfg(any(feature = "gemini", feature = "tools", test))]
 fn referenced_definition(
     reference: &str,
     definitions: &serde_json::Map<String, Value>,
@@ -605,6 +642,7 @@ fn referenced_definition(
     )
 }
 
+#[cfg(any(feature = "gemini", feature = "tools", test))]
 fn append_json_path(path: &str, key: &str) -> String {
     let mut characters = key.chars();
     let is_identifier = matches!(
@@ -620,6 +658,7 @@ fn append_json_path(path: &str, key: &str) -> String {
     }
 }
 
+#[cfg(any(feature = "gemini", feature = "tools", test))]
 fn gemini_schema_compatibility_error(context: &str, path: &str, message: String) -> RStructorError {
     RStructorError::SchemaCompatibilityError {
         provider: "Gemini".into(),
@@ -631,6 +670,7 @@ fn gemini_schema_compatibility_error(context: &str, path: &str, message: String)
 
 /// Detects if a oneOf variant looks like an adjacently tagged enum variant.
 /// Returns Some((tag_key, content_key, tag_value)) if it matches the pattern.
+#[cfg(any(feature = "gemini", feature = "tools", test))]
 fn detect_adjacently_tagged_variant(variant: &Value) -> Option<(String, String, String)> {
     let obj = variant.as_object()?;
 
@@ -683,6 +723,7 @@ fn detect_adjacently_tagged_variant(variant: &Value) -> Option<(String, String, 
 
 /// Transforms adjacently tagged enum variants to internally tagged format for Gemini.
 /// This is a workaround for Gemini's limitation with nested content objects.
+#[cfg(any(feature = "gemini", feature = "tools", test))]
 fn transform_adjacently_tagged_to_internally_tagged(
     variant: &Value,
     _tag_key: &str,
@@ -755,6 +796,7 @@ fn transform_adjacently_tagged_to_internally_tagged(
     Value::Object(obj)
 }
 
+#[cfg(any(feature = "gemini", feature = "tools", test))]
 fn normalize_adjacently_tagged_variants(variants: &mut Vec<Value>) {
     // First, check if this looks like an adjacently tagged enum.
     // All variants should have the same tag/content keys.
@@ -805,6 +847,7 @@ fn normalize_adjacently_tagged_variants(variants: &mut Vec<Value>) {
 }
 
 /// Internal function that strips unsupported keywords after refs are resolved.
+#[cfg(any(feature = "gemini", feature = "tools", test))]
 fn strip_gemini_unsupported_keywords_recursive(schema: &mut Value) {
     if let Some(obj) = schema.as_object_mut() {
         // Remove unsupported keywords
@@ -925,6 +968,7 @@ fn strip_gemini_unsupported_keywords_recursive(schema: &mut Value) {
 ///
 /// This struct is used by OpenAI and Grok (and potentially other OpenAI-compatible APIs)
 /// for their native structured outputs feature.
+#[cfg(any(feature = "openai", feature = "grok", test))]
 #[derive(Debug, Serialize)]
 pub struct JsonSchemaFormat {
     /// Name of the schema (usually the type name)
@@ -939,6 +983,7 @@ pub struct JsonSchemaFormat {
 }
 
 /// Response format for structured outputs (OpenAI-compatible).
+#[cfg(any(feature = "openai", feature = "grok", test))]
 #[derive(Debug, Serialize)]
 #[serde(tag = "type")]
 pub enum ResponseFormat {
@@ -950,6 +995,7 @@ pub enum ResponseFormat {
     },
 }
 
+#[cfg(any(feature = "openai", feature = "grok", test))]
 impl ResponseFormat {
     /// Create a new JSON schema response format for structured outputs.
     ///

--- a/tests/anthropic_multimodal_tests.rs
+++ b/tests/anthropic_multimodal_tests.rs
@@ -4,6 +4,8 @@
 //! - `ANTHROPIC_API_KEY`
 //! - `--features anthropic`
 
+#![cfg(feature = "anthropic")]
+
 #[path = "common/mod.rs"]
 mod common;
 

--- a/tests/anyclient_env_tests.rs
+++ b/tests/anyclient_env_tests.rs
@@ -1,4 +1,9 @@
-#![cfg(feature = "_client")]
+#![cfg(all(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "gemini",
+    feature = "grok"
+))]
 //! Environment-driven construction of [`AnyClient`].
 //!
 //! Environment variables are process-global, and tests within a single binary

--- a/tests/complex_enum_integration_tests.rs
+++ b/tests/complex_enum_integration_tests.rs
@@ -1,4 +1,6 @@
 // tests/complex_enum_integration_tests.rs
+#![cfg(feature = "gemini")]
+
 #[cfg(test)]
 mod complex_enum_tests {
     use rstructor::{GeminiClient, GeminiModel, Instructor, LLMClient};

--- a/tests/gemini_multimodal_tests.rs
+++ b/tests/gemini_multimodal_tests.rs
@@ -7,6 +7,8 @@
 //! cargo test --test gemini_multimodal_tests --features gemini
 //! ```
 
+#![cfg(feature = "gemini")]
+
 #[path = "common/mod.rs"]
 mod common;
 

--- a/tests/grok_multimodal_tests.rs
+++ b/tests/grok_multimodal_tests.rs
@@ -4,6 +4,8 @@
 //! - `XAI_API_KEY`
 //! - `--features grok`
 
+#![cfg(feature = "grok")]
+
 #[path = "common/mod.rs"]
 mod common;
 

--- a/tests/hashmap_integration_tests.rs
+++ b/tests/hashmap_integration_tests.rs
@@ -1,4 +1,6 @@
 // tests/hashmap_integration_tests.rs
+#![cfg(feature = "gemini")]
+
 #[cfg(test)]
 mod hashmap_tests {
     use rstructor::{GeminiClient, GeminiModel, Instructor, LLMClient};

--- a/tests/http_mock_tests.rs
+++ b/tests/http_mock_tests.rs
@@ -335,6 +335,9 @@ async fn routed_client_sends_the_full_custom_model_string() {
         .await;
 
     let routed = rstructor::client("openai/vendor/some-model").unwrap();
+    // The wildcard is reachable with additional provider features and intentionally
+    // retained so this assertion stays valid under both default and all-feature builds.
+    #[allow(unreachable_patterns)]
     let client = match routed {
         AnyClient::OpenAI(client) => client.base_url(server.url()).no_retries(),
         _ => panic!("openai prefix should construct the OpenAI AnyClient variant"),

--- a/tests/llm_integration_tests.rs
+++ b/tests/llm_integration_tests.rs
@@ -12,16 +12,24 @@
 
 #[cfg(test)]
 mod llm_integration_tests {
+    #[cfg(any(
+        feature = "openai",
+        feature = "anthropic",
+        feature = "gemini",
+        feature = "grok"
+    ))]
+    use rstructor::LLMClient;
     #[cfg(feature = "anthropic")]
     use rstructor::{AnthropicClient, AnthropicModel};
     #[cfg(feature = "gemini")]
     use rstructor::{GeminiClient, GeminiModel};
     #[cfg(feature = "grok")]
     use rstructor::{GrokClient, GrokModel};
-    use rstructor::{Instructor, LLMClient, SchemaType};
+    use rstructor::{Instructor, SchemaType};
     #[cfg(feature = "openai")]
     use rstructor::{OpenAIClient, OpenAIModel};
     use serde::{Deserialize, Serialize};
+    #[cfg(any(feature = "openai", feature = "anthropic"))]
     use std::env;
 
     // Simple model for testing

--- a/tests/map_fidelity_tests.rs
+++ b/tests/map_fidelity_tests.rs
@@ -4,9 +4,19 @@
 //! Providers must either preserve those keys and the value schema or reject the
 //! request locally before a paid HTTP call.
 
+#![cfg(any(
+    feature = "mock",
+    feature = "openai",
+    feature = "anthropic",
+    feature = "gemini",
+    feature = "grok"
+))]
+
 use std::collections::HashMap;
 
-use rstructor::{Instructor, LLMClient, RStructorError};
+#[cfg(any(feature = "openai", feature = "anthropic", feature = "grok"))]
+use rstructor::RStructorError;
+use rstructor::{Instructor, LLMClient};
 use serde::{Deserialize, Serialize};
 
 #[derive(Instructor, Serialize, Deserialize, Debug, PartialEq)]
@@ -42,6 +52,7 @@ fn scenario_price_toolbox() -> rstructor::Toolbox {
     ))
 }
 
+#[cfg(any(feature = "openai", feature = "anthropic", feature = "grok"))]
 fn assert_map_compatibility_error(
     error: RStructorError,
     expected_provider: &str,

--- a/tests/model_string_test.rs
+++ b/tests/model_string_test.rs
@@ -1,3 +1,10 @@
+#![cfg(all(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "gemini",
+    feature = "grok"
+))]
+
 #[cfg(test)]
 mod tests {
     use rstructor::{AnthropicModel, GeminiModel, GrokModel, OpenAIModel};

--- a/tests/openai_enum_anyof_test.rs
+++ b/tests/openai_enum_anyof_test.rs
@@ -9,6 +9,8 @@
 //! cargo test --test openai_enum_anyof_test
 //! ```
 
+#![cfg(feature = "openai")]
+
 #[cfg(test)]
 mod openai_enum_anyof_tests {
     use rstructor::Instructor;
@@ -55,7 +57,6 @@ mod openai_enum_anyof_tests {
     ///
     /// Before the fix this would fail with:
     /// > Invalid schema for response_format '...': 'oneOf' is not permitted.
-    #[cfg(feature = "openai")]
     #[tokio::test]
     async fn test_openai_accepts_complex_enum_schema() {
         use rstructor::{LLMClient, OpenAIClient, OpenAIModel};

--- a/tests/openai_multimodal_tests.rs
+++ b/tests/openai_multimodal_tests.rs
@@ -4,6 +4,8 @@
 //! - `OPENAI_API_KEY`
 //! - `--features openai`
 
+#![cfg(feature = "openai")]
+
 #[path = "common/mod.rs"]
 mod common;
 

--- a/tests/provider_offline_tests.rs
+++ b/tests/provider_offline_tests.rs
@@ -1,4 +1,10 @@
 //! Offline unit tests for provider-facing pure logic.
+#![cfg(all(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "gemini",
+    feature = "grok"
+))]
 //!
 //! Covers two report rows (no network, no mockito):
 //!   * `provider | ThinkingLevel mapping fns (4) zero direct tests`

--- a/tests/recursive_structures_tests.rs
+++ b/tests/recursive_structures_tests.rs
@@ -1,4 +1,6 @@
 // tests/recursive_structures_tests.rs
+#![cfg(feature = "gemini")]
+
 #[cfg(test)]
 mod recursive_tests {
     #[cfg(feature = "streaming")]

--- a/tests/system_prompt_request_tests.rs
+++ b/tests/system_prompt_request_tests.rs
@@ -26,6 +26,7 @@ struct RiskSummary {
     gross_exposure: f64,
 }
 
+#[cfg(any(feature = "openai", feature = "grok"))]
 fn openai_compatible_completion(text: &str) -> String {
     json!({
         "choices": [{

--- a/tests/timeout_tests.rs
+++ b/tests/timeout_tests.rs
@@ -3,6 +3,13 @@
 //! These tests verify that timeout configuration works correctly
 //! and that timeout errors are properly handled.
 
+#![cfg(any(
+    feature = "openai",
+    feature = "anthropic",
+    feature = "gemini",
+    feature = "grok"
+))]
+
 #[cfg(test)]
 mod timeout_tests {
     #[cfg(feature = "anthropic")]
@@ -15,6 +22,7 @@ mod timeout_tests {
     #[cfg(feature = "openai")]
     use rstructor::{OpenAIClient, OpenAIModel};
     use serde::{Deserialize, Serialize};
+    #[cfg(any(feature = "openai", feature = "anthropic"))]
     use std::env;
     use std::time::Duration;
 

--- a/tests/weird_types_tests.rs
+++ b/tests/weird_types_tests.rs
@@ -1,4 +1,6 @@
 // tests/weird_types_tests.rs
+#![cfg(feature = "gemini")]
+
 #[cfg(test)]
 mod weird_types_tests {
     use rstructor::{GeminiClient, GeminiModel, Instructor, LLMClient};


### PR DESCRIPTION
## Summary

- make the default install intentionally narrow: `derive` plus OpenAI
- keep Anthropic, Gemini, Grok, logging helpers, streaming, tools, mocks, and schemars opt-in
- add `all-providers` for applications that select a provider at runtime
- publish from an explicit source/docs/examples allowlist; the verified archive contains 73 files and compresses to 223.9 KiB
- build docs.rs with all features and lint default, schema-only, mock-only, schemars/mock, and every single-provider surface in CI
- align README, cookbook, integration-test gates, and doctests with the smaller defaults

## Compatibility

Applications that previously relied on Anthropic, Gemini, Grok, or logging being enabled implicitly must now select those features. Runtime multi-provider applications can add `features = ["all-providers"]`.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- strict clippy across derive-only, mock-only, mock/schemars, derive/mock, and each derive/provider surface
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --no-fail-fast`
- `cargo test --doc`
- `cargo test --all-features --no-fail-fast`
- `cargo package --allow-dirty --target-dir tmp/pr5-package-target`
